### PR TITLE
Implement p-norm definitions

### DIFF
--- a/exla/test/exla/defn_expr_test.exs
+++ b/exla/test/exla/defn_expr_test.exs
@@ -2392,8 +2392,7 @@ defmodule EXLA.DefnExprTest do
     test "works with norm calls" do
       t = Nx.tensor([3.0, 4.0, 0.0])
       assert compare_tensors!(normalize(t), Nx.tensor([0.6, 0.8, 0.0]))
-
-      assert compare_tensors!(Nx.dot(t, t), Nx.power(Nx.norm(t), 2))
+      assert compare_tensors!(Nx.norm(normalize(t)), Nx.tensor(1.0))
     end
   end
 

--- a/exla/test/exla/defn_expr_test.exs
+++ b/exla/test/exla/defn_expr_test.exs
@@ -2388,11 +2388,25 @@ defmodule EXLA.DefnExprTest do
 
   describe "norm" do
     defn normalize(t), do: t / Nx.norm(t)
+    defn l2_cols(t), do: Nx.norm(t, ord: 2, axes: [0])
+    defn l2_rows(t), do: Nx.norm(t, ord: 2, axes: [1])
+    defn l2_cols_keep_axes(t), do: Nx.norm(t, ord: 2, axes: [0], keep_axes: true)
+    defn l2_rows_keep_axes(t), do: Nx.norm(t, ord: 2, axes: [1], keep_axes: true)
 
     test "works with norm calls" do
       t = Nx.tensor([3.0, 4.0, 0.0])
-      assert compare_tensors!(normalize(t), Nx.tensor([0.6, 0.8, 0.0]))
-      assert compare_tensors!(Nx.norm(normalize(t)), Nx.tensor(1.0))
+      compare_tensors!(normalize(t), Nx.tensor([0.6, 0.8, 0.0]))
+      compare_tensors!(Nx.norm(normalize(t)), Nx.tensor(1.0))
+    end
+
+    test "accepts axes and keep_axes arguments" do
+      t = Nx.tensor([[5.0, 12.0, 0.0], [12.0, 5.0, 0.0]])
+
+      compare_tensors!(l2_cols(t),  Nx.tensor([13.0, 13.0, 0.0]))
+      compare_tensors!(l2_rows(t),  Nx.tensor([13.0, 13.0]))
+
+      compare_tensors!(l2_cols_keep_axes(t),  [13.0, 13.0, 0.0] |> Nx.tensor() |> Nx.reshape({1, 3}))
+      compare_tensors!(l2_rows_keep_axes(t),  [13.0, 13.0] |> Nx.tensor() |> Nx.reshape({2, 1}))
     end
   end
 

--- a/exla/test/exla/defn_expr_test.exs
+++ b/exla/test/exla/defn_expr_test.exs
@@ -2386,6 +2386,17 @@ defmodule EXLA.DefnExprTest do
     end
   end
 
