### PR TITLE
Fix 404 link to EXLA in README.md

### DIFF
--- a/nx/README.md
+++ b/nx/README.md
@@ -96,7 +96,7 @@ defmodule MyModule do
 end
 ```
 
-`defn` supports multiple compiler backends, which can compile said functions to run on the CPU or in the GPU. For example, [using the `EXLA` compiler](https://github.com/elixir-nx/nx/tree/exla), which provides bindings to Google's XLA:
+`defn` supports multiple compiler backends, which can compile said functions to run on the CPU or in the GPU. For example, [using the `EXLA` compiler](https://github.com/elixir-nx/nx/tree/main/exla), which provides bindings to Google's XLA:
 
 ```elixir
 @defn_compiler {EXLA, client: :host}


### PR DESCRIPTION
Just fixing 404 link in README.md.