### PR TITLE
Add erf_inv/1 to Nx and enable in EXLA

### DIFF
--- a/exla/test/exla/defn_expr_test.exs
+++ b/exla/test/exla/defn_expr_test.exs
@@ -628,7 +628,7 @@ defmodule EXLA.DefnExprTest do
 
     for fun <-
           [:exp, :expm1, :log, :log1p, :logistic, :cos, :sin, :tanh, :sqrt, :rsqrt, :cbrt] ++
-            [:tan, :arccosh, :arcsinh, :cosh, :sinh, :erf, :erfc] do
+            [:tan, :arccosh, :arcsinh, :cosh, :sinh, :erf, :erfc, :erf_inv] do
       exla_fun = :"unary_#{fun}"
       nx_fun = :"unary_#{fun}_nx"
       defn unquote(exla_fun)(t), do: Nx.unquote(fun)(t)

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -3541,7 +3541,7 @@ defmodule Nx do
     formula = code |> Macro.to_string() |> String.replace("var!(x)", "x")
 
     {{one, _}, {two, _}, {three, _}} =
-      if name in [:arccos, :arcsin, :arctan, :arctanh] do
+      if name in [:arccos, :arcsin, :arctan, :arctanh, :erf_inv] do
         {Code.eval_quoted(code, x: 0.1), Code.eval_quoted(code, x: 0.5),
          Code.eval_quoted(code, x: 0.9)}
       else
@@ -3549,12 +3549,12 @@ defmodule Nx do
       end
 
     first_val =
-      if name in [:arccos, :arcsin, :arctan, :arctanh],
+      if name in [:arccos, :arcsin, :arctan, :arctanh, :erf_inv],
         do: 0.1,
         else: 1
 
     list_of_vals =
-      if name in [:arccos, :arcsin, :arctan, :arctanh],
+      if name in [:arccos, :arcsin, :arctan, :arctanh, :erf_inv],
         do: [0.1, 0.5, 0.9],
         else: [1.0, 2.0, 3.0]
 

--- a/nx/lib/nx/defn/expr.ex
+++ b/nx/lib/nx/defn/expr.ex
@@ -458,7 +458,7 @@ defmodule Nx.Defn.Expr do
     [:exp, :expm1, :log, :log1p, :logistic, :cos, :sin, :tan, :cosh, :sinh, :tanh] ++
       [:arccosh, :arcsinh, :arctanh, :sqrt, :rsqrt, :cbrt, :negate, :sign, :abs, :bitwise_not] ++
       [:population_count, :count_leading_zeros, :floor, :ceil, :round, :as_type] ++
-      [:erf, :erfc, :arccos, :arcsin, :arctan]
+      [:erf, :erfc, :erf_inv, :arccos, :arcsin, :arctan]
 
   for op <- unary_ops do
     @impl true

--- a/nx/lib/nx/defn/grad.ex
+++ b/nx/lib/nx/defn/grad.ex
@@ -446,6 +446,14 @@ defmodule Nx.Defn.Grad do
     to_grad(x, g, cache)
   end
 
+  @half_sqrt_pi :math.sqrt(:math.pi) / 2
+
+  defp grad(:erf_inv, [x], ans, g, cache) do
+    g = Nx.multiply(g, Nx.exp(Nx.power(ans, 2)))
+    g = Nx.multiply(@half_sqrt_pi, g)
+    to_grad(x, g, cache)
+  end
+
   defp grad(:reduce, _, _, _, _) do
     raise ArgumentError, """
     cannot compute gradient for Nx.reduce/4.

--- a/nx/lib/nx/shared.ex
+++ b/nx/lib/nx/shared.ex
@@ -253,7 +253,19 @@ defmodule Nx.Shared do
   @doc """
   Approximation for the inverse error function.
 
