### PR TITLE
Handle args, wrapped in tensors by mistake

### DIFF
--- a/nx/lib/nx/tensor.ex
+++ b/nx/lib/nx/tensor.ex
@@ -55,6 +55,11 @@ defmodule Nx.Tensor do
   def fetch(tensor, [_ | _] = list),
     do: {:ok, fetch_axes(tensor, with_index(list, 0, []))}
 
+  def fetch(tensor, %Nx.Tensor{shape: {}, data: %Nx.Defn.Expr{op: :parameter}}) do
+    raise ArgumentError,
+          "You have to hint defn argument with default value, if you want it to be passed \"as is\""
+  end
+
   def fetch(_tensor, value) do
     raise """
     tensor[slice] expects slice to be one of:

--- a/nx/test/nx/defn_test.exs
+++ b/nx/test/nx/defn_test.exs
@@ -240,7 +240,8 @@ defmodule Nx.DefnTest do
       do: t |> Nx.broadcast({5, 3, 7}, axes: [1]) |> Nx.broadcast({9, 5, 3, 7}, axes: [1, 2, 3])
 
     defn broadcast_collapse7(t),
-      do: t |> Nx.broadcast({3, 5, 7}, axes: [0, 2]) |> Nx.broadcast({3, 9, 5, 7}, axes: [0, 2, 3])
+      do:
+        t |> Nx.broadcast({3, 5, 7}, axes: [0, 2]) |> Nx.broadcast({3, 9, 5, 7}, axes: [0, 2, 3])
 
     test "collapses" do
       assert %T{data: %Expr{op: :broadcast, args: [_, {7, 5, 3}, [1]]}, shape: {7, 5, 3}} =
@@ -1029,6 +1030,21 @@ defmodule Nx.DefnTest do
 
       sum_axis_expr(Nx.tensor([[1, 2], [3, 4]]), axes: [0])
       assert Process.get(Identity) == key0
+    end
+
+    test "raise when not hinted" do
+      assert_raise ArgumentError,
+                   ~r"You have to hint defn argument",
+                   fn ->
+                     defmodule Sample do
+                       import Nx.Defn
+
+                       defn access(t, i), do: t[i]
+                     end
+
+                     t = Nx.tensor([1, 2, 3])
+                     Sample.access(t, 1)
+                   end
     end
   end
 


### PR DESCRIPTION
This is to start discussion.
How can we help beginner users of `defn` pass plain number vars without being confused by cryptic errors from the inwards of the lib?

Create a special guard for this or something? This can really be a show stopper for the beginners.

Examples of errors:

  1.
```
defnp compute_l(c, alphas, i1, i2, targets) do
    a1 = alphas[i1]
```
and i'm getting this error:
```
** (RuntimeError) tensor[slice] expects slice to be one of:
  * an integer representing a zero-based index
  * a first..last range representing inclusive start-stop indexes
  * a list of integers and ranges
  * a keyword list of integers and ranges
Got #Nx.Tensor<
  s64
  Nx.Defn.Expr
  parameter a  s64
>
    (nx 0.1.0-dev) lib/nx/tensor.ex:59: Nx.Tensor.fetch/2
    (elixir 1.11.3) lib/access.ex:286: Access.get/3
    (nixa 0.1.0) lib/nixa/optimize/smo.ex:188: Nixa.Optimize.SMO."__defn:compute_l__"/5

```

  2.
```
defmodule Mod do
  import Nx.Defn
  defn(fun(data, n), do: Nx.window_mean(data, {n}))
end
```
For the above module,
`Nx.iota({10}) |> Mod.fun(3)`  errors
```
** (ArithmeticError) bad argument in arithmetic expression
    (nx 0.1.0-dev) lib/nx/shape.ex:606: Nx.Shape.padded_dims/3
    (nx 0.1.0-dev) lib/nx/shape.ex:582: Nx.Shape.pad/2
    (nx 0.1.0-dev) lib/nx.ex:5217: Nx.aggregate_window_op/4
    (nx 0.1.0-dev) lib/nx.ex:5431: Nx.window_mean/3
    iex:7: anonymous fn/1 in Mod.fun/2
    (nx 0.1.0-dev) lib/nx/defn/evaluator.ex:20: Nx.Defn.Evaluator.__jit__/4

```

