### PR TITLE
Remove NumPy dependency

### DIFF
--- a/exla/Makefile
+++ b/exla/Makefile
@@ -28,7 +28,7 @@ TENSORFLOW_DIR = $(EXLA_CACHE)/$(TENSORFLOW_NS)/erts-$(ERTS_VERSION)
 TENSORFLOW_EXLA_NS = tensorflow/compiler/xla/exla
 TENSORFLOW_EXLA_DIR = $(TENSORFLOW_DIR)/$(TENSORFLOW_EXLA_NS)
 
-all: symlinks
+all: symlinks disable_python_check
 	cd $(TENSORFLOW_DIR) && \
 		bazel build $(BAZEL_FLAGS) $(EXLA_FLAGS) //$(TENSORFLOW_EXLA_NS):libexla.so
 	mkdir -p priv
@@ -52,6 +52,13 @@ $(TENSORFLOW_DIR):
 		git remote add origin $(EXLA_TENSORFLOW_GIT_REPO) && \
 		git fetch --depth 1 origin $(EXLA_TENSORFLOW_GIT_REV) && \
 		git checkout FETCH_HEAD
+
+disable_python_check:
+	cd $(TENSORFLOW_DIR) && \
+		sed -i '21 s/^/#/' WORKSPACE && \
+		sed -i '8 s/^/#/' tensorflow/workspace.bzl && \
+		sed -i '81 s/^/#/' tensorflow/workspace.bzl && \
+		sed -i '101 s/^/#/' tensorflow/workspace.bzl
 
 clean:
 	cd $(TENSORFLOW_DIR) && bazel clean --expunge

--- a/exla/Makefile
+++ b/exla/Makefile
@@ -55,10 +55,10 @@ $(TENSORFLOW_DIR):
 
 disable_python_check:
 	cd $(TENSORFLOW_DIR) && \
-		sed -i '21 s/^/#/' WORKSPACE && \
-		sed -i '8 s/^/#/' tensorflow/workspace.bzl && \
-		sed -i '81 s/^/#/' tensorflow/workspace.bzl && \
-		sed -i '101 s/^/#/' tensorflow/workspace.bzl
+		sed -e '/register_toolchains("@local_config_python\/\/:py_toolchain")/ s/^#*/#/' -i WORKSPACE && \
+		sed -e '/load("\/\/third_party\/py:python_configure.bzl", "python_configure")/ s/^#*/#/' -i tensorflow/workspace.bzl && \
+		sed -e '/native.register_toolchains("@local_execution_config_python\/\/:py_toolchain")/ s/^#*/#/' -i tensorflow/workspace.bzl && \
+		sed -e '/python_configure(name = "local_config_python")/ s/^#*/#/' -i tensorflow/workspace.bzl
 
 clean:
 	cd $(TENSORFLOW_DIR) && bazel clean --expunge

--- a/exla/Makefile.win
+++ b/exla/Makefile.win
@@ -38,7 +38,7 @@ TENSORFLOW_DIR=$(EXLA_CACHE)/$(TENSORFLOW_NS)
 TENSORFLOW_EXLA_NS=tensorflow/compiler/xla/exla
 TENSORFLOW_EXLA_DIR=$(TENSORFLOW_DIR)/$(TENSORFLOW_EXLA_NS)
 
-all: symlinks
+all: symlinks disable_python_check
 	cd $(TENSORFLOW_DIR) && \
 		bazel build $(BAZEL_FLAGS) $(EXLA_FLAGS) //$(TENSORFLOW_EXLA_NS):libexla.so
 	mkdir -p priv
@@ -62,6 +62,13 @@ $(TENSORFLOW_DIR):
 		git remote add origin $(EXLA_TENSORFLOW_GIT_REPO) && \
 		git fetch --depth 1 origin $(EXLA_TENSORFLOW_GIT_REV) && \
 		git checkout FETCH_HEAD
+
+disable_python_check:
+  cd $(TENSORFLOW_DIR) && \
+    sed -e '/register_toolchains("@local_config_python\/\/:py_toolchain")/ s/^#*/#/' -i WORKSPACE && \
+    sed -e '/load("\/\/third_party\/py:python_configure.bzl", "python_configure")/ s/^#*/#/' -i tensorflow/workspace.bzl && \
+    sed -e '/native.register_toolchains("@local_execution_config_python\/\/:py_toolchain")/ s/^#*/#/' -i tensorflow/workspace.bzl && \
+    sed -e '/python_configure(name = "local_config_python")/ s/^#*/#/' -i tensorflow/workspace.bzl
 
 clean:
 	cd $(TENSORFLOW_DIR) && bazel clean --expunge

--- a/exla/README.md
+++ b/exla/README.md
@@ -24,11 +24,11 @@ end
 You will need the following installed in your system to compile EXLA:
 
   * [Git](https://git-scm.com/) for checking out Tensorflow
-  * [Bazel v3.1](https://bazel.build/) for compiling Tensorflow (note more recent versions are available but they are not compatible)
-  * [Python3](https://python.org) with numpy installed (`pip3 install numpy`) for compiling Tensorflow
+  * [Bazel v3.1](https://bazel.build/) for compiling Tensorflow (note Bazel v4 is available but it is not compatible)
+  * [Python3](https://python.org) for compiling Tensorflow
 
 If running on Windows, you will also need:
-  
+
   * [MSYS2](https://www.msys2.org/)
   * [Microsoft Build Tools 2019](https://visualstudio.microsoft.com/downloads/)
   * [Microsoft Visual C++ 2019 Redistributable](https://visualstudio.microsoft.com/downloads/)

--- a/exla/docker/Dockerfile.cuda
+++ b/exla/docker/Dockerfile.cuda
@@ -4,7 +4,7 @@ ARG bazel_bin_url="https://github.com/bazelbuild/bazel/releases/download/3.4.1/b
 WORKDIR /etc/apt/sources.list.d
 RUN rm cuda.list nvidia-ml.list
 WORKDIR /
-RUN apt-get update && apt-get install -y --no-install-recommends wget curl git locales python3 python3-pip ca-certificates python3-dev gdb
+RUN apt-get update && apt-get install -y --no-install-recommends wget curl git locales python3 ca-certificates gdb
 RUN echo ${bazel_bin_url}
 RUN curl -L ${bazel_bin_url} -o /usr/local/bin/bazel \
     && chmod +x /usr/local/bin/bazel \
@@ -25,9 +25,6 @@ RUN echo $LANG UTF-8 > /etc/locale.gen \
     && update-locale LANG=$LANG
 
 RUN mix local.hex --force
-
-# For some reason tensorflow expects numpy
-RUN python3 -m pip install ${pip_args} numpy
 
 RUN ln -s /usr/bin/python3 /usr/bin/python
 ENV LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH}"

--- a/exla/docker/Dockerfile.rocm
+++ b/exla/docker/Dockerfile.rocm
@@ -30,9 +30,6 @@ RUN echo $LANG UTF-8 > /etc/locale.gen \
 
 RUN mix local.hex --force
 
-# For some reason tensorflow expects numpy
-RUN python3 -m pip install ${pip_args} numpy
-
 ENV LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH}"
 
 ENV ROCM_PATH="/opt/rocm-3.9.0"


### PR DESCRIPTION
This is about as much of a hack as you can get, but basically we just comment out 4 parts of the TensorFlow build workflow so it doesn't check for the NumPy dependency up front. LLVM requires Python later on so we can't get rid of that, but we no longer need to depend on NumPy just to build.

I think this `sed` will just keep prepending comments to those lines, though.