-  from Giles, M., "Approximating the erfinv function"
+  ## Examples
+
+    iex> Nx.erf_inv(0.999)
+    #Nx.Tensor<
+      f64
+      2.326753756865462
+    >
+
+    iex> Nx.erf_inv(0.01)
+    #Nx.Tensor<
+      f64
+      0.008862500728738846
+    >
   """
   def erf_inv(x) do
     w = -:math.log((1 - x) * (1 + x))

--- a/nx/lib/nx/shared.ex
+++ b/nx/lib/nx/shared.ex
@@ -162,7 +162,8 @@ defmodule Nx.Shared do
       rsqrt: {"reverse square root", quote(do: 1 / :math.sqrt(var!(x)))},
       cbrt: {"cube root", quote(do: :math.pow(var!(x), 1 / 3))},
       erf: {"error function", erf_formula()},
-      erfc: {"one minus error function", erfc_formula()}
+      erfc: {"one minus error function", erfc_formula()},
+      erf_inv: {"inverse error function", quote(do: Nx.Shared.erf_inv(var!(x)))}
     ]
 
   defp atanh_formula do
@@ -247,6 +248,44 @@ defmodule Nx.Shared do
   rescue
     UndefinedFunctionError ->
       false
+  end
+
+  @doc """
+  Approximation for the inverse error function.
+
+  from Giles, M., "Approximating the erfinv function"
+  """
+  def erf_inv(x) do
+    w = -:math.log((1 - x) * (1 + x))
+    erf_inv_p(w) * x
+  end
+
+  defp erf_inv_p(w) when w < 5 do
+    w = w - 2.5
+
+    2.81022636e-08
+    |> muladd(w, 3.43273939e-07)
+    |> muladd(w, -3.5233877e-06)
+    |> muladd(w, -4.39150654e-06)
+    |> muladd(w, 0.00021858087)
+    |> muladd(w, -0.00125372503)
+    |> muladd(w, -0.00417768164)
+    |> muladd(w, 0.246640727)
+    |> muladd(w, 1.50140941)
+  end
+
+  defp erf_inv_p(w) do
+    w = :math.sqrt(w) - 3
+
+    -0.000200214257
+    |> muladd(w, 0.000100950558)
+    |> muladd(w, 0.00134934322)
+    |> muladd(w, -0.00367342844)
+    |> muladd(w, 0.00573950773)
+    |> muladd(w, -0.0076224613)
+    |> muladd(w, 0.00943887047)
+    |> muladd(w, 1.00167406)
+    |> muladd(w, 2.83297682)
   end
 
   ## Types

--- a/nx/lib/nx/shared.ex
+++ b/nx/lib/nx/shared.ex
@@ -255,17 +255,11 @@ defmodule Nx.Shared do
 
   ## Examples
 
-    iex> Nx.erf_inv(0.999)
-    #Nx.Tensor<
-      f64
+      iex> Nx.Shared.erf_inv(0.999)
       2.326753756865462
-    >
 
-    iex> Nx.erf_inv(0.01)
-    #Nx.Tensor<
-      f64
+      iex> Nx.Shared.erf_inv(0.01)
       0.008862500728738846
-    >
   """
   def erf_inv(x) do
     w = -:math.log((1 - x) * (1 + x))

--- a/nx/test/nx/defn/grad_test.exs
+++ b/nx/test/nx/defn/grad_test.exs
@@ -507,6 +507,49 @@ defmodule Nx.Defn.GradTest do
     end
   end
 
+  describe "erf_inv" do
+    defn grad_erf_inv(t), do: grad(t, Nx.erf_inv(t))
+
+    test "computes gradient close to 0.0" do
+      for _ <- 1..25 do
+        t = Nx.random_uniform({}, 0.0, 0.9, type: {:f, 64})
+        check_grads!(&Nx.erf_inv/1, &grad_erf_inv/1, t, 1.0e-4)
+      end
+    end
+
+    test "computes gradient between 0.9 and 0.95" do
+      for _ <- 1..25 do
+        t = Nx.random_uniform({}, 0.9, 0.95, type: {:f, 64})
+        check_grads!(&Nx.erf_inv/1, &grad_erf_inv/1, t, 1.0e-3)
+      end
+    end
+
+    test "computes gradient between 0.95 and 0.98" do
+      for _ <- 1..25 do
+        t = Nx.random_uniform({}, 0.95, 0.98, type: {:f, 64})
+        check_grads!(&Nx.erf_inv/1, &grad_erf_inv/1, t, 0.00004)
+      end
+    end
+
+    test "computes gradient approaching 1.0 but is sharply curved" do
+      #check_grads! does not work near 1 due to sharp curve between close x's
+      coords = [
+        {0.9, 3.43},
+        {0.98, 13.26},
+        {0.99, 24.45},
+        {0.991, 26.85},
+        {0.992, 29.84},
+        {0.993, 33.64},
+        {0.994, 38.64},
+        {0.995, 45.56},
+        {0.999, 198.94},
+      ]
+      for {x, y} <- coords do
+        assert_in_delta(Nx.to_scalar(grad_erf_inv(x)), y, 0.01)
+      end
+    end
+  end
+
   describe "broadcast" do
     defn grad_sum_broadcast(t), do: grad(t, Nx.sum(Nx.broadcast(t, {3, 2, 2})))
 

--- a/nx/test/nx/shared_test.exs
+++ b/nx/test/nx/shared_test.exs
@@ -1,5 +1,6 @@
 defmodule Nx.SharedTest do
   use ExUnit.Case, async: true
+  doctest Nx.Shared
 
   if Nx.Shared.math_func_supported?(:erf, 1) do
     describe "erf_fallback/1" do


### PR DESCRIPTION
This PR adds `erf_inv/1` operation to `Nx`, `Nx.Backend`, and `EXLA`.

 #### SciPy:
 
 ```python
 In [2]: from scipy import special

In [3]: special.erfinv(0.999)
Out[3]: 2.3267537655135464

In [4]: special.erfinv(0.01)
Out[4]: 0.008862501280950608
 ```
 
 #### Nx:
 ```elixir
 iex(1)> Nx.erf_inv(0.999)
#Nx.Tensor<
  f64
  2.326753756865462
>
iex(2)> Nx.erf_inv(0.01) 
#Nx.Tensor<
  f64
  0.008862500728738846
>
 ```
 
 #### Resouces:

  + [erf_inv in XLA](https://github.com/tensorflow/tensorflow/blob/0e6b3a307f6363a9ee9dc9e03a8a0350c7668799/tensorflow/compiler/xla/client/lib/math.cc#L340-L390)
  
  + [erf_inv's grad in Jax](https://github.com/google/jax/blob/7e040c0a89b7b1f5c3607623d67c811d977470f4/jax/_src/lax/lax.py#L2434-L2436)
 