### PR TITLE
Add QR decomposition

### DIFF
--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -7056,107 +7056,81 @@ defmodule Nx do
 
     * `:reduced` - returns `q` and `r` with shapes `{M, K}` and `{K, N}`
     * `:complete` - returns `q` and `r` with shapes `{M, M}` and `{M, N}`
-    * `:r` - returns `r` with shape `{K, N}`
-    * `:raw` - returns `{h, tau}`, with `h` being the array of Householder reflectors and
-               `tau` being the array with the respective scaling factors.
 
   ## Examples
 
   Note: The following examples round elements of the output tensors
   to minimize rounding errors on different host machines.
 
-    iex(1)> [q, r] = Nx.qr(Nx.tensor([[12, -51, 4], [6, 167, -68], [-4, 24, -41]])) |> Tuple.to_list() |> Enum.map(fn t -> Nx.map(t, &Float.round(&1, 4)) end)
-    [
+      iex(1)> [q, r] = Nx.qr(Nx.tensor([[12, -51, 4], [6, 167, -68], [-4, 24, -41]])) |> Tuple.to_list() |> Enum.map(fn t -> Nx.map(t, &Float.round(&1, 4)) end)
+      [
+        Nx.tensor([
+          [-0.8571, 0.3943, -0.3314],
+          [-0.4286, -0.9029, 0.0343],
+          [0.2857, -0.1714, -0.9429]
+        ]),
+        Nx.tensor([
+          [-14.0, -21.0, 14.0],
+          [-0.0, -175.0, 70.0],
+          [-0.0, -0.0, 35.0]
+        ])
+      ]
+      iex(2)> Nx.dot(q, r) |> Nx.map(&Float.round(&1, 0))
       Nx.tensor([
-        [-0.8571, 0.3943, -0.3314],
-        [-0.4286, -0.9029, 0.0343],
-        [0.2857, -0.1714, -0.9429]
-      ]),
-      Nx.tensor([
-        [-14.0, -21.0, 14.0],
-        [-0.0, -175.0, 70.0],
-        [-0.0, -0.0, 35.0]
+        [12.0, -51.0, 4.0],
+        [6.0, 167.0, -68.0],
+        [-4.0, 24.0, -41.0]
       ])
-    ]
-    iex(2)> Nx.dot(q, r) |> Nx.map(&Float.round(&1, 0))
-    Nx.tensor([
-      [12.0, -51.0, 4.0],
-      [6.0, 167.0, -68.0],
-      [-4.0, 24.0, -41.0]
-    ])
 
-    iex(1)> [q, r] = Nx.qr(Nx.tensor([[1, -1, 4], [1, 4, -2], [1, 4, 2], [1, -1, 0]]), mode: :reduced) |> Tuple.to_list() |> Enum.map(fn t -> Nx.map(t, &Float.round(&1, 4)) end)
-    [
+      iex(1)> [q, r] = Nx.qr(Nx.tensor([[1, -1, 4], [1, 4, -2], [1, 4, 2], [1, -1, 0]]), mode: :reduced) |> Tuple.to_list() |> Enum.map(fn t -> Nx.map(t, &Float.round(&1, 4)) end)
+      [
+        Nx.tensor([
+          [-0.5774, 0.8165, 0.0],
+          [-0.5774, -0.4082, 0.7071],
+          [-0.5774, -0.4082, -0.7071],
+          [0.0, 0.0, 0.0]
+        ]),
+        Nx.tensor([
+          [-1.7321, -4.0415, -2.3094],
+          [0.0, -4.0825, 3.266],
+          [0.0, 0.0, -2.8284]
+        ])
+      ]
+      iex(2)> Nx.dot(q, r) |> Nx.map(&Float.round(&1, 0))
       Nx.tensor([
-        [-0.5774, 0.8165, 0.0],
-        [-0.5774, -0.4082, 0.7071],
-        [-0.5774, -0.4082, -0.7071],
-        [0.0, 0.0, 0.0]
-      ]),
-      Nx.tensor([
-        [-1.7321, -4.0415, -2.3094],
-        [0.0, -4.0825, 3.266],
-        [0.0, 0.0, -2.8284]
+        [1.0, -1.0, 4.0],
+        [1.0, 4.0, -2.0],
+        [1.0, 4.0, 2.0],
+        [0.0, -0.0, 0.0]
       ])
-    ]
-    iex(2)> Nx.dot(q, r) |> Nx.map(&Float.round(&1, 0))
-    Nx.tensor([
-      [1.0, -1.0, 4.0],
-      [1.0, 4.0, -2.0],
-      [1.0, 4.0, 2.0],
-      [0.0, -0.0, 0.0]
-    ])
 
