### PR TITLE
Add infeed and outfeed primitives

### DIFF
--- a/c_src/exla/BUILD
+++ b/c_src/exla/BUILD
@@ -24,6 +24,7 @@ cc_library (
   srcs = ["exla_device.cc"],
   hdrs = ["exla_device.h"],
   deps = [
+    ":exla_nif_util",
     "@org_tensorflow//tensorflow/compiler/xla/client:local_client",
     "@org_tensorflow//tensorflow/stream_executor:stream_executor",
     "@com_google_absl//absl/memory",

--- a/c_src/exla/exla.cc
+++ b/c_src/exla/exla.cc
@@ -1489,7 +1489,7 @@ ERL_NIF_TERM run(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
   }
 
   exla::uint32 num_args;
-  std::vector<exla::ExlaBuffer**> buffers;
+  std::vector<exla::ExlaBuffer*> buffers;
   if (!enif_get_list_length(env, argv[2], &num_args)) {
     buffers.reserve(num_args);
   }
@@ -1525,7 +1525,7 @@ ERL_NIF_TERM block_until_done(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[
   if (!exla::get<xla::StatusOr<xla::ExecutionOutput>>(env, argv[1], execution_status)) {
     return exla::error(env, "Unable to get execution status.");
   }
-  if (!exla::get_list<exla::ExlaBuffer**>(env, argv[2], buffers)) {
+  if (!exla::get_list<exla::ExlaBuffer*>(env, argv[2], buffers)) {
     return exla::error(env, "Unable to get buffers.");
   }
   if (!exla::get(env, argv[3], &device_id)) {
@@ -1568,7 +1568,7 @@ ERL_NIF_TERM block_until_done(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[
     EXLA_ASSIGN_OR_RETURN_NIF(ERL_NIF_TERM tuple,
       (*client)->ErlListFromBuffer(env, buffer_ref), env);
     delete buffer_ref;
-    return tuple;
+    return exla::ok(env, tuple);
   } else {
     EXLA_ASSIGN_OR_RETURN_NIF(ErlNifBinary binary,
       (*client)->ErlBinFromBuffer(buffer_ref), env);

--- a/c_src/exla/exla_client.cc
+++ b/c_src/exla/exla_client.cc
@@ -83,7 +83,7 @@ ExlaExecutable::ExlaExecutable(std::vector<std::unique_ptr<xla::LocalExecutable>
 
 xla::StatusOr<xla::ExecutionOutput> ExlaExecutable::Run(ErlNifEnv* env,
                                                         ERL_NIF_TERM arguments,
-                                                        std::vector<ExlaBuffer**>& buffers,
+                                                        std::vector<ExlaBuffer*>& buffers,
                                                         int replica,
                                                         int partition,
                                                         int run_id,
@@ -155,7 +155,7 @@ xla::StatusOr<xla::ExecutionOutput> ExlaExecutable::Run(ErlNifEnv* env,
         });
 
       inputs.push_back(std::move(inp));
-      buffers.push_back(&buf);
+      buffers.emplace_back(buf);
 
     } else if (get<ExlaBuffer*>(env, head, buffer)) {
       if (*buffer == NULL) {

--- a/c_src/exla/exla_client.h
+++ b/c_src/exla/exla_client.h
@@ -48,6 +48,8 @@ class ExlaBuffer {
 
   bool is_tuple() { return !empty() && buffer_->on_host_shape().IsTuple(); }
 
+  bool zero_copy() { return zero_copy_; }
+
  private:
   // Used for donating this buffer to another function, like `Run`
   xla::ScopedShapedBuffer* buffer_;
@@ -88,7 +90,7 @@ class ExlaExecutable {
 
   xla::StatusOr<xla::ExecutionOutput> Run(ErlNifEnv* env,
                                           ERL_NIF_TERM arguments,
-                                          std::vector<ExlaBuffer**>& buffers,
+                                          std::vector<ExlaBuffer*>& buffers,
                                           int replica,
                                           int partition,
                                           int run_id,

--- a/c_src/exla/exla_client.h
+++ b/c_src/exla/exla_client.h
@@ -86,15 +86,16 @@ class ExlaExecutable {
 
   void Delete() { executables_.clear(); }
 
-  xla::StatusOr<ERL_NIF_TERM> Run(ErlNifEnv* env,
-                                  ERL_NIF_TERM arguments,
-                                  int replica,
-                                  int partition,
-                                  int run_id,
-                                  int rng_seed,
-                                  int launch_id,
-                                  ExlaDevice* device,
-                                  bool keep_on_device);
+  xla::StatusOr<xla::ExecutionOutput> Run(ErlNifEnv* env,
+                                          ERL_NIF_TERM arguments,
+                                          std::vector<ExlaBuffer**>& buffers,
+                                          int replica,
+                                          int partition,
+                                          int run_id,
+                                          int rng_seed,
+                                          int launch_id,
+                                          ExlaDevice* device,
+                                          bool keep_on_device);
 
  private:
   ExlaClient* client_;

--- a/c_src/exla/exla_device.cc
+++ b/c_src/exla/exla_device.cc
@@ -1,4 +1,5 @@
 #include "tensorflow/compiler/xla/exla/exla_device.h"
+#include <memory>
 
 namespace exla {
 
@@ -15,6 +16,27 @@ namespace exla {
     host_to_device_stream_->Init();
     callback_stream_->Init();
     device_to_host_stream_->Init();
+  }
+
+  xla::Status ExlaDevice::TransferBinaryToInfeed(const ErlNifBinary bin, const xla::Shape& shape) const {
+    xla::BorrowingLiteral literal(const_cast<char*>(reinterpret_cast<char*>(bin.data)), shape);
+    return this->client()->TransferToInfeedLocal(literal, this->device_ordinal());
+  }
+
+  xla::StatusOr<ErlNifBinary> ExlaDevice::TransferBinaryFromOutfeed(const xla::Shape& shape) const {
+    EXLA_ASSIGN_OR_RETURN(xla::Literal literal,
+      this->client()->TransferFromOutfeedLocal(shape, this->device_ordinal()));
+
+    // Allocate enough space for the binary
+    int64 size = literal.size_bytes();
+    ErlNifBinary binary;
+    enif_alloc_binary(size, &binary);
+
+    // No need to copy, just move to the underlying bytes in memory
+    void *src_mem = const_cast<void*>(literal.untyped_data());
+    std::memmove(binary.data, src_mem, size);
+
+    return binary;
   }
 
 }  // namespace exla

--- a/c_src/exla/exla_device.h
+++ b/c_src/exla/exla_device.h
@@ -5,6 +5,7 @@
 
 #include "tensorflow/compiler/xla/client/local_client.h"
 #include "tensorflow/stream_executor/stream_executor.h"
+#include "tensorflow/compiler/xla/exla/exla_nif_util.h"
 
 namespace exla {
 
@@ -53,6 +54,10 @@ class ExlaDevice {
     se::Stream* callback_stream() const {
       return callback_stream_.get();
     }
+
+    xla::Status TransferBinaryToInfeed(const ErlNifBinary binary, const xla::Shape& shape) const;
+
+    xla::StatusOr<ErlNifBinary> TransferBinaryFromOutfeed(const xla::Shape& shape) const;
 
  private:
     int id_;

--- a/c_src/exla/exla_nif_util.h
+++ b/c_src/exla/exla_nif_util.h
@@ -239,16 +239,16 @@ ERL_NIF_TERM make(ErlNifEnv* env, T &var) {
 }
 
 template <typename T>
-ERL_NIF_TERM make_list(ErlNifEnv* env, std::vector<T*> &var) {
+ERL_NIF_TERM make_list(ErlNifEnv* env, std::vector<T> &var) {
   const uint32 list_size = var.size();
-  ERL_NIF_TERM terms[list_size];
-  int i = 0;
+  std::vector<ERL_NIF_TERM> terms;
+  terms.reserve(list_size);
   for(auto val : var) {
-    ERL_NIF_TERM term = make<T>(env, *val);
-    terms[i++] = term;
+    ERL_NIF_TERM term = make<T>(env, val);
+    terms.emplace_back(term);
   }
 
-  return enif_make_list_from_array(env, terms, list_size);
+  return enif_make_list_from_array(env, &terms[0], list_size);
 }
 
 /*

--- a/c_src/exla/exla_nif_util.h
+++ b/c_src/exla/exla_nif_util.h
@@ -238,6 +238,19 @@ ERL_NIF_TERM make(ErlNifEnv* env, T &var) {
   return ret;
 }
 
+template <typename T>
+ERL_NIF_TERM make_list(ErlNifEnv* env, std::vector<T*> &var) {
+  const uint32 list_size = var.size();
+  ERL_NIF_TERM terms[list_size];
+  int i = 0;
+  for(auto val : var) {
+    ERL_NIF_TERM term = make<T>(env, *val);
+    terms[i++] = term;
+  }
+
+  return enif_make_list_from_array(env, terms, list_size);
+}
+
 /*
  * Helper for extracting information from `GetShape` and sending it back as a Tuple.
  */

--- a/examples/infeed.exs
+++ b/examples/infeed.exs
@@ -1,0 +1,28 @@
+client = Exla.Client.fetch!(:default)
+
+builder = Exla.Builder.new("infeed")
+shape = Exla.Shape.make_shape({:s, 64}, {})
+
+token = Exla.Op.create_token(builder)
+
+{x, token} = Exla.Op.infeed(token, shape)
+{y, token} = Exla.Op.infeed(token, shape)
+z = Exla.Op.add(x, y)
+
+intermediate_value = Exla.Op.outfeed(z, token, shape)
+
+ast = Exla.Op.add(z, x)
+
+comp = Exla.Builder.build(ast)
+
+exec = Exla.Client.compile(client, comp, [])
+
+b1 = Exla.Buffer.buffer(<<1::64-native>>, shape)
+b2 = Exla.Buffer.buffer(<<1::64-native>>, shape)
+
+run = Task.async(fn -> Exla.Executable.run(exec, []) end)
+Exla.Buffer.to_infeed(b1, client, 0)
+Process.sleep(3000)
+Exla.Buffer.to_infeed(b2, client, 0)
+IO.inspect Exla.Buffer.from_outfeed(client, shape, 0)
+IO.inspect Task.await(run, :infinity)

--- a/lib/exla/buffer.ex
+++ b/lib/exla/buffer.ex
@@ -73,6 +73,26 @@ defmodule Exla.Buffer do
     Exla.NIF.deallocate_device_mem(ref) |> unwrap!()
   end
 
+  @doc """
+  Attempts to transfer the buffer to the given device infeed.
+
+  Returns `:ok` | `{:error, reason}`
+  """
+  def to_infeed(buffer = %Buffer{}, client = %Client{}, device_id) when is_integer(device_id) do
+    device_id = Client.check_device_compatibility!(client, device_id)
+    Exla.NIF.binary_to_device_infeed(client.ref, buffer.data, buffer.shape.ref, device_id)
+  end
+
+  @doc """
+  Attempts to transfer a buffer from the device outfeed.
+  """
+  def from_outfeed(client = %Client{}, %Shape{ref: shape_ref} = shape, device_id)
+      when is_integer(device_id) do
+    device_id = Client.check_device_compatibility!(client, device_id)
+    data = Exla.NIF.binary_from_device_outfeed(client.ref, shape_ref, device_id) |> unwrap!()
+    %Buffer{data: data, shape: shape}
+  end
+
   defp unwrap!({:ok, ref}), do: ref
   defp unwrap!({:error, error}), do: raise(List.to_string(error))
   defp unwrap!(status) when is_atom(status), do: status

--- a/lib/exla/nif.ex
+++ b/lib/exla/nif.ex
@@ -219,7 +219,7 @@ defmodule Exla.NIF do
       ),
       do: nif_error(__ENV__.function)
 
-  def run_cpu(
+  def run(
         _client,
         _executable,
         _arguments,
@@ -233,19 +233,8 @@ defmodule Exla.NIF do
       ),
       do: nif_error(__ENV__.function)
 
-  def run_io(
-        _client,
-        _executable,
-        _arguments,
-        _device_ordinal,
-        _run_id,
-        _rng_seed,
-        _launch_id,
-        _replica,
-        _partition,
-        _keep_on_device
-      ),
-      do: nif_error(__ENV__.function)
+  def block_until_done(_client, _execution_status, _buffers, _device_id, _keep_on_device),
+    do: nif_error(__ENV__.function)
 
   def device_assignment_to_device_id(_exec, _replica, _partition), do: nif_error(__ENV__.function)
 

--- a/lib/exla/nif.ex
+++ b/lib/exla/nif.ex
@@ -180,7 +180,13 @@ defmodule Exla.NIF do
 
   def tuple(_builder, _elements), do: nif_error(__ENV__.function)
 
-  def get_tuple_element(_operand, _indeX), do: nif_error(__ENV__.function)
+  def get_tuple_element(_operand, _index), do: nif_error(__ENV__.function)
+
+  def create_token(_builder), do: nif_error(__ENV__.function)
+
+  def infeed(_token, _shape), do: nif_error(__ENV__.function)
+
+  def outfeed(_operand, _token, _shape), do: nif_error(__ENV__.function)
 
   def get_host_client(_num_replicas, _intra_op_parallelism_threads),
     do: nif_error(__ENV__.function)
@@ -250,6 +256,12 @@ defmodule Exla.NIF do
     do: nif_error(__ENV__.function)
 
   def deallocate_device_mem(_buffer),
+    do: nif_error(__ENV__.function)
+
+  def binary_to_device_infeed(_client, _binary, _shape, _device_id),
+    do: nif_error(__ENV__.function)
+
+  def binary_from_device_outfeed(_client, _shape, _device_id),
     do: nif_error(__ENV__.function)
 
   defp nif_error({name, arity}) do

--- a/lib/exla/op.ex
+++ b/lib/exla/op.ex
@@ -328,6 +328,25 @@ defmodule Exla.Op do
     %Op{builder: builder, ref: ref}
   end
 
+  def create_token(%Builder{ref: builder}) do
+    ref = Exla.NIF.create_token(builder) |> unwrap!()
+    %Op{builder: builder, ref: ref}
+  end
+
+  def infeed(%Op{builder: builder, ref: token}, %Shape{ref: shape}) do
+    ref = Exla.NIF.infeed(token, shape) |> unwrap!()
+    tuple = %Op{builder: builder, ref: ref}
+    # InfeedWithToken returns {x, token}
+    {get_tuple_element(tuple, 0), get_tuple_element(tuple, 1)}
+  end
+
+  def outfeed(%Op{builder: builder, ref: operand}, %Op{builder: builder, ref: token}, %Shape{
+        ref: shape
+      }) do
+    ref = Exla.NIF.outfeed(operand, token, shape) |> unwrap!()
+    %Op{builder: builder, ref: ref}
+  end
+
   ## Helpers
 
   defp tuple_product(tuple), do: tuple_product(tuple, tuple_size(tuple))


### PR DESCRIPTION
This is a simple example showing how we can use Infeeds to stream data to a function at run time and how we can use Outfeeds receive data from a function at run time.

Next steps would be an Infeed Pool and an Outfeed Receiver from EXLA. 