### PR TITLE
Math ops

### DIFF
--- a/lib/nx.ex
+++ b/lib/nx.ex
@@ -3087,6 +3087,42 @@ defmodule Nx do
     end
   end
 
+  for {name, {desc, code}} <- Nx.Shared.unary_inverse_trig_funs() do
+    formula = code |> Macro.to_string() |> String.replace("var!(x)", "x")
+
+    {neg_one, _} = Code.eval_quoted(code, x: -1)
+    {zero, _} = Code.eval_quoted(code, x: 0)
+    {one, _} = Code.eval_quoted(code, x: 1)
+
+    @doc """
+    Calculates the #{desc} of each element in the tensor.
+
+    It is equivalent to:
+
+        #{formula}
+
+    ## Examples
+
+        iex> Nx.#{name}(1)
+        #Nx.Tensor<
+          f64
+          #{one}
+        >
+
+        iex> Nx.#{name}(Nx.tensor([-1.0, 0.0, 1.0], names: [:x]))
+        #Nx.Tensor<
+          f64[x: 3]
+          [#{neg_one}, #{zero}, #{one}]
+        >
+
+    """
+    def unquote(name)(tensor) do
+      tensor = tensor!(tensor)
+      type = Nx.Type.to_floating(tensor.type)
+      impl!(tensor).unquote(name)(%{tensor | type: type}, tensor)
+    end
+  end
+
   @doc """
   Negates each element in the tensor.
 

--- a/lib/nx/binary_tensor.ex
+++ b/lib/nx/binary_tensor.ex
@@ -617,6 +617,13 @@ defmodule Nx.BinaryTensor do
     end
   end
 
+  for {name, {_desc, code}} <- Nx.Shared.unary_inverse_trig_funs() do
+    @impl true
+    def unquote(name)(out, tensor) do
+      element_wise_unary_op(out, tensor, fn x -> unquote(code) end)
+    end
+  end
+
   @impl true
   def count_leading_zeros(out, %{type: {_, size} = type} = tensor) do
     data =

--- a/lib/nx/shared.ex
+++ b/lib/nx/shared.ex
@@ -148,10 +148,28 @@ defmodule Nx.Shared do
       logistic: {"standard logistic (a sigmoid)", quote(do: 1 / (1 + :math.exp(-var!(x))))},
       cos: {"cosine", quote(do: :math.cos(var!(x)))},
       sin: {"sine", quote(do: :math.sin(var!(x)))},
+      tan: {"tangent", quote(do: :math.tan(var!(x)))},
+      cosh: {"hyperbolic cosine", quote(do: :math.cosh(var!(x)))},
+      sinh: {"hyperbolic sine", quote(do: :math.sinh(var!(x)))},
       tanh: {"hyperbolic tangent", quote(do: :math.tanh(var!(x)))},
+      arccosh: {"inverse hyperbolic cosine", quote(do: :math.acosh(var!(x)))},
+      arcsinh: {"inverse hyperbolic sine", quote(do: :math.asinh(var!(x)))},
       sqrt: {"square root", quote(do: :math.sqrt(var!(x)))},
       rsqrt: {"reverse square root", quote(do: 1 / :math.sqrt(var!(x)))},
-      cbrt: {"cube root", quote(do: :math.pow(var!(x), 1 / 3))}
+      cbrt: {"cube root", quote(do: :math.pow(var!(x), 1 / 3))},
+      erf: {"error function", quote(do: :math.erf(var!(x)))},
+      erfc: {"one minus error function", quote(do: :math.erfc(var!(x)))}
+    ]
+
+  @doc """
+  Returns the definition for inverse trig funs with
+  special domains.
+  """
+  def unary_inverse_trig_funs,
+    do: [
+      arccos: {"inverse cosine", quote(do: :math.acos(var!(x)))},
+      arcsin: {"inverse sine", quote(do: :math.asin(var!(x)))},
+      arctan: {"inverse tangent", quote(do: :math.atan(var!(x)))}
     ]
 
   ## Types


### PR DESCRIPTION
This is to collect feedback on how best to resolve #155.

In here you'll see the Binary implementations for some of those mathematical functions. With this approach, the biggest advantage (I think?) are that we greatly simplify expressions which might help with debugging. For example we could implement `erf` like this: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/client/lib/math.cc#L206

But the resulting expression would be a mess, rather than just indicating a call to `erf`; however, we'd have the following advantages:
- Automatic EXLA/defn implementation
- Automatic gradient implementation
- Limits the size of the Tensor behavior

In the current approach, we'd have to still implement these functions in EXLA one way or another, and also have to add the gradients in. Is there a way that maybe we can implement these functions in terms of what we already have, but also ensure that the resulting expressions aren't crowded with implementation details?