### PR TITLE
feat: add lu decomposition

### DIFF
--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -7657,7 +7657,7 @@ defmodule Nx do
   end
 
   @doc """
-  Calculates the (P)LU decomposition of a 2-D tensor with shape `{N, N}`.
+  Calculates the A = PLU decomposition of a 2-D tensor A with shape `{N, N}`.
 
   ## Options
     * `:p_names` - Defines the names for the `p` tensor

--- a/nx/lib/nx/shape.ex
+++ b/nx/lib/nx/shape.ex
@@ -928,6 +928,17 @@ defmodule Nx.Shape do
         "tensor must have rank 2, got rank #{tuple_size(shape)} with shape #{inspect(shape)}"
       )
 
+  def lu({n, n}) do
+    {{n, n}, {n, n}, {n, n}}
+  end
+
+  def lu(shape),
+    do:
+      raise(
+        ArgumentError,
+        "tensor must have as many rows as columns, got shape: #{inspect(shape)}"
+      )
+
   defp validate_concat_names!(names) do
     :ok =
       names


### PR DESCRIPTION
This PR implements LU decomposition for #157, as per the [scipy.linalg.lu](https://docs.scipy.org/doc/scipy/reference/generated/scipy.linalg.lu.html).

No options are supported besides our own `:eps` and `*_names` because:

- overwrite_a: this doesn't make sense for Elixir
- permute_l: makes the function's return type polymorphic so it wasn't implemented
- check_finite: we don't support infinities yet