-    iex(1)> [q, r] = Nx.qr(Nx.tensor([[1, -1, 4], [1, 4, -2], [1, 4, 2], [1, -1, 0]]), mode: :complete) |> Tuple.to_list() |> Enum.map(fn t -> Nx.map(t, &Float.round(&1, 4)) end)
-    [
+      iex(1)> [q, r] = Nx.qr(Nx.tensor([[1, -1, 4], [1, 4, -2], [1, 4, 2], [1, -1, 0]]), mode: :complete) |> Tuple.to_list() |> Enum.map(fn t -> Nx.map(t, &Float.round(&1, 4)) end)
+      [
+        Nx.tensor([
+          [-0.5, 0.5, -0.5, -0.5],
+          [-0.5, -0.5, 0.5, -0.5],
+          [-0.5, -0.5, -0.5, 0.5],
+          [-0.5, 0.5, 0.5, 0.5]
+        ]),
+        Nx.tensor([
+          [-2.0, -3.0, -2.0],
+          [0.0, -5.0, 2.0],
+          [-0.0, -0.0, -4.0],
+          [0.0, 0.0, 0.0]
+        ])
+      ]
+      iex(2)> Nx.dot(q, r) |> Nx.map(&Float.round(&1, 0))
       Nx.tensor([
-        [-0.5, 0.5, -0.5, -0.5],
-        [-0.5, -0.5, 0.5, -0.5],
-        [-0.5, -0.5, -0.5, 0.5],
-        [-0.5, 0.5, 0.5, 0.5]
-      ]),
-      Nx.tensor([
-        [-2.0, -3.0, -2.0],
-        [0.0, -5.0, 2.0],
-        [-0.0, -0.0, -4.0],
-        [0.0, 0.0, 0.0]
+        [1.0, -1.0, 4.0],
+        [1.0, 4.0, -2.0],
+        [1.0, 4.0, 2.0],
+        [1.0, -1.0, 0.0]
       ])
-    ]
-    iex(2)> Nx.dot(q, r) |> Nx.map(&Float.round(&1, 0))
-    Nx.tensor([
-      [1.0, -1.0, 4.0],
-      [1.0, 4.0, -2.0],
-      [1.0, 4.0, 2.0],
-      [1.0, -1.0, 0.0]
-    ])
-
-    iex(1)> {_q, _r, reflectors} = Nx.qr(Nx.tensor([[1, -1, 4], [1, 4, -2], [1, 4, 2], [1, -1, 0]]), mode: :raw)
-    iex(2)> Enum.map(reflectors, fn t -> Nx.map(t, &Float.round(&1, 4)) end)
-    [
-      Nx.tensor([
-        [1.0, 0.0, 0.0, 0.0],
-        [0.0, 1.0, 0.0, 0.0],
-        [0.0, 0.0, -0.6, 0.8],
-        [0.0, 0.0, 0.8, 0.6]
-      ]),
-      Nx.tensor([
-        [1.0, 0.0, 0.0, 0.0],
-        [0.0, -0.6667, -0.6667, 0.3333],
-        [0.0, -0.6667, 0.7333, 0.1333],
-        [0.0, 0.3333, 0.1333, 0.9333]
-      ]),
-      Nx.tensor([
-        [-0.5, -0.5, -0.5, -0.5],
-        [-0.5, 0.8333, -0.1667, -0.1667],
-        [-0.5, -0.1667, 0.8333, -0.1667],
-        [-0.5, -0.1667, -0.1667, 0.8333]
-      ])
-    ]
 
   ## Error cases
 
