### PR TITLE
Update README with direnv+asdf python workaround

### DIFF
--- a/exla/README.md
+++ b/exla/README.md
@@ -57,7 +57,7 @@ ElixirLS will need to run its own compile of `:exla`, so if you want to use Elix
 
 #### Python and asdf
 
-`Bazel` cannot find `python` installed via the `asdf` version manager by default.`asdf` uses a function to lookup the specified version of a given binary, this approach prevents `Bazel` from being able to correctly build `EXLA`. The error is `unknown command: python. Perhaps you have to reshim?`. There are two known workarounds:
+`Bazel` cannot find `python` installed via the `asdf` version manager by default. `asdf` uses a function to lookup the specified version of a given binary, this approach prevents `Bazel` from being able to correctly build `EXLA`. The error is `unknown command: python. Perhaps you have to reshim?`. There are two known workarounds:
 
 1. Use a separate installer or explicitly change your `$PATH` to point to a Python installation (note the build process looks for `python`, not `python3`). For example, on Homebrew on macOS, you would do:
 

--- a/exla/README.md
+++ b/exla/README.md
@@ -66,41 +66,11 @@ export PATH=/usr/local/opt/python@3.9/libexec/bin:/usr/local/bin:$PATH
 mix deps.compile
 ```
 
-Note the build process looks for `python`, not `python3`. You may need to remove `~/.cache/exla` to clean up from previous build attempts.
-
+Note the build process looks for `python`, not `python3`.
 
 2. Use the [`asdf direnv`](https://github.com/asdf-community/asdf-direnv) plugin to install [`direnv 2.20.0`](https://direnv.net). `direnv` along with the `asdf-direnv` plugin will explicitly set the paths for any binary specified in your project's `.tool-version` files.
 
-```
-asdf plugin-add direnv
-asdf install direnv 2.20.0
-asdf global  direnv 2.20.0
-```
-
-Add the `asdf direnv hook` to your shell profile:
-
-**BASH** Add the following line to the bottom of your `~/.bashrc`
-```
-eval "$(direnv hook bash)"
-direnv() { asdf exec direnv "$@"; }
-```
-
-**ZSH** Add the following line to the bottom of your `~/.zshrc`
-```
-eval "$(direnv hook zsh)"
-direnv() { asdf exec direnv "$@"; }
-```
-
-Next, add the `asdf-direnv` plugin to the `direnvrc` configuration file `~/.config/direnv/direnvrc`:
-
-```
-source "$(asdf direnv hook asdf)"
-```
-Then, in the root of your `Nx` project add an `.envrc` file with the following: `use asdf`.
-
-`direnv` will now prompt you to allow the changes to the `.envrc` file, you can explicitly allow it with: `direnv allow`. You should now see `direnv` output a list of which `asdf` plugins it is going to set paths for, and any environment variables you choose to set using it. If your `.tool-versions` are all correctly set, `exla` should now be able to successfully compile.
-
-Note after setting up `direnv` it is high recommended you clear the build cache by removing ` ~/.cache/exla`.
+After doing any of the steps above, it may be necessary to clear the build cache by removing ` ~/.cache/exla`.
 
 ### GPU Support
 

--- a/exla/README.md
+++ b/exla/README.md
@@ -59,14 +59,12 @@ ElixirLS will need to run its own compile of `:exla`, so if you want to use Elix
 
 `Bazel` cannot find `python` installed via the `asdf` version manager by default.`asdf` uses a function to lookup the specified version of a given binary, this approach prevents `Bazel` from being able to correctly build `EXLA`. The error is `unknown command: python. Perhaps you have to reshim?`. There are two known workarounds:
 
-1. Use a separate installer or explicitly change your `$PATH` to point to a Python installation. For example, on Homebrew on macOS, you would do:
+1. Use a separate installer or explicitly change your `$PATH` to point to a Python installation (note the build process looks for `python`, not `python3`). For example, on Homebrew on macOS, you would do:
 
-```
-export PATH=/usr/local/opt/python@3.9/libexec/bin:/usr/local/bin:$PATH
-mix deps.compile
-```
-
-Note the build process looks for `python`, not `python3`.
+    ```
+    export PATH=/usr/local/opt/python@3.9/libexec/bin:/usr/local/bin:$PATH
+    mix deps.compile
+    ```
 
 2. Use the [`asdf direnv`](https://github.com/asdf-community/asdf-direnv) plugin to install [`direnv 2.20.0`](https://direnv.net). `direnv` along with the `asdf-direnv` plugin will explicitly set the paths for any binary specified in your project's `.tool-version` files.
 


### PR DESCRIPTION
Ahoy!

I've been using `asdf` with `direnv` via the `asdf-direnv` plugin without issue. I saw the `README` update the other day, and figured I could definitely add what worked for me in regards to `asdf`. FWIW, `direnv` makes `asdf` really wonderful where it was once pretty darn rough to live with.

While I didn't explicitly add my versions to the README, I was able to successfully build `EXLA` with `asdf` on Linux and CUDA working quite well:

```
# .tool-versions (ignore my erlang version)
erlang ref:master
python 3.8.8 2.7.18
bazel 3.1.0
elixir master

# .envrc
use asdf

EXLA_FLAGS=--config=cuda
```

I'm more than happy to adjust the language, formatting, or otherwise alter the details I've added (including just deleting my changes, haha 😺)-- please, just let me know. Thanks everyone's hard work on this! It's soooo freakin' cool.

P.S. I can also add something about setting the correct versions of `CUDA` and `cuDNN` if that's helpful for anyone else, I had to add the following to my `.envrc` explicitly pointing to the right versions:

```
export TF_CUDA_VERSION="11.1"
export CUDA_TOOLKIT_PATH="/usr/lib/cuda-11.1"
export CUDNN_INSTALL_PATH="/usr/lib/cuda-11.1"
export TF_CUDNN_VERSION="8"
```