+  describe "norm" do
+    defn normalize(t), do: t / Nx.norm(t)
+
+    test "works with norm calls" do
+      t = Nx.tensor([3.0, 4.0, 0.0])
+      assert compare_tensors!(normalize(t), Nx.tensor([0.6, 0.8, 0.0]))
+
+      assert compare_tensors!(Nx.dot(t, t), Nx.power(Nx.norm(t), 2))
+    end
+  end
+
   # We need to round the floats because of imprecision between platforms
   defp compare_tensors!(
          %{type: {:f, size}, data: %{state: left_data} = lhs} = left,

--- a/exla/test/exla/defn_expr_test.exs
+++ b/exla/test/exla/defn_expr_test.exs
@@ -2393,6 +2393,8 @@ defmodule EXLA.DefnExprTest do
     defn l2_cols_keep_axes(t), do: Nx.norm(t, ord: 2, axes: [0], keep_axes: true)
     defn l2_rows_keep_axes(t), do: Nx.norm(t, ord: 2, axes: [1], keep_axes: true)
 
+    defn non_zero_element_count(t), do: Nx.norm(t, ord: 0)
+
     test "works with norm calls" do
       t = Nx.tensor([3.0, 4.0, 0.0])
       compare_tensors!(normalize(t), Nx.tensor([0.6, 0.8, 0.0]))
@@ -2407,6 +2409,16 @@ defmodule EXLA.DefnExprTest do
 
       compare_tensors!(l2_cols_keep_axes(t),  [13.0, 13.0, 0.0] |> Nx.tensor() |> Nx.reshape({1, 3}))
       compare_tensors!(l2_rows_keep_axes(t),  [13.0, 13.0] |> Nx.tensor() |> Nx.reshape({2, 1}))
+    end
+
+    test "works with ord: 0" do
+      assert_raise RuntimeError, "ord 0 not implemented for 2-D tensor.", fn ->
+        non_zero_element_count(Nx.tensor([[0, 1, -1, 2]]))
+      end
+
+      %{type: type} = result = non_zero_element_count(Nx.tensor([0, 1, -1, 2]))
+
+      compare_tensors!(result, Nx.tensor(3, type: type))
     end
   end
 

--- a/exla/test/exla/defn_expr_test.exs
+++ b/exla/test/exla/defn_expr_test.exs
@@ -2412,7 +2412,7 @@ defmodule EXLA.DefnExprTest do
     end
 
     test "works with ord: 0" do
-      assert_raise RuntimeError, "ord 0 not implemented for 2-D tensor.", fn ->
+      assert_raise ArgumentError, "expected 1-D tensor for ord: 0, got a 2-D tensor", fn ->
         non_zero_element_count(Nx.tensor([[0, 1, -1, 2]]))
       end
 

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -6737,6 +6737,15 @@ defmodule Nx do
       5.0
     >
 
+    iex> Nx.norm(Nx.tensor([[3, 4], [0, -4]]), axes: [1], keep_axes: true)
+    #Nx.Tensor<
+      f64[2][1]
+      [
+        [5.0],
+        [4.0]
+      ]
+    >
+
   ### Caveats
 
   For big values of p, f64 rounding errors come into play

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -6855,8 +6855,9 @@ defmodule Nx do
     raise ArgumentError, "invalid :ord for 2-D tensor, got: #{inspect(ord)}"
   end
 
-  defp norm_integer(t, ord, opts) when is_integer(ord) do
-    inv_ord = tensor(1 / ord)
+  defp norm_integer(%{type: type} = t, ord, opts) when is_integer(ord) do
+    output_type = Nx.Type.to_floating(type)
+    inv_ord = tensor(1 / ord, type: output_type)
 
     # We extract this result to a variable because it's used both for
     # getting the normalization coefficient and for the main pipe chain

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -6685,7 +6685,7 @@ defmodule Nx do
 
   ## Examples
 
-    ### Vector norms
+  ### Vector norms
 
     iex> Nx.norm(Nx.tensor([3, 4]))
     #Nx.Tensor<
@@ -6789,7 +6789,7 @@ defmodule Nx do
     rank = rank(t)
 
     unless rank == 1 or rank == 2,
-      do: raise("expected 1-D or 2-D tensor, got tensor with shape #{inspect(s)}")
+      do: raise(ArgumentError, "expected 1-D or 2-D tensor, got tensor with shape #{inspect(s)}")
 
     {ord, axes_opts} = Keyword.pop(opts, :ord)
 
@@ -6798,10 +6798,10 @@ defmodule Nx do
 
   defp do_p_norm(t, nil, opts), do: do_p_norm(t, 2, opts)
 
-  defp do_p_norm(_t, :nuclear, _opts), do: raise("nuclear norm not implemented yet.")
+  defp do_p_norm(_t, :nuclear, _opts), do: raise("nuclear norm not implemented yet")
 
   defp do_p_norm(%{shape: {_}}, :frobenius, _opts),
-    do: raise("expected a 2-D tensor. Got a 1-D tensor.")
+    do: raise(ArgumentError, "expected a 2-D tensor for ord: :frobenius, got a 1-D tensor")
 
   defp do_p_norm(%{shape: {_, _}} = t, :frobenius, opts), do: do_p_norm(t, 2, opts)
 
@@ -6812,7 +6812,7 @@ defmodule Nx do
   end
 
   defp do_p_norm(%{shape: {_, _}}, 0, _opts) do
-    raise "expected 1-D tensor for ord: 0. Got: 2-D tensor."
+    raise ArgumentError, "expected 1-D tensor for ord: 0, got a 2-D tensor"
   end
 
   defp do_p_norm(%{shape: shape} = t, ord, axes_opts) when ord in [:inf, :neg_inf] do
@@ -6842,11 +6842,11 @@ defmodule Nx do
   end
 
   defp do_p_norm(%{shape: {_, _}}, -2, _opts) do
-    raise "ord: -2 for 2-D tensor not implemented yet."
+    raise "ord: -2 for 2-D tensor not implemented yet"
   end
 
   defp do_p_norm(%{shape: {_, _}}, ord, _opts) when ord not in -1..2 or ord == 0 do
-    raise "invalid ord for 2-D tensor. Got: #{inspect(ord)}"
+    raise ArgumentError, "invalid :ord for 2-D tensor, got: #{inspect(ord)}"
   end
 
   defp do_p_norm(t, ord, opts) when is_integer(ord) do

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -6835,8 +6835,7 @@ defmodule Nx do
 
   defp do_p_norm(t, 0, 1, opts) do
     t
-    |> equal(0)
-    |> logical_not()
+    |> not_equal(0)
     |> sum(opts)
   end
 
@@ -6884,6 +6883,8 @@ defmodule Nx do
   defp do_p_norm(t, ord, _, opts) do
     inv_ord = divide(1, ord)
 
+    # We extract this result to a variable because it's used both for
+    # getting the normalization coefficient and for the main pipe chain
     abs_t = Nx.abs(t)
 
     # This coefficient is introduced for better numerical stability

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -6766,6 +6766,9 @@ defmodule Nx do
       ]
     >
 