-    iex> Nx.qr(Nx.tensor([[1, 1, 1, 1], [-1, 4, 4, -1], [4, -2, 2, 0]])) |> Tuple.to_list() |> Enum.map(fn t -> Nx.map(t, &Float.round(&1, 4)) end)
-    ** (ArgumentError) tensor must have at least as many rows than columns, got shape: {3, 4}
+      iex> Nx.qr(Nx.tensor([[1, 1, 1, 1], [-1, 4, 4, -1], [4, -2, 2, 0]])) |> Tuple.to_list() |> Enum.map(fn t -> Nx.map(t, &Float.round(&1, 4)) end)
+      ** (ArgumentError) tensor must have at least as many rows than columns, got shape: {3, 4}
   """
   @doc type: :linalg
   def qr(tensor, opts \\ []) do
@@ -7176,20 +7150,14 @@ defmodule Nx do
 
     output_type = Nx.Type.to_floating(type)
 
-    {q_shape, {k, n}} = Nx.Shape.qr(shape, opts)
+    {q_shape, r_shape} = Nx.Shape.qr(shape, opts)
 
-    q = iota(q_shape, type: output_type)
-
-    mode = opts[:mode]
-
-    r =
-      if mode == :reduced do
-        tensor[[0..(k - 1), 0..(n - 1)]]
-      else
-        tensor
-      end
-
-    impl!(tensor).qr(q, r, opts)
+    impl!(tensor).qr(
+      {%{tensor | type: output_type, shape: q_shape},
+       %{tensor | type: output_type, shape: r_shape}},
+      tensor,
+      opts
+    )
   end
 
   ## Helpers

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -7063,9 +7063,6 @@ defmodule Nx do
 
   ## Examples
 
-  Note: The following examples round elements of the output tensors
-  to minimize rounding errors on different host machines.
-
       iex> Nx.qr(Nx.tensor([[-3, 2, 1], [0, 1, 1], [0, 0, -1]]))
       {
         Nx.tensor([

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -7046,6 +7046,58 @@ defmodule Nx do
     impl!(tensor).sort(tensor, tensor, axis: axis, comparator: comparator)
   end
 
+  def qr(tensor) do
+    %T{type: type, shape: shape} = tensor = tensor!(tensor)
+
+    output_type = Nx.Type.to_floating(type)
+
+    {q_shape, r_shape} = Nx.Shape.qr(shape)
+
+    q = iota(q_shape, type: output_type)
+    r = iota(r_shape, type: output_type)
+
+    impl!(tensor).qr(q, r, tensor)
+  end
+
+  # def qr(tensor, opts \\ []) do
+  #   %{shape: shape, type: type} = t = tensor!(tensor)
+
+  #   if tuple_size(shape) != 2, do: raise(ArgumentError, "expected 2-D tensor")
+
+  #   {m, n} = shape
+
+  #   q = eye(m, type: type)
+
+  #   max_i = if m == n, do: n - 1, else: n - 2
+
+  #   for i <- 0..max_i, reduce: {q, t} do
+  #     {q, r} ->
+  #       reflector = householder_reflector(t[[i..(m - 1), i]])
+  #       # placeholder implementation of H = eye(m); H[i:, i:] = reflector[i:, i:]
+  #       h = eye(m, type: type)
+
+  #       for c <- 0..(m - 1), r <- 0..(m - 1), reduce: [] do
+  #         acc ->
+  #           if c < i or r < i do
+  #             [h[[r, c]] | acc]
+  #           else
+  #             [reflector[[r, c]] | acc]
+  #           end
+  #       end
+  #       |> Enum.reverse()
+  #       |> tensor()
+  #       |> reshape({max_i, max_i})
+
+  #       {multiply(q, h), multiply(h, r)}
+  #   end
+  # end
+
+  # # placeholder identity matrix definition
+  # defp eye(n, type: type) do
+  #   m = Enum.map(1..n, fn i -> Enum.map(1..n, fn j -> if i == j, do: 1, else: 0 end) end)
+  #   tensor(m, type: type)
+  # end
+
   ## Helpers
 
   defp tensor!(%T{} = t),

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -7047,19 +7047,19 @@ defmodule Nx do
   end
 
   @doc """
-  Calculates the QR decomposition of an 2-D tensor with shape `{M, N}` via the Householder method.
+  Calculates the QR decomposition of a 2-D tensor with shape `{M, N}`.
 
   ## Options
 
