### PR TITLE
Add and use allclose? when testing

### DIFF
--- a/exla/test/exla/defn_expr_test.exs
+++ b/exla/test/exla/defn_expr_test.exs
@@ -1331,7 +1331,7 @@ defmodule EXLA.DefnExprTest do
           window_dilations: [1, 2, 2]
         )
 
-      compare_tensors!(lhs, rhs, round: 3)
+      compare_tensors!(lhs, rhs)
     end
   end
 
@@ -2452,7 +2452,7 @@ defmodule EXLA.DefnExprTest do
       assert s.shape == {3}
       assert vt.shape == {3, 3}
       s_full = Nx.multiply(s, Nx.tensor([[1, 0, 0], [0, 1, 0], [0, 0, 1]]))
-      assert compare_tensors!(u |> Nx.dot(s_full) |> Nx.dot(Nx.transpose(vt)), output)
+      assert compare_tensors!(u |> Nx.dot(s_full) |> Nx.dot(Nx.transpose(vt)), output, atol: 1.0e-5, rtol: 1.0e-2)
     end
   end
 
@@ -2503,7 +2503,7 @@ defmodule EXLA.DefnExprTest do
     test "works on 2x2 matrix" do
       lhs = cholesky(Nx.tensor([[20.0, 17.6], [17.6, 16.0]]))
       rhs = Nx.tensor([[4.47213595499958, 0.0], [3.93547964039963, 0.7155417527999305]])
-      compare_tensors!(lhs, rhs, round: 1)
+      compare_tensors!(lhs, rhs)
     end
 
     test "works on a 4x4 matrix" do
@@ -2525,7 +2525,7 @@ defmodule EXLA.DefnExprTest do
           [3.2659863237109046, -1.4142135623730956, 1.5877132402714704, 3.1324910215354165]
         ])
 
-      compare_tensors!(lhs, rhs, round: 2)
+      compare_tensors!(lhs, rhs)
     end
 
     test "works on a 50x50 matrix" do
@@ -2533,7 +2533,7 @@ defmodule EXLA.DefnExprTest do
       tensor = Nx.dot(tensor, Nx.transpose(tensor))
       lhs = cholesky(tensor)
       rhs = Nx.cholesky(tensor)
-      compare_tensors!(lhs, rhs, round: 2)
+      compare_tensors!(lhs, rhs, atol: 1.0e-5, rtol: 1.0e-2)
     end
   end
 
@@ -2574,9 +2574,9 @@ defmodule EXLA.DefnExprTest do
     end
   end
 
-  defp compare_tensors!(left, right) do
-    atol = 1.0e-7
-    rtol = 1.0e-4
+  defp compare_tensors!(left, right, opts \\ []) do
+    atol = opts[:atol] || 1.0e-7
+    rtol = opts[:rtol] || 1.0e-4
     try do
       assert Nx.allclose?(left, right, atol: atol, rtol: rtol) == Nx.tensor(1, type: {:u, 8})
     rescue

--- a/exla/test/exla/defn_expr_test.exs
+++ b/exla/test/exla/defn_expr_test.exs
@@ -2574,31 +2574,13 @@ defmodule EXLA.DefnExprTest do
     end
   end
 
-  # We need to round the floats because of imprecision between platforms
-  defp compare_tensors!(left, right, opts \\ [])
-
-  defp compare_tensors!(
-         %{type: {:f, size}, data: %{state: left_data} = lhs} = left,
-         %{data: %{state: right_data} = rhs} = right,
-         opts
-       ) do
-    round = opts[:round] || 5
-
-    left_data =
-      for <<x::float-size(size)-native <- left_data>>,
-        into: <<>>,
-        do: <<Float.round(x, round)::float-size(size)-native>>
-
-    right_data =
-      for <<x::float-size(size)-native <- right_data>>,
-        into: <<>>,
-        do: <<Float.round(x, round)::float-size(size)-native>>
-
-    assert %{left | data: %{lhs | state: left_data}} ==
-             %{right | data: %{rhs | state: right_data}}
-  end
-
-  defp compare_tensors!(left, right, _opts) do
-    assert left == right
+  defp compare_tensors!(left, right) do
+    atol = 1.0e-7
+    rtol = 1.0e-4
+    try do
+      assert Nx.allclose?(left, right, atol: atol, rtol: rtol) == Nx.tensor(1, type: {:u, 8})
+    rescue
+      _ -> assert left == right # So we can see the diff
+    end
   end
 end

