### PR TITLE
Handle any scalars (integer or float) in NIFs

### DIFF
--- a/torchx/lib/torchx/backend.ex
+++ b/torchx/lib/torchx/backend.ex
@@ -98,13 +98,13 @@ defmodule Torchx.Backend do
   ## Creation
 
   @impl true
-  # TODO: Do not cast to floats as there is low of precision for large integers
   def scalar(%T{shape: {}, type: type} = out, scalar, backend_options) do
-    NIF.scalar_tensor(1.0 * scalar, torch_type(type), torch_device(backend_options)) |> from_ref(out)
+    NIF.scalar_tensor(scalar, torch_type(type), torch_device(backend_options))
+    |> from_ref(out)
   end
 
   def scalar(%T{shape: shape, type: type} = out, scalar, backend_options) do
-    NIF.full(shape, 1.0 * scalar, torch_type(type), torch_device(backend_options)) |> from_ref(out)
+    NIF.full(shape, scalar, torch_type(type), torch_device(backend_options)) |> from_ref(out)
   end
 
   @impl true

--- a/torchx/test/torchx/nx_doctest_test.exs
+++ b/torchx/test/torchx/nx_doctest_test.exs
@@ -64,7 +64,6 @@ defmodule Torchx.NxDoctestTest do
     :ok
   end
 
-
   doctest Nx,
     except:
       Torchx.Backend.__unimplemented__()
@@ -78,8 +77,8 @@ defmodule Torchx.NxDoctestTest do
         logistic: 1,
         random_uniform: 4,
         random_normal: 4,
-
         broadcast: 3,
+        slice_axis: 5,
         outer: 2,
         dot: 2,
         qr: 2,
@@ -96,5 +95,5 @@ defmodule Torchx.NxDoctestTest do
         atan2: 2,
         bitcast: 2
       )
-    |> Kernel.++([:moduledoc])
+      |> Kernel.++([:moduledoc])
 end


### PR DESCRIPTION
It gets shape mismatch exceptions on new `Nx.slice_axis` doctests.