-  `:mode` - Can be one of `:reduced`, `:complete`, `:r` or `:raw`. Defaults to `:reduced`
+  `:mode` - Can be one of `:reduced`, `:complete`. Defaults to `:reduced`
     For the following, `K = min(M, N)`
 
     * `:reduced` - returns `q` and `r` with shapes `{M, K}` and `{K, N}`
     * `:complete` - returns `q` and `r` with shapes `{M, M}` and `{M, N}`
 
-  `:q_axes` - Defines the axes for the `q` tensor
+  `:q_names` - Defines the axes for the `q` tensor
 
-  `:r_axes` - Defines the axes for the `r` tensor
+  `:r_names` - Defines the axes for the `r` tensor
 
   ## Examples
 
@@ -7080,7 +7080,7 @@ defmodule Nx do
         ])
       }
 
-      iex> Nx.qr(Nx.tensor([[3, 2, 1], [0, 1, 1], [0, 0, 1]]), q_axes: [:row, :base_vector], r_axes: [:coef, :vars])
+      iex> Nx.qr(Nx.tensor([[3, 2, 1], [0, 1, 1], [0, 0, 1]]), q_names: [:row, :base_vector], r_names: [:coef, :vars])
       {
         Nx.tensor([
           [-1.0, 0.0, 0.0],
@@ -7127,14 +7127,14 @@ defmodule Nx do
 
   ## Error cases
 
-      iex> Nx.qr(Nx.tensor([[1, 1, 1, 1], [-1, 4, 4, -1], [4, -2, 2, 0]])) |> Tuple.to_list() |> Enum.map(fn t -> Nx.map(t, &Float.round(&1, 4)) end)
+      iex> Nx.qr(Nx.tensor([[1, 1, 1, 1], [-1, 4, 4, -1], [4, -2, 2, 0]]))
       ** (ArgumentError) tensor must have at least as many rows as columns, got shape: {3, 4}
   """
   @doc type: :linalg
   def qr(tensor, opts \\ []) do
     %T{type: type, shape: shape, names: names} = tensor = tensor!(tensor)
 
-    assert_keys!(opts, [:mode, :q_axes, :r_axes])
+    assert_keys!(opts, [:mode, :q_names, :r_names])
 
     opts = Keyword.merge([mode: :reduced], opts)
 
@@ -7152,8 +7152,8 @@ defmodule Nx do
 
     [n1, n2] = names
 
-    q_names = opts[:q_axes] || [n1, nil]
-    r_names = opts[:r_axes] || [nil, n2]
+    q_names = opts[:q_names] || [n1, nil]
+    r_names = opts[:r_names] || [nil, n2]
 
     impl!(tensor).qr(
       {%{tensor | type: output_type, shape: q_shape, names: q_names},

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -7057,86 +7057,84 @@ defmodule Nx do
     * `:reduced` - returns `q` and `r` with shapes `{M, K}` and `{K, N}`
     * `:complete` - returns `q` and `r` with shapes `{M, M}` and `{M, N}`
 
+  `:q_axes` - Defines the axes for the `q` tensor
+
+  `:r_axes` - Defines the axes for the `r` tensor
+
   ## Examples
 
   Note: The following examples round elements of the output tensors
   to minimize rounding errors on different host machines.
 
-      iex(1)> [q, r] = Nx.qr(Nx.tensor([[12, -51, 4], [6, 167, -68], [-4, 24, -41]])) |> Tuple.to_list() |> Enum.map(fn t -> Nx.map(t, &Float.round(&1, 4)) end)
-      [
+      iex> Nx.qr(Nx.tensor([[-3, 2, 1], [0, 1, 1], [0, 0, -1]]))
+      {
         Nx.tensor([
-          [-0.8571, 0.3943, -0.3314],
-          [-0.4286, -0.9029, 0.0343],
-          [0.2857, -0.1714, -0.9429]
+          [-1.0, 0.0, 0.0],
+          [0.0, -1.0, 0.0],
+          [0.0, 0.0, -1.0]
         ]),
         Nx.tensor([
-          [-14.0, -21.0, 14.0],
-          [-0.0, -175.0, 70.0],
-          [-0.0, -0.0, 35.0]
+          [3.0, -2.0, -1.0],
+          [0.0, -1.0, -1.0],
+          [0.0, 0.0, 1.0]
         ])
-      ]
-      iex(2)> Nx.dot(q, r) |> Nx.map(&Float.round(&1, 0))
-      Nx.tensor([
-        [12.0, -51.0, 4.0],
-        [6.0, 167.0, -68.0],
-        [-4.0, 24.0, -41.0]
-      ])
+      }
 
-      iex(1)> [q, r] = Nx.qr(Nx.tensor([[1, -1, 4], [1, 4, -2], [1, 4, 2], [1, -1, 0]]), mode: :reduced) |> Tuple.to_list() |> Enum.map(fn t -> Nx.map(t, &Float.round(&1, 4)) end)
-      [
+      iex> Nx.qr(Nx.tensor([[3, 2, 1], [0, 1, 1], [0, 0, 1]]), q_axes: [:row, :base_vector], r_axes: [:coef, :vars])
+      {
         Nx.tensor([
-          [-0.5774, 0.8165, 0.0],
-          [-0.5774, -0.4082, 0.7071],
-          [-0.5774, -0.4082, -0.7071],
+          [-1.0, 0.0, 0.0],
+          [0.0, -1.0, 0.0],
+          [0.0, 0.0, -1.0]
+        ], names: [:row, :base_vector]),
+        Nx.tensor([
+          [-3.0, -2.0, -1.0],
+          [0.0, -1.0, -1.0],
+          [0.0, 0.0, -1.0]
+        ], names: [:coef, :vars])
+      }
+
+      iex> Nx.qr(Nx.tensor([[3, 2, 1], [0, 1, 1], [0, 0, 1], [0, 0, 1]]), mode: :reduced)
+      {
+        Nx.tensor([
+          [-1.0, 0.0, 0.0],
+          [0.0, -1.0, 0.0],
+          [0.0, 0.0, -1.0],
           [0.0, 0.0, 0.0]
         ]),
         Nx.tensor([
-          [-1.7321, -4.0415, -2.3094],
-          [0.0, -4.0825, 3.266],
-          [0.0, 0.0, -2.8284]
+          [-3.0, -2.0, -1.0],
+          [0.0, -1.0, -1.0],
+          [0.0, 0.0, -1.0]
         ])
-      ]
-      iex(2)> Nx.dot(q, r) |> Nx.map(&Float.round(&1, 0))
-      Nx.tensor([
-        [1.0, -1.0, 4.0],
-        [1.0, 4.0, -2.0],
-        [1.0, 4.0, 2.0],
-        [0.0, -0.0, 0.0]
-      ])
+      }
 
-      iex(1)> [q, r] = Nx.qr(Nx.tensor([[1, -1, 4], [1, 4, -2], [1, 4, 2], [1, -1, 0]]), mode: :complete) |> Tuple.to_list() |> Enum.map(fn t -> Nx.map(t, &Float.round(&1, 4)) end)
-      [
+      iex> Nx.qr(Nx.tensor([[3, 2, 1], [0, 1, 1], [0, 0, 1], [0, 0, 0]]), mode: :complete)
+      {
         Nx.tensor([
-          [-0.5, 0.5, -0.5, -0.5],
-          [-0.5, -0.5, 0.5, -0.5],
-          [-0.5, -0.5, -0.5, 0.5],
-          [-0.5, 0.5, 0.5, 0.5]
+          [-1.0, 0.0, 0.0, 0.0],
+          [0.0, -1.0, 0.0, 0.0],
+          [0.0, 0.0, -1.0, 0.0],
+          [0.0, 0.0, 0.0, 1.0]
         ]),
         Nx.tensor([
-          [-2.0, -3.0, -2.0],
-          [0.0, -5.0, 2.0],
-          [-0.0, -0.0, -4.0],
+          [-3.0, -2.0, -1.0],
+          [0.0, -1.0, -1.0],
+          [0.0, 0.0, -1.0],
           [0.0, 0.0, 0.0]
         ])
-      ]
-      iex(2)> Nx.dot(q, r) |> Nx.map(&Float.round(&1, 0))
-      Nx.tensor([
-        [1.0, -1.0, 4.0],
-        [1.0, 4.0, -2.0],
-        [1.0, 4.0, 2.0],
-        [1.0, -1.0, 0.0]
-      ])
+      }
 
   ## Error cases
 
       iex> Nx.qr(Nx.tensor([[1, 1, 1, 1], [-1, 4, 4, -1], [4, -2, 2, 0]])) |> Tuple.to_list() |> Enum.map(fn t -> Nx.map(t, &Float.round(&1, 4)) end)
-      ** (ArgumentError) tensor must have at least as many rows than columns, got shape: {3, 4}
+      ** (ArgumentError) tensor must have at least as many rows as columns, got shape: {3, 4}
   """
   @doc type: :linalg
   def qr(tensor, opts \\ []) do
-    %T{type: type, shape: shape} = tensor = tensor!(tensor)
+    %T{type: type, shape: shape, names: names} = tensor = tensor!(tensor)
 
-    assert_keys!(opts, [:mode])
+    assert_keys!(opts, [:mode, :q_axes, :r_axes])
 
     opts = Keyword.merge([mode: :reduced], opts)
 
@@ -7152,9 +7150,14 @@ defmodule Nx do
 
     {q_shape, r_shape} = Nx.Shape.qr(shape, opts)
 
+    [n1, n2] = names
+
+    q_names = opts[:q_axes] || [n1, nil]
+    r_names = opts[:r_axes] || [nil, n2]
+
     impl!(tensor).qr(
-      {%{tensor | type: output_type, shape: q_shape},
-       %{tensor | type: output_type, shape: r_shape}},
+      {%{tensor | type: output_type, shape: q_shape, names: q_names},
+       %{tensor | type: output_type, shape: r_shape, names: r_names}},
       tensor,
       opts
     )

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -7141,7 +7141,7 @@ defmodule Nx do
     opts = Keyword.merge([mode: :reduced], opts)
 
     mode = opts[:mode]
-    valid_modes = [:reduced, :complete, :r, :raw]
+    valid_modes = [:reduced, :complete]
 
     unless mode in valid_modes do
       raise ArgumentError,

--- a/nx/lib/nx/backend.ex
+++ b/nx/lib/nx/backend.ex
@@ -75,7 +75,7 @@ defmodule Nx.Backend do
   @callback sort(out :: tensor, tensor, keyword) :: tensor
 
   @callback cholesky(out :: tensor, tensor) :: tensor
-
+  @callback qr(q :: tensor, r :: tensor, tensor) :: tensor
 
   binary_ops =
     [:add, :subtract, :multiply, :power, :remainder, :divide, :arctan2, :min, :max, :quotient] ++
@@ -96,5 +96,4 @@ defmodule Nx.Backend do
   for unary_op <- unary_ops do
     @callback unquote(unary_op)(out :: t, t) :: t
   end
-
 end

--- a/nx/lib/nx/backend.ex
+++ b/nx/lib/nx/backend.ex
@@ -75,7 +75,7 @@ defmodule Nx.Backend do
   @callback sort(out :: tensor, tensor, keyword) :: tensor
 
   @callback cholesky(out :: tensor, tensor) :: tensor
-  @callback qr(q :: tensor, r :: tensor, tensor) :: tensor
+  @callback qr(q :: tensor, r :: tensor, keyword) :: tensor
 
   binary_ops =
     [:add, :subtract, :multiply, :power, :remainder, :divide, :arctan2, :min, :max, :quotient] ++

--- a/nx/lib/nx/backend.ex
+++ b/nx/lib/nx/backend.ex
@@ -75,7 +75,7 @@ defmodule Nx.Backend do
   @callback sort(out :: tensor, tensor, keyword) :: tensor
 
   @callback cholesky(out :: tensor, tensor) :: tensor
-  @callback qr(q :: tensor, r :: tensor, keyword) :: tensor
+  @callback qr({q :: tensor, r :: tensor}, keyword) :: tensor
 
   binary_ops =
     [:add, :subtract, :multiply, :power, :remainder, :divide, :arctan2, :min, :max, :quotient] ++

--- a/nx/lib/nx/backend.ex
+++ b/nx/lib/nx/backend.ex
@@ -75,7 +75,7 @@ defmodule Nx.Backend do
   @callback sort(out :: tensor, tensor, keyword) :: tensor
 
   @callback cholesky(out :: tensor, tensor) :: tensor
-  @callback qr({q :: tensor, r :: tensor}, keyword) :: tensor
+  @callback qr({q :: tensor, r :: tensor}, tensor, keyword) :: tensor
 
   binary_ops =
     [:add, :subtract, :multiply, :power, :remainder, :divide, :arctan2, :min, :max, :quotient] ++

--- a/nx/lib/nx/binary_backend.ex
+++ b/nx/lib/nx/binary_backend.ex
@@ -1114,6 +1114,8 @@ defmodule Nx.BinaryBackend do
   end
 
   defp dot_binary(b1, shape1, b2, shape2, {_, s} = type) do
+    # matrix multiplication for when b1 and b2 are matrices
+    # represented in binary form
     fun = fn lhs, rhs, acc ->
       res = binary_to_number(lhs, type) * binary_to_number(rhs, type) + acc
       {res, res}

--- a/nx/lib/nx/binary_backend.ex
+++ b/nx/lib/nx/binary_backend.ex
@@ -1137,14 +1137,14 @@ defmodule Nx.BinaryBackend do
   end
 
   defp identity(%{type: {_, num_bits} = type} = tensor, shape: {m, n} = shape) do
+    one = number_to_binary(1, type)
+    zero = number_to_binary(0, type)
+
     identity_binary =
-      for col <- 0..(n - 1), row <- 0..(m - 1), reduce: "" do
-        data ->
-          if col == row do
-            data <> <<1::size(num_bits)>>
-          else
-            data <> <<0::size(num_bits)>>
-          end
+      for row <- 0..(m - 1), col <- 0..(n - 1), reduce: <<>> do
+        acc ->
+          value = if col == row, do: one, else: zero
+          acc <> value
       end
 
     from_binary(%{tensor | shape: {m, n}}, identity_binary)

--- a/nx/lib/nx/binary_backend.ex
+++ b/nx/lib/nx/binary_backend.ex
@@ -1137,15 +1137,14 @@ defmodule Nx.BinaryBackend do
   end
 
   defp identity(%{type: {_, num_bits} = type} = tensor, shape: {m, n} = shape) do
-    data_size = m * num_bits * n
-    # allocate empty data
-    data = <<0::size(data_size)>>
-
     identity_binary =
-      for col <- 0..(n - 1), row <- 0..(m - 1), reduce: data do
+      for col <- 0..(n - 1), row <- 0..(m - 1), reduce: "" do
         data ->
-          value = if col == row, do: 1, else: 0
-          set_value_at_index(data, type, shape, [row, col], value)
+          if col == row do
+            data <> <<1::size(num_bits)>>
+          else
+            data <> <<0::size(num_bits)>>
+          end
       end
 
     from_binary(%{tensor | shape: {m, n}}, identity_binary)

--- a/nx/lib/nx/defn/expr.ex
+++ b/nx/lib/nx/defn/expr.ex
@@ -676,6 +676,12 @@ defmodule Nx.Defn.Expr do
   end
 
   @impl true
+  def qr(out, tensor, opts) do
+    tensor = to_expr(tensor)
+    expr(out, tensor.data.context, :qr, [tensor, opts])
+  end
+
+  @impl true
   def sort(out, tensor, opts) do
     comparator = opts[:comparator]
 

--- a/nx/lib/nx/shape.ex
+++ b/nx/lib/nx/shape.ex
@@ -891,6 +891,15 @@ defmodule Nx.Shape do
         "tensor must have rank 2, got rank #{tuple_size(shape)} with shape #{inspect(shape)}"
       )
 
+  def qr({m, n} = shape), do: {{m, m}, {m, n}}
+
+  def qr(shape, _names),
+    do:
+      raise(
+        ArgumentError,
+        "tensor must have rank 2, got rank #{tuple_size(shape)} with shape #{inspect(shape)}"
+      )
+
   defp validate_concat_names!(names) do
     :ok =
       names

--- a/nx/lib/nx/shape.ex
+++ b/nx/lib/nx/shape.ex
@@ -891,9 +891,26 @@ defmodule Nx.Shape do
         "tensor must have rank 2, got rank #{tuple_size(shape)} with shape #{inspect(shape)}"
       )
 
-  def qr({m, n} = shape), do: {{m, m}, {m, n}}
+  def qr({m, n} = shape, opts) when m >= n do
+    mode = opts[:mode]
 
-  def qr(shape, _names),
+    case mode do
+      :reduced ->
+        {{m, n}, {n, n}}
+
+      _ ->
+        {{m, m}, {m, n}}
+    end
+  end
+
+  def qr({m, n}, _opts),
+    do:
+      raise(
+        ArgumentError,
+        "tensor must have at least as many rows than columns, got shape: #{inspect({m, n})}"
+      )
+
+  def qr(shape, _opts),
     do:
       raise(
         ArgumentError,

--- a/nx/lib/nx/shape.ex
+++ b/nx/lib/nx/shape.ex
@@ -891,7 +891,7 @@ defmodule Nx.Shape do
         "tensor must have rank 2, got rank #{tuple_size(shape)} with shape #{inspect(shape)}"
       )
 
-  def qr({m, n} = shape, opts) when m >= n do
+  def qr({m, n}, opts) when m >= n do
     mode = opts[:mode]
 
     case mode do
@@ -907,7 +907,7 @@ defmodule Nx.Shape do
     do:
       raise(
         ArgumentError,
-        "tensor must have at least as many rows than columns, got shape: #{inspect({m, n})}"
+        "tensor must have at least as many rows as columns, got shape: #{inspect({m, n})}"
       )
 
   def qr(shape, _opts),

--- a/nx/test/nx_test.exs
+++ b/nx/test/nx_test.exs
@@ -648,4 +648,30 @@ defmodule NxTest do
       assert Nx.broadcast(t, {2, 2}, names: [:x, :y]) == Nx.tensor([[1, 2], [3, 4]], names: [:x, :y])
     end
   end
+
+  describe "qr" do
+    test "correctly factors a square matrix" do
+      t = Nx.tensor([[2, -2, 18], [2, 1, 0], [1, 2, 0]])
+      assert {q, %{type: output_type} = r} = Nx.qr(t)
+      assert t |> Nx.round() |> Nx.as_type(output_type) == q |> Nx.dot(r) |> Nx.round()
+
+      assert round(q, 1) == Nx.tensor([
+        [-2/3, 2/3, -1/3],
+        [-2/3, -1/3, 2/3],
+        [-1/3, -2/3, -2/3]
+      ]) |> round(1)
+
+      assert round(r, 1) == Nx.tensor([
+        [-3.0, 0.0, -12.0],
+        [0.0, -3.0, 12.0],
+        [0.0, 0.0, -6.0]
+      ]) |> round(1)
+    end
+
+    defp round(tensor, places) do
+      Nx.map(tensor, fn x ->
+        Float.round(x, places)
+      end)
+    end
+  end
 end

--- a/nx/test/nx_test.exs
+++ b/nx/test/nx_test.exs
@@ -668,6 +668,31 @@ defmodule NxTest do
       ]) |> round(1)
     end
 
