### PR TITLE
Improve defn.ex docs

### DIFF
--- a/nx/lib/nx/defn.ex
+++ b/nx/lib/nx/defn.ex
@@ -24,7 +24,7 @@ defmodule Nx.Defn do
 
       defn add_and_mult(a, b, c) do
         a
-        |> Nx.multipy(b)
+        |> Nx.multiply(b)
         |> Nx.add(c)
       end
 


### PR DESCRIPTION
no function `Nx.multipy` exists, doc should updated to use `Nx.multiply` instead