--- a/exla/test/exla/defn_expr_test.exs
+++ b/exla/test/exla/defn_expr_test.exs
@@ -2578,7 +2578,7 @@ defmodule EXLA.DefnExprTest do
     atol = opts[:atol] || 1.0e-7
     rtol = opts[:rtol] || 1.0e-4
     try do
-      assert Nx.allclose?(left, right, atol: atol, rtol: rtol) == Nx.tensor(1, type: {:u, 8})
+      assert Nx.all_close?(left, right, atol: atol, rtol: rtol) == Nx.tensor(1, type: {:u, 8})
     rescue
       _ -> assert left == right # So we can see the diff
     end

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -4137,6 +4137,40 @@ defmodule Nx do
   end
 
   @doc """
+  Returns a scalar tensor of value 1 if element-wise values
+  of a are within tolerance of b, value 0 otherwise.
+
+  You may set the absolute tolerane, `:atol` and relative tolerance
+  `:rtol`. Given tolerances, this method returns true if:
+
+      absolute(a - b) <= (atol + rtol * absolute(b))
+
+  returns true for all elements of a and b.
+
+  ## Examples
+
+      iex> Nx.allclose?(Nx.tensor([1.0e10, 1.0e-7]), Nx.tensor([1.00001e10, 1.0e-8]))
+      #Nx.Tensor<
+        u8
+        0
+      >
+
+      iex> Nx.allclose?(Nx.tensor([1.0e-8, 1.0e-8]), Nx.tensor([1.0e-8, 1.0e-9]))
+      #Nx.Tensor<
+        u8
+        1
+      >
+
+  """
+  @doc type: :aggregation
+  def allclose?(a, b, opts \\ []) do
+    assert_keys!(opts, [:rtol, :atol])
+    rtol = opts[:rtol] || 1.0e-5
+    atol = opts[:atol] || 1.0e-8
+    all?(less_equal(Nx.abs(subtract(a, b)), add(atol, multiply(rtol, Nx.abs(b)))))
+  end
+
+  @doc """
   Returns the sum for the tensor.
 
   If the `:axes` option is given, it aggregates over

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -4149,13 +4149,13 @@ defmodule Nx do
 
   ## Examples
 
-      iex> Nx.allclose?(Nx.tensor([1.0e10, 1.0e-7]), Nx.tensor([1.00001e10, 1.0e-8]))
+      iex> Nx.all_close?(Nx.tensor([1.0e10, 1.0e-7]), Nx.tensor([1.00001e10, 1.0e-8]))
       #Nx.Tensor<
         u8
         0
       >
 
-      iex> Nx.allclose?(Nx.tensor([1.0e-8, 1.0e-8]), Nx.tensor([1.0e-8, 1.0e-9]))
+      iex> Nx.all_close?(Nx.tensor([1.0e-8, 1.0e-8]), Nx.tensor([1.0e-8, 1.0e-9]))
       #Nx.Tensor<
         u8
         1
@@ -4163,7 +4163,7 @@ defmodule Nx do
 
   """
   @doc type: :aggregation
-  def allclose?(a, b, opts \\ []) do
+  def all_close?(a, b, opts \\ []) do
     assert_keys!(opts, [:rtol, :atol])
     rtol = opts[:rtol] || 1.0e-5
     atol = opts[:atol] || 1.0e-8

--- a/nx/test/nx/defn/grad_test.exs
+++ b/nx/test/nx/defn/grad_test.exs
@@ -1348,10 +1348,10 @@ defmodule Nx.Defn.GradTest do
     test "computes gradient of inverse trig functions" do
       for _ <- @iters do
         t = Nx.random_uniform({}, -0.999, 0.999, type: {:f, 32})
