### PR TITLE
Convert Nx.slice to work with start+length instead of start+end indexes

### DIFF
--- a/lib/exla/defn.ex
+++ b/lib/exla/defn.ex
@@ -529,7 +529,9 @@ defmodule EXLA.Defn do
     EXLA.Op.clamp(operand, min, max)
   end
 
-  defp to_operator(:slice, [tensor, start_indices, limit_indices, strides], _ans, _state) do
+  defp to_operator(:slice, [tensor, start_indices, lengths, strides], _ans, _state) do
+    # TODO: Use Enum.zip_with on Elixir v1.12
+    limit_indices = start_indices |> Enum.zip(lengths) |> Enum.map(fn {i, len} -> i + len end)
     EXLA.Op.slice(tensor, start_indices, limit_indices, strides)
   end
 

--- a/lib/nx/binary_tensor.ex
+++ b/lib/nx/binary_tensor.ex
@@ -1271,7 +1271,7 @@ defmodule Nx.BinaryTensor do
   end
 
   @impl true
-  def slice(out, tensor, start_indices, _limit_indices, strides) do
+  def slice(out, tensor, start_indices, _lengths, strides) do
     # If you think of a slice as drawing a bounding box in the dimensions
     # of the tensor, then it's clear we can simply use a weighted
     # traversal to construct the new tensor

--- a/test/exla/defn_test.exs
+++ b/test/exla/defn_test.exs
@@ -2042,9 +2042,9 @@ defmodule EXLA.DefnTest do
   end
 
   describe "slicing" do
-    defn slice1(t), do: Nx.slice(t, [0, 6, 2], [2, 7, 5])
-    defn slice2(t), do: Nx.slice(t, [1, 4, 10], [2, 5, 20], [1, 2, 3])
-    defn slice3(t), do: Nx.slice(t, [0, 4, 11], [2, 7, 20], [2, 1, 3])
+    defn slice1(t), do: Nx.slice(t, [0, 6, 2], [2, 1, 3])
+    defn slice2(t), do: Nx.slice(t, [1, 4, 10], [1, 1, 10], [1, 2, 3])
+    defn slice3(t), do: Nx.slice(t, [0, 4, 11], [2, 3, 9], [2, 1, 3])
 
     test "works without stride" do
       t = Nx.iota({900})

--- a/test/nx/defn/grad_test.exs
+++ b/test/nx/defn/grad_test.exs
@@ -536,15 +536,15 @@ defmodule Nx.Defn.GradTest do
   end
 
   describe "slice" do
-    defn grad_mean_slice(t), do: grad(t, Nx.mean(Nx.slice(t, [0, 1], [1, 3], [1, 2])))
-    defn grad_sum_slice(t), do: grad(t, Nx.sum(Nx.slice(t, [1, 0], [2, 2], [1, 1])))
+    defn grad_mean_slice(t), do: grad(t, Nx.mean(Nx.slice(t, [0, 1], [1, 2], [1, 2])))
+    defn grad_sum_slice(t), do: grad(t, Nx.sum(Nx.slice(t, [1, 0], [1, 2], [1, 1])))
 
     defn grad_sum_pad_slice(t) do
       grad(
         t,
-        Nx.sum(
-          Nx.pad(Nx.slice(t, [1, 0], [2, 2], [1, 1]), Nx.mean(Nx.sin(t)), [{2, 1, 2}, {-1, 2, 0}])
-        )
+        Nx.slice(t, [1, 0], [1, 2], [1, 1])
+        |> Nx.pad(Nx.mean(Nx.sin(t)), [{2, 1, 2}, {-1, 2, 0}])
+        |> Nx.sum()
       )
     end
 


### PR DESCRIPTION
This was done for two reasons:

  * Enum.slice/3 works with lengths, so we keep the naming consistent

  * XLA's dynamic slice works with start + lengths too, so if we want
    to support dynamic slicing through the same API, this is required