### PR TITLE
feat: accept prng seed for random_* functions

### DIFF
--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -705,7 +705,6 @@ defmodule Nx do
     * `:backend` - the backend to allocate the tensor on. It is either
       an atom or a tuple in the shape `{backend, options}`. This option
       is ignored inside `defn`
-
   """
   @doc type: :random
   def random_uniform(tensor_or_shape, min, max, opts \\ [])

--- a/nx/test/nx_test.exs
+++ b/nx/test/nx_test.exs
@@ -1267,6 +1267,28 @@ defmodule NxTest do
         Nx.random_normal(1, 0.1, 10.0, type: {:s, 32})
       end)
     end
+
+    test "accepts random seed option" do
+      result = Nx.random_normal(1, 0.1, 10.0, backend: {Nx.BinaryBackend, prng_seed: 42})
+      results = Enum.map(1..4, fn _ -> Nx.random_normal(1, 0.1, 10.0) end)
+
+      assert result == Nx.random_normal(1, 0.1, 10.0, backend: {Nx.BinaryBackend, prng_seed: 42})
+      assert results == Enum.map(1..4, fn _ -> Nx.random_normal(1, 0.1, 10.0) end)
+    end
+
+    test "accepts random seed option with the prng alg" do
+      result =
+        Nx.random_normal(1, 0.1, 10.0, backend: {Nx.BinaryBackend, prng_seed: {:exs1024s, 42}})
+
+      results = Enum.map(1..4, fn _ -> Nx.random_normal(1, 0.1, 10.0) end)
+
+      assert result ==
+               Nx.random_normal(1, 0.1, 10.0,
+                 backend: {Nx.BinaryBackend, prng_seed: {:exs1024s, 42}}
+               )
+
+      assert results == Enum.map(1..4, fn _ -> Nx.random_normal(1, 0.1, 10.0) end)
+    end
   end
 
   describe "random_uniform/3" do
@@ -1299,6 +1321,28 @@ defmodule NxTest do
           Nx.random_uniform(1, 0.1, 10.0, type: {:s, 32})
         end
       )
+    end
+
+    test "accepts random seed option" do
+      result = Nx.random_uniform(1, 0.1, 10.0, backend: {Nx.BinaryBackend, prng_seed: 42})
+      results = Enum.map(1..4, fn _ -> Nx.random_uniform(1, 0.1, 10.0) end)
+
+      assert result == Nx.random_uniform(1, 0.1, 10.0, backend: {Nx.BinaryBackend, prng_seed: 42})
+      assert results == Enum.map(1..4, fn _ -> Nx.random_uniform(1, 0.1, 10.0) end)
+    end
+
+    test "accepts random seed option with the prng alg" do
+      result =
+        Nx.random_uniform(1, 0.1, 10.0, backend: {Nx.BinaryBackend, prng_seed: {:exs1024s, 42}})
+
+      results = Enum.map(1..4, fn _ -> Nx.random_uniform(1, 0.1, 10.0) end)
+
+      assert result ==
+               Nx.random_uniform(1, 0.1, 10.0,
+                 backend: {Nx.BinaryBackend, prng_seed: {:exs1024s, 42}}
+               )
+
+      assert results == Enum.map(1..4, fn _ -> Nx.random_uniform(1, 0.1, 10.0) end)
     end
   end
 


### PR DESCRIPTION
As per the discussion in Slack, this is a proposal for accepting a random seed option in `Nx.random_*` functions.

I'm not sure where to modify to implement this for Torchx and ExLA, so pointers are welcome!