### PR TITLE
Gradients for inverse trig functions (arccos, arcsin, arctan)

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.11.3-otp-23
+erlang 23.2.4

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,0 @@
-elixir 1.11.3-otp-23
-erlang 23.2.4

--- a/nx/lib/nx/defn/grad.ex
+++ b/nx/lib/nx/defn/grad.ex
@@ -417,7 +417,7 @@ defmodule Nx.Defn.Grad do
   end
 
   defp grad(:arccos, [x], _ans, g, cache) do
-    g = Nx.divide(g, Nx.negate(Nx.sqrt(Nx.subtract(1.0, Nx.power(x, 2.0)))))
+    g = Nx.multiply(g, Nx.negate(Nx.rsqrt(Nx.subtract(1.0, Nx.power(x, 2.0)))))
     to_grad(x, g, cache)
   end
 

--- a/nx/lib/nx/defn/grad.ex
+++ b/nx/lib/nx/defn/grad.ex
@@ -407,7 +407,7 @@ defmodule Nx.Defn.Grad do
   end
 
   defp grad(:arcsin, [x], _ans, g, cache) do
-    g = Nx.divide(g, Nx.power(Nx.subtract(1.0, Nx.power(x, 2.0)), 0.5))
+    g = Nx.multiply(g, Nx.rsqrt(Nx.subtract(1.0, Nx.power(x, 2.0))))
     to_grad(x, g, cache)
   end
 
@@ -417,7 +417,7 @@ defmodule Nx.Defn.Grad do
   end
 
   defp grad(:arccos, [x], _ans, g, cache) do
-    g = Nx.divide(g, Nx.multiply(-1.0, Nx.power(Nx.subtract(1.0, Nx.power(x, 2.0)), 0.5)))
+    g = Nx.divide(g, Nx.negate(Nx.sqrt(Nx.subtract(1.0, Nx.power(x, 2.0)))))
     to_grad(x, g, cache)
   end
 

--- a/nx/lib/nx/defn/grad.ex
+++ b/nx/lib/nx/defn/grad.ex
@@ -426,6 +426,11 @@ defmodule Nx.Defn.Grad do
     to_grad(x, g, cache)
   end
 
+  defp grad(:arctan, [x], _ans, g, cache) do
+    g = Nx.divide(g, Nx.add(1.0, Nx.power(x, 2.0)))
+    to_grad(x, g, cache)
+  end
+
   defp grad(:tanh, [x], ans, g, cache) do
     g = Nx.multiply(g, Nx.subtract(1.0, Nx.multiply(ans, ans)))
     to_grad(x, g, cache)

--- a/nx/lib/nx/defn/grad.ex
+++ b/nx/lib/nx/defn/grad.ex
@@ -347,13 +347,13 @@ defmodule Nx.Defn.Grad do
     to_grad(x, g, cache)
   end
 
-  defp grad(:cbrt, [x], ans, g, cache) do
-    g = Nx.divide(g, 3 |> Nx.multiply(ans) |> Nx.multiply(ans))
+  defp grad(:sqrt, [x], ans, g, cache) do
+    g = Nx.multiply(g, Nx.divide(0.5, ans))
     to_grad(x, g, cache)
   end
 
-  defp grad(:cos, [x], _ans, g, cache) do
-    g = Nx.multiply(g, Nx.negate(Nx.sin(x)))
+  defp grad(:cbrt, [x], ans, g, cache) do
+    g = Nx.divide(g, 3 |> Nx.multiply(ans) |> Nx.multiply(ans))
     to_grad(x, g, cache)
   end
 
@@ -406,18 +406,18 @@ defmodule Nx.Defn.Grad do
     to_grad(x, g, cache)
   end
 
-  defp grad(:sqrt, [x], ans, g, cache) do
-    g = Nx.multiply(g, Nx.divide(0.5, ans))
-    to_grad(x, g, cache)
-  end
-
-  defp grad(:tanh, [x], ans, g, cache) do
-    g = Nx.multiply(g, Nx.subtract(1.0, Nx.multiply(ans, ans)))
+  defp grad(:cos, [x], _ans, g, cache) do
+    g = Nx.multiply(g, Nx.negate(Nx.sin(x)))
     to_grad(x, g, cache)
   end
 
   defp grad(:tan, [x], _ans, g, cache) do
     g = Nx.divide(g, Nx.power(Nx.cos(x), 2))
+    to_grad(x, g, cache)
+  end
+
+  defp grad(:tanh, [x], ans, g, cache) do
+    g = Nx.multiply(g, Nx.subtract(1.0, Nx.multiply(ans, ans)))
     to_grad(x, g, cache)
   end
 

