### PR TITLE
Add dilations to reduce window

### DIFF
--- a/c_src/exla/exla.cc
+++ b/c_src/exla/exla.cc
@@ -1013,7 +1013,7 @@ ERL_NIF_TERM variadic_reduce(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]
 }
 
 ERL_NIF_TERM reduce_window(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
-  if (argc != 6) {
+  if (argc != 7) {
     return exla::nif::error(env, "Bad argument count.");
   }
 
@@ -1024,7 +1024,7 @@ ERL_NIF_TERM reduce_window(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) 
   std::vector<exla::int64> window_strides;
   // TODO(seanmor5): Not yet supported in Nx
   // std::vector<exla::int64> base_dilations;
-  // std::vector<exla::int64> window_dilations;
+  std::vector<exla::int64> window_dilations;
   std::vector<std::pair<exla::int64, exla::int64>> padding_config;
 
   if (!exla::nif::get<xla::XlaOp>(env, argv[0], operand)) {
@@ -1042,7 +1042,10 @@ ERL_NIF_TERM reduce_window(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) 
   if (!exla::nif::get_tuple(env, argv[4], window_strides)) {
     return exla::nif::error(env, "Unable to get window strides.");
   }
-  if (!exla::nif::get_general_padding(env, argv[5], padding_config)) {
+  if (!exla::nif::get_tuple(env, argv[5], window_dilations)) {
+    return exla::nif::error(env, "Unable to get window dilations.");
+  }
+  if (!exla::nif::get_general_padding(env, argv[6], padding_config)) {
     return exla::nif::error(env, "Unable to get padding configuration.");
   }
 
@@ -1052,7 +1055,7 @@ ERL_NIF_TERM reduce_window(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) 
                                                       window_dimensions,
                                                       window_strides,
                                                       {},
-                                                      {},
+                                                      window_dilations,
                                                       padding_config);
 
   return exla::nif::ok(env, exla::nif::make<xla::XlaOp>(env, op));
@@ -1808,7 +1811,7 @@ static ErlNifFunc exla_funcs[] = {
   // Functional Ops
   {"reduce", 4, reduce},
   {"variadic_reduce", 5, variadic_reduce},
-  {"reduce_window", 6, reduce_window},
+  {"reduce_window", 7, reduce_window},
   {"map", 4, map},
   // Shape/Type Manipulation
   {"broadcast_in_dim", 3, broadcast_in_dim},

--- a/lib/exla/defn.ex
+++ b/lib/exla/defn.ex
@@ -490,6 +490,7 @@ defmodule EXLA.Defn do
        ) do
     padding_config = opts[:padding]
     strides = opts[:strides]
+    window_dilations = opts[:window_dilations]
 
     arg = to_type(arg, type)
     comp = to_computation(fun, type, state)
@@ -500,6 +501,7 @@ defmodule EXLA.Defn do
       comp,
       window_dimensions,
       strides,
+      window_dilations,
       padding_config
     )
   end
@@ -631,8 +633,9 @@ defmodule EXLA.Defn do
 
     strides = opts[:strides]
     padding = opts[:padding]
+    window_dilations = opts[:window_dilations]
 
-    EXLA.Op.reduce_window(arg, acc, comp, window_dimensions, strides, padding)
+    EXLA.Op.reduce_window(arg, acc, comp, window_dimensions, strides, window_dilations, padding)
   end
 
   defp subbuilder(%EXLA.Builder{name: name} = builder, desc) do

--- a/lib/exla/nif.ex
+++ b/lib/exla/nif.ex
@@ -178,6 +178,7 @@ defmodule EXLA.NIF do
         _computation,
         _window_dimensions,
         _window_strides,
+        _window_dilations,
         _padding_config
       ),
       do: nif_error(__ENV__.function)

--- a/lib/exla/op.ex
+++ b/lib/exla/op.ex
@@ -347,6 +347,7 @@ defmodule EXLA.Op do
         %Computation{ref: reduction},
         window_dimensions,
         window_strides,
+        window_dilations,
         padding_config
       ) do
     ref =
@@ -356,6 +357,7 @@ defmodule EXLA.Op do
         reduction,
         window_dimensions,
         window_strides,
+        window_dilations,
         padding_config
       )
       |> unwrap!()

--- a/lib/nx/heatmap.ex
+++ b/lib/nx/heatmap.ex
@@ -35,12 +35,11 @@ defmodule Nx.Heatmap do
         if Keyword.get_lazy(heatmap_opts, :ansi_enabled, &IO.ANSI.enabled?/0) do
           scale = length(@mono265) - 1
 
-          entry_fun =
-            fn range ->
-              index = range |> Kernel.*(scale) |> round()
-              color = Enum.fetch!(@mono265, index)
-              [IO.ANSI.color_background(color), whitespace]
-            end
+          entry_fun = fn range ->
+            index = range |> Kernel.*(scale) |> round()
+            color = Enum.fetch!(@mono265, index)
+            [IO.ANSI.color_background(color), whitespace]
+          end
 
           {entry_fun, &IO.iodata_to_binary([&1 | IO.ANSI.reset()])}
         else
@@ -105,7 +104,7 @@ defmodule Nx.Heatmap do
         end)
 
       doc =
-        (if dims == [], do: open, else: concat(open, line()))
+        if(dims == [], do: open, else: concat(open, line()))
         |> concat(concat(Enum.intersperse(acc, concat(sep, line()))))
         |> nest(2)
         |> concat(line())

--- a/test/nx_test.exs
+++ b/test/nx_test.exs
@@ -579,4 +579,34 @@ defmodule NxTest do
                """
     end
   end
+
+  describe "window aggregates" do
+    test "computes a window sum" do
+      assert Nx.window_sum(
+               Nx.tensor([[[4, 2, 1, 3], [4, 2, 1, 7]], [[1, 2, 5, 7], [1, 8, 9, 2]]]),
+               {2, 1, 2},
+               strides: {2, 1, 1},
+               padding: [{2, 1}, {3, 1}, {1, 0}],
+               window_dilations: {1, 2, 2}
+             ) ==
+               Nx.tensor([
+                 [
+                   [0, 0, 0],
+                   [0, 0, 0],
+                   [0, 0, 0],
+                   [0, 0, 0],
+                   [0, 0, 0],
+                   [0, 0, 0]
+                 ],
+                 [
+                   [0, 0, 0],
+                   [0, 0, 0],
+                   [0, 0, 0],
+                   [4, 11, 14],
+                   [10, 15, 19],
+                   [0, 0, 0]
+                 ]
+               ])
+    end
+  end
 end


### PR DESCRIPTION
WIP. Needs more test cases.

Also adds `dilations` to weighted shape and weighted offset, and I believe we can use this to optimize Conv quite a bit. Rather than padding the input tensor with interior padding to represent it, we can just use the new weighted_shape functions.