### PR TITLE
Add defndelegate for delegating defn functions

### DIFF
--- a/nx/.formatter.exs
+++ b/nx/.formatter.exs
@@ -2,7 +2,8 @@
 
 locals_without_parens = [
   defn: 2,
-  defnp: 2
+  defnp: 2,
+  defndelegate: 2
 ]
 
 [

--- a/nx/lib/nx/defn.ex
+++ b/nx/lib/nx/defn.ex
@@ -270,7 +270,7 @@ defmodule Nx.Defn do
   @doc """
   Defines a public numerical function that delegates to another module.
 
-  Function signatures must be valid defn function signatures - see defn.
+  Function signature must target defn function signature.
 
   ## Examples
 
@@ -299,11 +299,15 @@ defmodule Nx.Defn do
       {:__aliases__, _, _} ->
         Macro.expand(module, %{__CALLER__ | function: {:__info__, 1}})
       _ ->
-        raise ArgumentError, "expected :to to be a module, got #{Macro.to_string(module)}"
+        raise ArgumentError, "defndelegate expected :to to be a module, got #{Macro.to_string(module)}"
     end
-    func = Keyword.get(opts, :as) || name
-    arity = length(args)
 
+    func = Keyword.get(opts, :as, name)
+    if not is_atom(func) do
+      raise ArgumentError, "defndelegate expected :as to be an atom, got #{Macro.to_string(func)}"
+    end
+    
+    arity = length(args)
     defn_call = {:., [], [{:__aliases__, [alias: false], [:Nx, :Defn]}, :defn]}
 
     {:__block__, [], [

--- a/nx/lib/nx/defn.ex
+++ b/nx/lib/nx/defn.ex
@@ -268,9 +268,13 @@ defmodule Nx.Defn do
   end
 
   @doc """
-  Defines a public numerical function that delegates to another module.
+  Defines a public numerical function that delegates to another
+  module.
 
-  Function signature must target defn function signature.
+  Delegated function signature patterns must match target defn
+  function signature patterns. For example, if the target function
+  has a 2-tuple as its first arg then the delegated function
+  signature must also have a 2-tuple as its first arg.
 
   ## Examples
 

--- a/nx/test/nx/defn_test.exs
+++ b/nx/test/nx/defn_test.exs
@@ -1162,5 +1162,31 @@ defmodule Nx.DefnTest do
         Impl.target_not_defn(1)
       end
     end
+
+    test "raises for non-module :to option" do
+      assert_raise(ArgumentError, ~s|defndelegate expected :to to be a module, got "thing"|, fn ->
+        code = """
+        defmodule BadDefndelegate1 do
+          import Nx.Defn
+
+          defndelegate wont_compile, to: "thing"
+        end
+        """
+        Code.compile_string(code)
+      end)
+    end
+
+    test "raises for non-atom :as option" do
+      assert_raise(ArgumentError, ~s|defndelegate expected :as to be an atom, got "thing"|, fn ->
+        code = """
+        defmodule BadDefndelegate1 do
+          import Nx.Defn
+
+          defndelegate wont_compile, to: Thing, as: "thing"
+        end
+        """
+        Code.compile_string(code)
+      end)
+    end
   end
 end

--- a/nx/test/nx/defn_test.exs
+++ b/nx/test/nx/defn_test.exs
@@ -1236,5 +1236,32 @@ defmodule Nx.DefnTest do
       out = apply(VarModuleDefndelegate, :maximum_sum, [a, b])
       assert Nx.to_scalar(out) == 5
     end
+
+    import Nx.Defn
+
+    test "works with default arguments" do
+      code = """
+      defmodule DefaultArgImpl do
+        import Nx.Defn
+
+        defn sum(a, b), do: Nx.sum(Nx.add(a, b))
+      end
+
+      defmodule DefaultArgModule do
+        import Nx.Defn
+
+        defndelegate sum(a, b \\\\ 1), to: DefaultArgImpl, as: :sum
+      end
+      """
+
+      assert [{DefaultArgImpl, _}, {DefaultArgModule, _}] = Code.compile_string(code)
+      t = Nx.tensor([1, 1])
+
+      assert apply(DefaultArgImpl, :sum, [t, 1]) == Nx.tensor(4)
+      assert apply(DefaultArgModule, :sum, [t]) == Nx.tensor(4)
+
+      assert apply(DefaultArgImpl, :sum, [t, 2]) == Nx.tensor(6)
+      assert apply(DefaultArgModule, :sum, [t, 2]) == Nx.tensor(6)
+    end
   end
 end


### PR DESCRIPTION
Earlier today in a conversation with Sean I suggested he use `defdelegate` to delegate his numerical functions, and he responded saying that one could not use `defdelegate` with numerical functions. So I made `defndelegate` so Sean can delegate his numerical functions.

cc @seanmor5 

@josevalim I didn't want to end up with raw ast, but despite my efforts I could not get a normal `quote do` block to behave.

Suggestions welcome!