### PR TITLE
Add gradient for inverse hyperbolic functions

### DIFF
--- a/nx/lib/nx/defn/grad.ex
+++ b/nx/lib/nx/defn/grad.ex
@@ -413,6 +413,21 @@ defmodule Nx.Defn.Grad do
     to_grad(x, g, cache)
   end
 
+  defp grad(:arcsinh, [x], _ans, g, cache) do
+    g = Nx.multiply(g, Nx.rsqrt(Nx.add(Nx.power(x, 2.0), 1.0)))
+    to_grad(x, g, cache)
+  end
+
+  defp grad(:arccosh, [x], _ans, g, cache) do
+    g = Nx.multiply(g, Nx.rsqrt(Nx.subtract(Nx.power(x, 2.0), 1.0)))
+    to_grad(x, g, cache)
+  end
+
+  defp grad(:arctanh, [x], _ans, g, cache) do
+    g = Nx.multiply(g, Nx.divide(1.0, Nx.subtract(1.0, Nx.power(x, 2.0))))
+    to_grad(x, g, cache)
+  end
+
   defp grad(:cos, [x], _ans, g, cache) do
     g = Nx.multiply(g, Nx.negate(Nx.sin(x)))
     to_grad(x, g, cache)

--- a/nx/test/nx/defn/grad_test.exs
+++ b/nx/test/nx/defn/grad_test.exs
@@ -509,6 +509,29 @@ defmodule Nx.Defn.GradTest do
     end
   end
 
+  describe "inverse hyperbolic functions" do
+    defn grad_arcsinh(t), do: grad(t, Nx.arcsinh(t))
+    defn grad_arccosh(t), do: grad(t, Nx.arccosh(t))
+    defn grad_arctanh(t), do: grad(t, Nx.arctanh(t))
+
+    test "computes gradient of inverse hyperbolic functions" do
+      for _ <- @iters do
+        t = Nx.random_uniform({}, -100.0, 100.0, type: {:f, 64})
+        check_grads!(&Nx.arcsinh/1, &grad_arcsinh/1, t, eps: 0.1)
+      end
+
+      for _ <- @iters do
+        t = Nx.random_uniform({}, 1.01, 100.0, type: {:f, 64})
+        check_grads!(&Nx.arccosh/1, &grad_arccosh/1, t, eps: 0.1)
+      end
+
+      for _ <- @iters do
+        t = Nx.random_uniform({}, -0.999, 0.999, type: {:f, 64})
+        check_grads!(&Nx.arctanh/1, &grad_arctanh/1, t, eps: 0.1)
+      end
+    end
+  end
+
   describe "erf_inv" do
     defn grad_erf_inv(t), do: grad(t, Nx.erf_inv(t))
 


### PR DESCRIPTION
This commit adds gradient for the following inverse hyperbolic functions:

- Arcsinh
- Arccosh
- Arctanh

PS: Shouldn't this functions drop the c? Wikipedia has some information on this. [Notation](https://en.wikipedia.org/wiki/Inverse_hyperbolic_functions#Notation)