### PR TITLE
Add missing :compiler opts to Defn.aot calls

### DIFF
--- a/exla/bench/softmax.exs
+++ b/exla/bench/softmax.exs
@@ -29,7 +29,7 @@ Nx.Defn.aot(
     {:softmax_64, &Softmax.softmax/1, [t64]},
     {:softmax_32, &Softmax.softmax/1, [t32]},
   ],
-  EXLA
+  compiler: EXLA
 )
 
 IO.inspect(AOTSoftmax.softmax_32(t32))

--- a/exla/examples/mnist.exs
+++ b/exla/examples/mnist.exs
@@ -163,7 +163,7 @@ IO.puts("AOT-compiling a trained neural network that predicts a batch")
 Nx.Defn.aot(
   MNIST.Trained,
   [{:predict, &MNIST.predict(final_params, &1), [Nx.template({30, 784}, {:f, 32})]}],
-  EXLA
+  compiler: EXLA
 )
 
 IO.puts("The result of the first batch against the AOT-compiled one")


### PR DESCRIPTION
Without this change the examples are currently broken.