-        check_grads!(&Nx.asin/1, &grad_asin/1, t, eps: 0.1)
-        check_grads!(&Nx.acos/1, &grad_acos/1, t, eps: 0.1)
-        check_grads!(&Nx.atan/1, &grad_atan/1, t, eps: 0.1)
-        check_grads!(&Nx.atan/1, &grad_atan/1, Nx.multiply(1000.0, t), eps: 0.1)
+        check_grads!(&Nx.asin/1, &grad_asin/1, t, atol: 1.0e-5, rtol: 1.0e-2)
+        check_grads!(&Nx.acos/1, &grad_acos/1, t, atol: 0.1, rtol: 1.0e-2)
+        check_grads!(&Nx.atan/1, &grad_atan/1, t, atol: 0.1, rtol: 1.0e-2)
+        check_grads!(&Nx.atan/1, &grad_atan/1, Nx.multiply(1000.0, t), atol: 1.0e-2)
       end
     end
   end
@@ -1377,17 +1377,17 @@ defmodule Nx.Defn.GradTest do
     test "computes gradient of inverse hyperbolic functions" do
       for _ <- @iters do
         t = Nx.random_uniform({}, -100.0, 100.0, type: {:f, 64})
-        check_grads!(&Nx.asinh/1, &grad_asinh/1, t, eps: 0.1)
+        check_grads!(&Nx.asinh/1, &grad_asinh/1, t, atol: 1.0e-5, rtol: 1.0e-2)
       end
 
       for _ <- @iters do
         t = Nx.random_uniform({}, 1.01, 100.0, type: {:f, 64})
-        check_grads!(&Nx.acosh/1, &grad_acosh/1, t, eps: 0.1)
+        check_grads!(&Nx.acosh/1, &grad_acosh/1, t, atol: 1.0e-5, rtol: 1.0e-2)
       end
 
       for _ <- @iters do
         t = Nx.random_uniform({}, -0.999, 0.999, type: {:f, 64})
-        check_grads!(&Nx.atanh/1, &grad_atanh/1, t, eps: 0.1)
+        check_grads!(&Nx.atanh/1, &grad_atanh/1, t, atol: 1.0e-5, rtol: 1.0e-2)
       end
     end
   end
@@ -1398,7 +1398,7 @@ defmodule Nx.Defn.GradTest do
     test "computes the gradient" do
       for _ <- @iters do
         t = Nx.random_uniform({}, -100.0, 100.0, type: {:f, 64})
-        check_grads!(&Nx.erf/1, &grad_erf/1, t, eps: 1.0e-4)
+        check_grads!(&Nx.erf/1, &grad_erf/1, t, atol: 1.0e-5, rtol: 1.0e-2)
       end
     end
   end
@@ -1409,7 +1409,7 @@ defmodule Nx.Defn.GradTest do
     test "computes the gradient" do
       for _ <- @iters do
         t = Nx.random_uniform({}, -100.0, 100.0, type: {:f, 64})
-        check_grads!(&Nx.erfc/1, &grad_erfc/1, t, eps: 1.0e-4)
+        check_grads!(&Nx.erfc/1, &grad_erfc/1, t, atol: 1.0e-4)
       end
     end
   end
@@ -1420,21 +1420,21 @@ defmodule Nx.Defn.GradTest do
     test "computes gradient close to 0.0" do
       for _ <- @iters do
         t = Nx.random_uniform({}, 0.0, 0.9, type: {:f, 64})
-        check_grads!(&Nx.erf_inv/1, &grad_erf_inv/1, t, eps: 1.0e-4)
+        check_grads!(&Nx.erf_inv/1, &grad_erf_inv/1, t, atol: 1.0e-5, rtol: 1.0e-2)
       end
     end
 
     test "computes gradient between 0.9 and 0.95" do
       for _ <- @iters do
         t = Nx.random_uniform({}, 0.9, 0.95, type: {:f, 64})
-        check_grads!(&Nx.erf_inv/1, &grad_erf_inv/1, t, eps: 1.0e-3)
+        check_grads!(&Nx.erf_inv/1, &grad_erf_inv/1, t, atol: 1.0e-5, rtol: 1.0e-2)
       end
     end
 
     test "computes gradient between 0.95 and 0.98" do
       for _ <- @iters do
         t = Nx.random_uniform({}, 0.95, 0.98, type: {:f, 64})