+    test "factors rectangular matrix" do
+      t = Nx.tensor([[1.0, -1.0, 4.0], [1.0, 4.0, -2.0], [1.0, 4.0, 2.0], [1.0, -1.0, 0.0]])
+      {q, r} = Nx.qr(t, mode: :reduced)
+
+      assert round(q, 1) == Nx.tensor([
+          [-0.5774, 0.8165, 0.0],
+          [-0.5774, -0.4082, 0.7071],
+          [-0.5774, -0.4082, -0.7071],
+          [0.0, 0.0, 0.0]
+        ]) |> round(1)
+
+      assert round(r, 1) == Nx.tensor([
+          [-1.7321, -4.0415, -2.3094],
+          [0.0, -4.0825, 3.266],
+          [0.0, 0.0, -2.8284]
+        ]) |> round(1)
+
+        assert Nx.tensor([
+          [1.0, -1.0, 4.0],
+          [1.0, 4.0, -2.0],
+          [1.0, 4.0, 2.0],
+          [0.0, 0.0, 0.0]
+        ]) == q |> Nx.dot(r) |> round(1)
+    end
+
     defp round(tensor, places) do
       Nx.map(tensor, fn x ->
         Float.round(x, places)


### PR DESCRIPTION
This PR adds an implementation for the Householder QR decomposition method. The function signature was designed for Numpy compatibility.

related to #157 