### PR TITLE
Add note about ElixirLS per request from Sean. Add note about gitref vs local path.

### DIFF
--- a/exla/README.md
+++ b/exla/README.md
@@ -46,6 +46,11 @@ The first compilation will take a long time, as it needs to compile parts of Ten
       * asdf global bazel 3.1.0
   * ElixirLS on VSCode
     * Make sure that your Python installation is available globally, as ElixirLS won't know how to activate Python
+  * When importing `:exla` into a project, make sure you use a git ref, and *not* `path: "../exla"`. Using a local reference will trigger a full build of `:exla` every time you compile your project.
+
+#### Compiling in ElixirLS
+
+ElixirLS will need to run its own compile of `:exla`, so if you want to use ElixirLS, be prepared to possibly wait another 2 hours for this compile to complete. As soon as you open VSCode with ElixirLS enabled and `:exla` as a dependency, let the ElixirLS compile complete (watch the output tab -> ElixirlS) *before* clicking around to any other files in your project, or else ElixirLS will rapid fire queue compiles that will all need to complete before you will be able to use your project. If no output appears in the ElixirLS output, you may need to trigger the compile by opening a file and saving it. Proceed slowly, one step at a time, and as soon as you see a build kick off in the ElixirLS output panel, walk away from your computer until it is done.
 
 ### GPU Support
 


### PR DESCRIPTION
Per the below slack request from @seanmor5 I have added a section on compiling in ElixirLS. I also added a note about gitref vs local path, as this was a mistake I made early on that cost me many hours in unnecessary recompilation.

![Screen Shot 2021-02-28 at 5 55 19 PM](https://user-images.githubusercontent.com/8557871/109436578-2b443600-79ee-11eb-9528-0dbd5f6a0637.png)
