### PR TITLE
feat: add Nx.tile/2 function

### DIFF
--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -1497,13 +1497,6 @@ defmodule Nx do
       >
 
       iex> b = Nx.tensor([[1,2],[3,4]])
-      #Nx.Tensor<
-        s64[2][2]
-        [
-          [1, 2],
-          [3, 4]
-        ]
-      >
       iex> Nx.tile(b, 2)
       #Nx.Tensor<
         s64[2][4]
@@ -1532,10 +1525,6 @@ defmodule Nx do
       >
 
       iex> c = Nx.tensor([1,2,3,4])
-      #Nx.Tensor<
-        s64[4]
-        [1, 2, 3, 4]
-      >
       iex> Nx.tile(c, [4,1])
       #Nx.Tensor<
         s64[4][4]
@@ -1547,16 +1536,16 @@ defmodule Nx do
         ]
       >
 
-    ### Error cases
+  ### Error cases
 
-    iex> Nx.tile(Nx.tensor([1,2]), 1.0)
-    ** (ArgumentError) repetitions must be either an integer or a list of integers. Got: 1.0
+      iex> Nx.tile(Nx.tensor([1,2]), 1.0)
+      ** (ArgumentError) repetitions must be either an integer or a list of integers. Got: 1.0
 
-    iex> Nx.tile(Nx.tensor([1,2]), [1, 1.0])
-    ** (ArgumentError) repetitions must be either an integer or a list of integers. Got: [1, 1.0]
+      iex> Nx.tile(Nx.tensor([1,2]), [1, 1.0])
+       ** (ArgumentError) repetitions must be either an integer or a list of integers. Got: [1, 1.0]
 
-    iex> Nx.tile(Nx.tensor([1,2]), nil)
-    ** (ArgumentError) repetitions must be either an integer or a list of integers. Got: nil
+      iex> Nx.tile(Nx.tensor([1,2]), nil)
+      ** (ArgumentError) repetitions must be either an integer or a list of integers. Got: nil
   """
   @doc type: :shape
   def tile(tensor, repetitions) do
@@ -1597,9 +1586,7 @@ defmodule Nx do
     broadcast_shape = zipped_shapes |> Enum.flat_map(&Tuple.to_list/1) |> List.to_tuple()
 
     tensor_reshape =
-      [nil | resized_shape_list]
-      |> Enum.intersperse(1)
-      |> tl()
+      [1 | Enum.intersperse(resized_shape_list, 1)]
       |> List.to_tuple()
 
     result_shape = zipped_shapes |> Enum.map(fn {x, y} -> x * y end) |> List.to_tuple()

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -1539,13 +1539,13 @@ defmodule Nx do
   ### Error cases
 
       iex> Nx.tile(Nx.tensor([1,2]), 1.0)
-      ** (ArgumentError) repetitions must be a list of integers. Got: 1.0
+      ** (ArgumentError) repetitions must be a list of integers, got: 1.0
 
       iex> Nx.tile(Nx.tensor([1,2]), [1, 1.0])
-      ** (ArgumentError) repetitions must be a list of integers. Got: [1, 1.0]
+      ** (ArgumentError) repetitions must be a list of integers, got: [1, 1.0]
 
       iex> Nx.tile(Nx.tensor([1,2]), nil)
-      ** (ArgumentError) repetitions must be a list of integers. Got: nil
+      ** (ArgumentError) repetitions must be a list of integers, got: nil
   """
   @doc type: :shape
   def tile(tensor, repetitions) do
@@ -1553,7 +1553,7 @@ defmodule Nx do
 
     unless tile_valid_repetitions?(repetitions) do
       raise ArgumentError,
-            "repetitions must be a list of integers. Got: #{inspect(repetitions)}"
+            "repetitions must be a list of integers, got: #{inspect(repetitions)}"
     end
 
     {tensor_reshape, broadcast_shape, result_shape} = Nx.Shape.tile(tensor, repetitions)


### PR DESCRIPTION
Implements the `Nx.tile/2` function as per the [Numpy docs](https://numpy.org/doc/stable/reference/generated/numpy.tile.html) 