### PR TITLE
no type NX.Tensor.axes() exists

### DIFF
--- a/nx/lib/nx/backend.ex
+++ b/nx/lib/nx/backend.ex
@@ -28,7 +28,7 @@ defmodule Nx.Backend do
   @type tensor :: Nx.Tensor.t()
   @type shape :: Nx.Tensor.shape()
   @type axis :: Nx.Tensor.axis()
-  @type axes :: NX.Tensor.axes()
+  @type axes :: Nx.Tensor.axes()
 
   @callback iota(tensor, axis | nil) :: tensor
   @callback random_uniform(tensor, number, number) :: tensor


### PR DESCRIPTION
no type NX.Tensor.axes() exits, should be Nx.Tensor.axes() instead