--- a/nx/lib/nx/defn/grad.ex
+++ b/nx/lib/nx/defn/grad.ex
@@ -406,8 +406,18 @@ defmodule Nx.Defn.Grad do
     to_grad(x, g, cache)
   end
 
+  defp grad(:arcsin, [x], _ans, g, cache) do
+    g = Nx.divide(g, Nx.power(Nx.subtract(1.0, Nx.power(x, 2.0)), 0.5))
+    to_grad(x, g, cache)
+  end
+
   defp grad(:cos, [x], _ans, g, cache) do
     g = Nx.multiply(g, Nx.negate(Nx.sin(x)))
+    to_grad(x, g, cache)
+  end
+
+  defp grad(:arccos, [x], _ans, g, cache) do
+    g = Nx.divide(g, Nx.multiply(-1.0, Nx.power(Nx.subtract(1.0, Nx.power(x, 2.0)), 0.5)))
     to_grad(x, g, cache)
   end
 

--- a/nx/test/nx/defn/grad_test.exs
+++ b/nx/test/nx/defn/grad_test.exs
@@ -485,10 +485,11 @@ defmodule Nx.Defn.GradTest do
 
     test "computes gradient of inverse trig functions" do
       for _ <- 1..100 do
-        t = Nx.random_uniform({}, -0.999, 0.999, type: {:f, 64})
+        t = Nx.random_uniform({}, -0.996, 0.996, type: {:f, 64})
         check_grads!(&Nx.arcsin/1, &grad_arcsin/1, t)
         check_grads!(&Nx.arccos/1, &grad_arccos/1, t)
         check_grads!(&Nx.arctan/1, &grad_arctan/1, t)
+        check_grads!(&Nx.arctan/1, &grad_arctan/1, Nx.multiply(1000.0,t))
       end
     end
   end

--- a/nx/test/nx/defn/grad_test.exs
+++ b/nx/test/nx/defn/grad_test.exs
@@ -466,7 +466,7 @@ defmodule Nx.Defn.GradTest do
   describe "tan" do
     defn grad_tan(t), do: grad(t, Nx.tan(t))
 
-    test "computes gradient of tan" do
+    test "computes gradient" do
       for _ <- 1..100 do
           # check_grads!/4 fails for values close to the asymptotes
           # of tan's gradient, so we select t to avoid them.

--- a/nx/test/nx/defn/grad_test.exs
+++ b/nx/test/nx/defn/grad_test.exs
@@ -466,7 +466,7 @@ defmodule Nx.Defn.GradTest do
   describe "tan" do
     defn grad_tan(t), do: grad(t, Nx.tan(t))
 
-    test "computes gradient" do
+    test "computes gradient of tan" do
       for _ <- 1..100 do
           # check_grads!/4 fails for values close to the asymptotes
           # of tan's gradient, so we select t to avoid them.
@@ -475,6 +475,19 @@ defmodule Nx.Defn.GradTest do
           t = 3.14159 |> Nx.multiply(multiplier) |> Nx.add(offset)
           check_grads!(&Nx.tan/1, &grad_tan/1, t)
         end
+    end
+  end
+
+  describe "inverse trig family" do
+    defn grad_arcsin(t), do: grad(t, Nx.arcsin(t))
+    defn grad_arccos(t), do: grad(t, Nx.arccos(t))
+
+    test "computes gradient of inverse trig functions" do
+      for _ <- 1..100 do
+        t = Nx.random_uniform({}, -0.999, 0.999, type: {:f, 64})
+        check_grads!(&Nx.arcsin/1, &grad_arcsin/1, t)
+        check_grads!(&Nx.arccos/1, &grad_arccos/1, t)
+      end
     end
   end
 

--- a/nx/test/nx/defn/grad_test.exs
+++ b/nx/test/nx/defn/grad_test.exs
@@ -481,12 +481,14 @@ defmodule Nx.Defn.GradTest do
   describe "inverse trig family" do
     defn grad_arcsin(t), do: grad(t, Nx.arcsin(t))
     defn grad_arccos(t), do: grad(t, Nx.arccos(t))
+    defn grad_arctan(t), do: grad(t, Nx.arctan(t))
 
     test "computes gradient of inverse trig functions" do
       for _ <- 1..100 do
         t = Nx.random_uniform({}, -0.999, 0.999, type: {:f, 64})
         check_grads!(&Nx.arcsin/1, &grad_arcsin/1, t)
         check_grads!(&Nx.arccos/1, &grad_arccos/1, t)
+        check_grads!(&Nx.arctan/1, &grad_arctan/1, t)
       end
     end
   end


### PR DESCRIPTION
This is for progress in issue #161  .

- Added gradients for `arccos` and `arcsin`.
- Added a test that checks the gradients of those functions.
- Moved some grad functions around to be closer to each other.