-        check_grads!(&Nx.erf_inv/1, &grad_erf_inv/1, t, eps: 0.00004)
+        check_grads!(&Nx.erf_inv/1, &grad_erf_inv/1, t, atol: 1.0e-5, rtol: 1.0e-2)
       end
     end
 
@@ -2085,23 +2085,13 @@ defmodule Nx.Defn.GradTest do
     end
   end
 
-  # We need to round the floats because of imprecision between platforms
-  defp compare_tensors!(left, right, opts \\ [])
-
-  defp compare_tensors!(
-         %{type: {:f, size}, data: %{state: left_data} = lhs} = left,
-         %{data: %{state: right_data} = rhs} = right,
-         opts
-       ) do
-    round = opts[:round] || 5
-    left_data = for <<x::float-size(size)-native <- left_data>>, do: Float.round(x, round)
-    right_data = for <<x::float-size(size)-native <- right_data>>, do: Float.round(x, round)
-
-    assert %{left | data: %{lhs | state: left_data}} ==
-            %{right | data: %{rhs | state: right_data}}
-  end
-
-  defp compare_tensors!(left, right, _) do
-    assert left == right
+  defp compare_tensors!(left, right) do
+    atol = 1.0e-7
+    rtol = 1.0e-4
+    try do
+      assert Nx.allclose?(left, right, atol: atol, rtol: rtol) == Nx.tensor(1, type: {:u, 8})
+    rescue
+      _ -> assert left == right # So we can see the diff
+    end
   end
 end

--- a/nx/test/nx/defn/grad_test.exs
+++ b/nx/test/nx/defn/grad_test.exs
@@ -2089,7 +2089,7 @@ defmodule Nx.Defn.GradTest do
     atol = 1.0e-7
     rtol = 1.0e-4
     try do
-      assert Nx.allclose?(left, right, atol: atol, rtol: rtol) == Nx.tensor(1, type: {:u, 8})
+      assert Nx.all_close?(left, right, atol: atol, rtol: rtol) == Nx.tensor(1, type: {:u, 8})
     rescue
       _ -> assert left == right # So we can see the diff
     end

--- a/nx/test/test_helper.exs
+++ b/nx/test/test_helper.exs
@@ -15,7 +15,7 @@ defmodule Nx.GradHelpers do
   end
 
   defp approx_equal?(lhs, rhs, x, atol, rtol) do
-    unless Nx.allclose?(lhs, rhs, atol: atol, rtol: rtol) == Nx.tensor(1, type: {:u, 8}) do
+    unless Nx.all_close?(lhs, rhs, atol: atol, rtol: rtol) == Nx.tensor(1, type: {:u, 8}) do
       raise """
       expected
 

--- a/nx/test/test_helper.exs
+++ b/nx/test/test_helper.exs
@@ -6,23 +6,22 @@ defmodule Nx.GradHelpers do
   variable with a partial application of `func`.
   """
   def check_grads!(func, grad_func, x, opts \\ []) when is_list(opts) do
-    eps = opts[:eps] || 1.0e-4
+    atol = opts[:atol] || 1.0e-7
+    rtol = opts[:rtol] || 1.0e-4
     step = opts[:step] || 1.0e-4
     est_grad = finite_differences(func, x, step)
     comp_grad = grad_func.(x)
-    approx_equal?(est_grad, comp_grad, x, eps)
+    approx_equal?(comp_grad, est_grad, x, atol, rtol)
   end
 
-  defp approx_equal?(lhs, rhs, x, eps) do
-    [value] = Nx.to_flat_list(Nx.abs(Nx.subtract(lhs, rhs)))
-
-    unless value < eps do
+  defp approx_equal?(lhs, rhs, x, atol, rtol) do
+    unless Nx.allclose?(lhs, rhs, atol: atol, rtol: rtol) == Nx.tensor(1, type: {:u, 8}) do
       raise """
       expected
 
       #{inspect(lhs)}
 
-      to be #{eps} within
+      to be within tolerance of
 
       #{inspect(rhs)}
 


### PR DESCRIPTION
This is what JAX uses to test against NumPy, a bit more precise than float rounding. Also updates `check_grads!` to support n-D output so we can use finite differences for all of the gradient tests rather than just comparing against JAX output