+    iex> Nx.norm(Nx.tensor([0, 1]), my_opt: 1)
+    ** (RuntimeError) unknown key :my_opt in [my_opt: 1], expected one of [:ord, :axes, :keep_axes]
+
   ### Caveats
 
   For big values of p, f64 rounding errors come into play
@@ -6773,6 +6776,10 @@ defmodule Nx do
 
   def norm(t_raw, input_opts \\ []) when is_list(input_opts) do
     t = tensor!(t_raw)
+    assert_keys!(input_opts, [:ord, :axes, :keep_axes])
+
+    default_axes_opts = [axes: nil, keep_axes: false, ord: nil]
+    opts = Keyword.merge(default_axes_opts, input_opts)
 
     case shape(t) do
       {_, _} ->
@@ -6786,11 +6793,9 @@ defmodule Nx do
     end
 
     rank = rank(t)
-    ord = get_norm_ord!(input_opts, rank)
+    ord = get_norm_ord!(opts, rank)
 
-    default_axes_opts = [axes: nil, keep_axes: false]
-
-    axes_opts = Keyword.merge(default_axes_opts, Keyword.take(input_opts, [:axes, :keep_axes]))
+    axes_opts = Keyword.take(opts, [:axes, :keep_axes])
 
     do_p_norm(t, ord, rank, axes_opts)
   end

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -6687,96 +6687,96 @@ defmodule Nx do
 
   ### Vector norms
 
-    iex> Nx.norm(Nx.tensor([3, 4]))
-    #Nx.Tensor<
-      f64
-      5.0
-    >
+      iex> Nx.norm(Nx.tensor([3, 4]))
+      #Nx.Tensor<
+        f64
+        5.0
+      >
 
-    iex> Nx.norm(Nx.tensor([3, 4]), ord: 1)
-    #Nx.Tensor<
-      f64
-      7.0
-    >
+      iex> Nx.norm(Nx.tensor([3, 4]), ord: 1)
+      #Nx.Tensor<
+        f64
+        7.0
+      >
 
-    iex> Nx.norm(Nx.tensor([3, -4]), ord: :inf)
-    #Nx.Tensor<
-      s64
-      4
-    >
+      iex> Nx.norm(Nx.tensor([3, -4]), ord: :inf)
+      #Nx.Tensor<
+        s64
+        4
+      >
 
