### PR TITLE
Optimise concatenate along axis 0

### DIFF
--- a/nx/lib/nx/binary_backend.ex
+++ b/nx/lib/nx/binary_backend.ex
@@ -1537,8 +1537,14 @@ defmodule Nx.BinaryBackend do
         end
       else
         input_data = Enum.map(tensors, &to_binary/1) |> IO.iodata_to_binary()
-        output_weighted_shape = weighted_shape(output_shape, size)
-        IO.iodata_to_binary(weighted_traverse(output_weighted_shape, input_data, size))
+
+        if axis == 0 do
+          # When concatenating along the first axis, joining bytes is all we need
+          input_data
+        else
+          output_weighted_shape = weighted_shape(output_shape, size)
+          IO.iodata_to_binary(weighted_traverse(output_weighted_shape, input_data, size))
+        end
       end
 
     from_binary(out, output_data)


### PR DESCRIPTION
When concatenating along various axis we traverse bytes to order them properly, but that's not necessary for concatenating over axis 0. In such case all we have to do is to join the bytes.

Here's a benchmark for concatenating `Nx.iota({100, 100, 100}) |> Nx.to_batched_list(1)`:

<details>
  <summary>Output</summary>

```
Operating System: Linux
CPU Information: Intel(R) Core(TM) i5-6200U CPU @ 2.30GHz
Number of Available Cores: 4
Available memory: 30.80 GB
Elixir 1.12.0-dev
Erlang 23.0.3

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 5 s
memory time: 0 ns
parallel: 1
inputs: none specified
Estimated total run time: 14 s

Benchmarking Nx.concatenate...
Benchmarking Nx.concatenate before...

Name                            ips        average  deviation         median         99th %
Nx.concatenate               412.43      0.00242 s    ±75.51%      0.00202 s       0.0127 s
Nx.concatenate before          0.86         1.16 s    ±14.97%         1.19 s         1.32 s

Comparison: 
Nx.concatenate               412.43
Nx.concatenate before          0.86 - 476.81x slower +1.15 s
```

</details>