### PR TITLE
feat: concatenate scalar tensors

### DIFF
--- a/exla/test/exla/defn_expr_test.exs
+++ b/exla/test/exla/defn_expr_test.exs
@@ -2412,6 +2412,10 @@ defmodule EXLA.DefnExprTest do
     defn concatenate2(t1, t2, t3), do: Nx.concatenate([t1, t2, t3], axis: 2)
     defn concatenate1_inp(t1), do: Nx.concatenate([t1], axis: 2)
 
+    test "works on list of scalar tensors" do
+      assert concatenate0(Nx.tensor(1), Nx.tensor(2), Nx.tensor(3)) == Nx.tensor([1, 2, 3])
+    end
+
     test "works 0th axis" do
       t1 = Nx.iota({2, 2, 2})
       t2 = Nx.iota({1, 2, 2})

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -7288,6 +7288,12 @@ defmodule Nx do
           ]
         ]
       >
+
+      iex> Nx.concatenate([Nx.tensor(1), Nx.tensor(2), Nx.tensor(3)])
+      #Nx.Tensor<
+        s64
+        [1, 2, 3]
+      >
   """
   @doc type: :ndim
   def concatenate(tensors, opts \\ []) when is_list(tensors) do
@@ -7310,7 +7316,7 @@ defmodule Nx do
           end)
           |> unzip4()
 
-        axis = Nx.Shape.normalize_axis(s1, axis, n1)
+        axis = Nx.Shape.normalize_axis(s1, axis, n1, accept_zero_axis_for_scalar: true)
         {output_shape, output_names} = Nx.Shape.concatenate(shapes, names, axis)
 
         output_type =

--- a/nx/lib/nx/binary_backend.ex
+++ b/nx/lib/nx/binary_backend.ex
@@ -1568,6 +1568,7 @@ defmodule Nx.BinaryBackend do
     from_binary(out, data)
   end
 
+  defp product_part({}, _, _), do: 1
   defp product_part(_tuple, n, n), do: 1
   defp product_part(tuple, n, limit), do: elem(tuple, n) * product_part(tuple, n + 1, limit)
 


### PR DESCRIPTION
This was brought up in the slack channel. Basically, it would be nice to `Nx.concatenate([Nx.tensor(1), Nx.tensor(2)])` into `Nx.tensor([1, 2])`

This first attempt started by changing some Nx.Shape functions which ended up being sufficient for Nx.BinaryBackend to work. However, I ended up stumbling across the same problem in EXLA (in which scalar tensors have no axes).

The main question here is: should I treat this at the Backend level or should I just reshape scalar tensors into `{1}`-shaped tensors for concatenation in the `nx.ex` `def concatenate` itself?