-    iex> Nx.norm(Nx.tensor([3, -4]), ord: :neg_inf)
-    #Nx.Tensor<
-      s64
-      3
-    >
+      iex> Nx.norm(Nx.tensor([3, -4]), ord: :neg_inf)
+      #Nx.Tensor<
+        s64
+        3
+      >
 
-    iex> Nx.norm(Nx.tensor([3, -4, 0, 0]), ord: 0)
-    #Nx.Tensor<
-      u64
-      2
-    >
+      iex> Nx.norm(Nx.tensor([3, -4, 0, 0]), ord: 0)
+      #Nx.Tensor<
+        u64
+        2
+      >
 
-    ### Matrix norms
+  ### Matrix norms
 
-    iex> Nx.norm(Nx.tensor([[3, -1], [2, -4]]), ord: -1)
-    #Nx.Tensor<
-      s64
-      5
-    >
+      iex> Nx.norm(Nx.tensor([[3, -1], [2, -4]]), ord: -1)
+      #Nx.Tensor<
+        s64
+        5
+      >
 
-    iex> Nx.norm(Nx.tensor([[3, -2], [2, -4]]), ord: 1)
-    #Nx.Tensor<
-      s64
-      6
-    >
+      iex> Nx.norm(Nx.tensor([[3, -2], [2, -4]]), ord: 1)
+      #Nx.Tensor<
+        s64
+        6
+      >
 
-    iex> Nx.norm(Nx.tensor([[3, -2], [2, -4]]), ord: :neg_inf)
-    #Nx.Tensor<
-      s64
-      5
-    >
+      iex> Nx.norm(Nx.tensor([[3, -2], [2, -4]]), ord: :neg_inf)
+      #Nx.Tensor<
+        s64
+        5
+      >
 
-    iex> Nx.norm(Nx.tensor([[3, -2], [2, -4]]), ord: :inf)
-    #Nx.Tensor<
-      s64
-      6
-    >
+      iex> Nx.norm(Nx.tensor([[3, -2], [2, -4]]), ord: :inf)
+      #Nx.Tensor<
+        s64
+        6
+      >
 
-    iex> Nx.norm(Nx.tensor([[3, 0], [0, -4]]), ord: :frobenius)
-    #Nx.Tensor<
-      f64
-      5.0
-    >
+      iex> Nx.norm(Nx.tensor([[3, 0], [0, -4]]), ord: :frobenius)
+      #Nx.Tensor<
+        f64
+        5.0
+      >
 
-    iex> Nx.norm(Nx.tensor([[3, 0], [0, -4]]))
-    #Nx.Tensor<
-      f64
-      5.0
-    >
+      iex> Nx.norm(Nx.tensor([[3, 0], [0, -4]]))
+      #Nx.Tensor<
+        f64
+        5.0
+      >
 
-    iex> Nx.norm(Nx.tensor([[3, 4], [0, -4]]), axes: [1], keep_axes: true)
-    #Nx.Tensor<
-      f64[2][1]
-      [
-        [5.0],
-        [4.0]
-      ]
-    >
+      iex> Nx.norm(Nx.tensor([[3, 4], [0, -4]]), axes: [1], keep_axes: true)
+      #Nx.Tensor<
+        f64[2][1]
+        [
+          [5.0],
+          [4.0]
+        ]
+      >
 
-    ### Error cases
+  ### Error cases
 
-    iex> Nx.norm(Nx.tensor([3, 4]), ord: :frobenius)
-    ** (RuntimeError) expected a 2-D tensor. Got a 1-D tensor.
+      iex> Nx.norm(Nx.tensor([3, 4]), ord: :frobenius)
+      ** (ArgumentError) expected a 2-D tensor for ord: :frobenius, got a 1-D tensor
 
-    iex> Nx.norm(Nx.tensor([3, 4]), ord: :nuclear)
-    ** (RuntimeError) nuclear norm not implemented yet.
+      iex> Nx.norm(Nx.tensor([3, 4]), ord: :nuclear)
+      ** (RuntimeError) nuclear norm not implemented yet
 
-    iex> Nx.norm(Nx.tensor([[0], [1]]), ord: :nuclear)
-    ** (RuntimeError) nuclear norm not implemented yet.
+      iex> Nx.norm(Nx.tensor([[0], [1]]), ord: :nuclear)
+      ** (RuntimeError) nuclear norm not implemented yet
 
-    iex> Nx.norm(Nx.tensor([[0], [1]]), ord: -2)
-    ** (RuntimeError) ord: -2 for 2-D tensor not implemented yet.
+      iex> Nx.norm(Nx.tensor([[0], [1]]), ord: -2)
+      ** (RuntimeError) ord: -2 for 2-D tensor not implemented yet
   """
 
   def norm(tensor, opts \\ []) when is_list(opts) do

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -6769,6 +6769,12 @@ defmodule Nx do
     iex> Nx.norm(Nx.tensor([0, 1]), my_opt: 1)
     ** (RuntimeError) unknown key :my_opt in [my_opt: 1], expected one of [:ord, :axes, :keep_axes]
 
+    iex> Nx.norm(Nx.tensor([[0], [1]]), ord: :nuclear)
+    ** (RuntimeError) nuclear norm not implemented yet.
+
+    iex> Nx.norm(Nx.tensor([[0], [1]]), ord: -2)
+    ** (RuntimeError) ord: -2 for 2-D tensor not implemented yet.
+
   ### Caveats
 
   For big values of p, f64 rounding errors come into play
@@ -6816,6 +6822,9 @@ defmodule Nx do
       {:nuclear, _} ->
         raise "nuclear norm not implemented yet."
 
+      {-2, 2} ->
+        raise "ord: -2 for 2-D tensor not implemented yet."
+
       {ord, 2} when ord in [:inf, :neg_inf] ->
         ord
 
@@ -6823,7 +6832,7 @@ defmodule Nx do
         ord
 
       {0, 2} ->
-        raise "ord #{inspect(ord)} not implemented for 2-D tensor."
+        raise "ord 0 not implemented for 2-D tensor."
 
       {0, 1} ->
         0

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -6663,11 +6663,11 @@ defmodule Nx do
 
   For the 0-norm, the norm is the number of non-zero elements in the tensor.
 
-  ### Options
+  ## Options
 
-  - `:axes` - defines the axes upon which the norm will be calculated. Default: `nil`.
-  - `:keep_axes` - defines if the resulting tensor should have the same dimensions as the input. Default: `false`.
-  - `:ord` - defines which norm will be calculated according to the table below. Default: `2`
+    * `:axes` - defines the axes upon which the norm will be calculated. Default: `nil`.
+    * `:keep_axes` - defines if the resulting tensor should have the same dimensions as the input. Default: `false`.
+    * `:ord` - defines which norm will be calculated according to the table below. Default: `2`
 
   | ord          | 2-D                                       | 1-D                               |
   | ------------ | ----------------------------------------- | --------------------------------- |
@@ -6683,7 +6683,7 @@ defmodule Nx do
   | -2           | smallest singular value (not implemented) | as below                          |
   | other        | -                                         | power(sum(power(abs(x), p)), 1/p) |
 
-  ### Examples
+  ## Examples
 
     iex> Nx.norm(Nx.tensor([3, 4]))
     #Nx.Tensor<
@@ -6766,8 +6766,6 @@ defmodule Nx do
       ]
     >
 
-    iex> Nx.norm(Nx.tensor([0, 1]), my_opt: 1)
-    ** (RuntimeError) unknown key :my_opt in [my_opt: 1], expected one of [:ord, :axes, :keep_axes]
 
     iex> Nx.norm(Nx.tensor([[0], [1]]), ord: :nuclear)
     ** (RuntimeError) nuclear norm not implemented yet.
@@ -6780,23 +6778,16 @@ defmodule Nx do
   For big values of p, f64 rounding errors come into play
   """
 
-  def norm(t_raw, input_opts \\ []) when is_list(input_opts) do
+  def norm(tensor, opts \\ []) when is_list(opts) do
     t = tensor!(t_raw)
     assert_keys!(input_opts, [:ord, :axes, :keep_axes])
 
     default_axes_opts = [axes: nil, keep_axes: false, ord: nil]
     opts = Keyword.merge(default_axes_opts, input_opts)
 
-    case shape(t) do
-      {_, _} ->
-        :ok
-
-      {_} ->
-        :ok
-
-      s ->
-        raise "expected 1-D or 2-D tensor. Received a tensor with shape #{inspect(s)} instead."
-    end
+rank = rank(t)
+unless rank == 1 or rank == 2,
+  do: raise "expected 1-D or 2-D tensor, got tensor with shape #{inspect(s)}"
 
     rank = rank(t)
     ord = get_norm_ord!(opts, rank)

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -6659,6 +6659,53 @@ defmodule Nx do
   end
 
   @doc """
+  Calculates the p-norm of a tensor.
+
+  For the 0-norm, the norm is the number of non-zero elements in the tensor.
+
+  ### Examples
+
+    iex> Nx.p_norm(Nx.tensor([3, 4]), 2)
+    #Nx.Tensor<
+      f64
+      5.0
+    >
+
+    iex> Nx.p_norm(Nx.tensor([[0, -3, 4], [0, 0, 0]]), 1)
+    #Nx.Tensor<
+      f64
+      7.0
+    >
+
+    iex> Nx.p_norm(Nx.tensor([[[0, -3, -4]], [[0, 0, 0]]]), 0)
+    #Nx.Tensor<
+      f64
+      2.0
+    >
+
+  ### Caveats
+
+  For big values of p, f64 rounding errors come into play
+  """
+  def p_norm(t, 0) do
+    t
+    |> equal(0)
+    |> logical_not()
+    |> sum()
+    |> as_type({:f, 64})
+  end
+
+  def p_norm(t, p) do
+    inv_p = divide(1, p)
+
+    t
+    |> Nx.abs()
+    |> power(p)
+    |> sum()
+    |> power(inv_p)
+  end
+
+  @doc """
   Sorts the tensor along the given axis with the
   given comparator.
 

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -6685,6 +6685,8 @@ defmodule Nx do
 
   ## Examples
 
+    ### Vector norms
+
     iex> Nx.norm(Nx.tensor([3, 4]))
     #Nx.Tensor<
       f64
@@ -6715,11 +6717,7 @@ defmodule Nx do
       2
     >
 
-    iex> Nx.norm(Nx.tensor([3, 4]), ord: :frobenius)
-    ** (RuntimeError) expected a 2-D tensor. Got a 1-D tensor.
-
-    iex> Nx.norm(Nx.tensor([3, 4]), ord: :nuclear)
-    ** (RuntimeError) nuclear norm not implemented yet.
+    ### Matrix norms
 
     iex> Nx.norm(Nx.tensor([[3, -1], [2, -4]]), ord: -1)
     #Nx.Tensor<
@@ -6766,16 +6764,19 @@ defmodule Nx do
       ]
     >
 
+    ### Error cases
+
+    iex> Nx.norm(Nx.tensor([3, 4]), ord: :frobenius)
+    ** (RuntimeError) expected a 2-D tensor. Got a 1-D tensor.
+
+    iex> Nx.norm(Nx.tensor([3, 4]), ord: :nuclear)
+    ** (RuntimeError) nuclear norm not implemented yet.
 
     iex> Nx.norm(Nx.tensor([[0], [1]]), ord: :nuclear)
     ** (RuntimeError) nuclear norm not implemented yet.
 
     iex> Nx.norm(Nx.tensor([[0], [1]]), ord: -2)
     ** (RuntimeError) ord: -2 for 2-D tensor not implemented yet.
-
-  ### Caveats
-
-  For big values of p, f64 rounding errors come into play
   """
 
   def norm(tensor, opts \\ []) when is_list(opts) do

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -6881,7 +6881,7 @@ defmodule Nx do
     raise "invalid ord for 2-D tensor. Got: #{inspect(ord)}"
   end
 
-  defp do_p_norm(%{type: type} = t, ord, _, opts) do
+  defp do_p_norm(t, ord, _, opts) do
     inv_ord = divide(1, ord)
 
     abs_t = Nx.abs(t)


### PR DESCRIPTION
This PR aims to implement the 0-norm, 1-norm and 2-norm cited in #157 via the `p_norm/2` function