### PR TITLE
Add batching to EXLA dot product

### DIFF
--- a/exla/c_src/exla/exla_nif_util.cc
+++ b/exla/c_src/exla/exla_nif_util.cc
@@ -265,26 +265,46 @@ namespace nif {
     const ERL_NIF_TERM* terms;
     int count;
     if (!enif_get_tuple(env, tuple, &count, &terms)) return 0;
-    if (count != 2) return 0;
+    if (count != 4) return 0;
 
-    ERL_NIF_TERM lhs, lhs_tail;
+    ERL_NIF_TERM lhs_contract, lhs_contract_tail;
     ERL_NIF_TERM list = terms[0];
-    while (enif_get_list_cell(env, list, &lhs, &lhs_tail)) {
+    while (enif_get_list_cell(env, list, &lhs_contract, &lhs_contract_tail)) {
       int64 dim;
-      if (!get(env, lhs, &dim)) return 0;
+      if (!get(env, lhs_contract, &dim)) return 0;
       dims->add_lhs_contracting_dimensions(dim);
 
-      list = lhs_tail;
+      list = lhs_contract_tail;
     }
 
-    ERL_NIF_TERM rhs, rhs_tail;
+    ERL_NIF_TERM lhs_batch, lhs_batch_tail;
     list = terms[1];
-    while (enif_get_list_cell(env, list, &rhs, &rhs_tail)) {
+    while (enif_get_list_cell(env, list, &lhs_batch, &lhs_batch_tail)) {
       int64 dim;
-      if (!get(env, rhs, &dim)) return 0;
+      if (!get(env, lhs_batch, &dim)) return 0;
+      dims->add_lhs_batch_dimensions(dim);
+
+      list = lhs_batch_tail;
+    }
+
+    ERL_NIF_TERM rhs_contract, rhs_contract_tail;
+    list = terms[2];
+    while (enif_get_list_cell(env, list, &rhs_contract, &rhs_contract_tail)) {
+      int64 dim;
+      if (!get(env, rhs_contract, &dim)) return 0;
       dims->add_rhs_contracting_dimensions(dim);
 
-      list = rhs_tail;
+      list = rhs_contract_tail;
+    }
+
+    ERL_NIF_TERM rhs_batch, rhs_batch_tail;
+    list = terms[3];
+    while (enif_get_list_cell(env, list, &rhs_batch, &rhs_batch_tail)) {
+      int64 dim;
+      if (!get(env, rhs_batch, &dim)) return 0;
+      dims->add_rhs_batch_dimensions(dim);
+
+      list = rhs_batch_tail;
     }
 
     return 1;

--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -300,9 +300,20 @@ defmodule EXLA.Defn do
     EXLA.Op.get_tuple_element(op, index)
   end
 
-  defp to_operator(:dot, [left, contract_axes1, [], right, contract_axes2, []], %{type: type}, state) do
+  defp to_operator(
+         :dot,
+         [left, contract_axes1, batch_axes1, right, contract_axes2, batch_axes2],
+         %{type: type},
+         state
+       ) do
     precision = state.precision
-    EXLA.Op.dot_general(to_type(left, type), to_type(right, type), {contract_axes1, contract_axes2}, precision)
+
+    EXLA.Op.dot_general(
+      to_type(left, type),
+      to_type(right, type),
+      {contract_axes1, batch_axes1, contract_axes2, batch_axes2},
+      precision
+    )
   end
 
   defp to_operator(

--- a/exla/test/exla/defn_expr_test.exs
+++ b/exla/test/exla/defn_expr_test.exs
@@ -5,7 +5,7 @@ defmodule EXLA.DefnExprTest do
   @default_defn_compiler EXLA
 
   describe "tuples" do
-    defn add_subtract_tuple(a, b), do: {a + b, a - b}
+    defn(add_subtract_tuple(a, b), do: {a + b, a - b})
 
     test "on results" do
       assert add_subtract_tuple(2, 3) == {Nx.tensor(5), Nx.tensor(-1)}
@@ -14,7 +14,7 @@ defmodule EXLA.DefnExprTest do
                {Nx.tensor([9, 10, 11]), Nx.tensor([-11, -10, -9])}
     end
 
-    defn pattern_tuple({a, b}), do: a + b
+    defn(pattern_tuple({a, b}), do: a + b)
 
     test "on patterns" do
       assert pattern_tuple({2, 3}) == Nx.tensor(5)
@@ -23,7 +23,7 @@ defmodule EXLA.DefnExprTest do
                Nx.tensor([[4, 5], [5, 6]])
     end
 
-    defn calls_pattern_tuple(a, b), do: pattern_tuple({a, b})
+    defn(calls_pattern_tuple(a, b), do: pattern_tuple({a, b}))
 
     test "on inlined tuples" do
       assert calls_pattern_tuple(2, 3) == Nx.tensor(5)
@@ -35,10 +35,10 @@ defmodule EXLA.DefnExprTest do
 
   describe "tensor constants" do
     @two 2
-    defn add_two_attribute(t), do: t + @two
+    defn(add_two_attribute(t), do: t + @two)
 
     @two_per_two Nx.tensor([[1, 2], [3, 4]])
-    defn add_2x2_attribute(t), do: t + @two_per_two
+    defn(add_2x2_attribute(t), do: t + @two_per_two)
 
     test "expands module attributes to scalars" do
       assert add_two_attribute(1) == Nx.tensor(3)
@@ -52,9 +52,9 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "+/2" do
-    defn add_two(a, b), do: a + b
+    defn(add_two(a, b), do: a + b)
     @defn_compiler Nx.Defn.Evaluator
-    defn add_two_nx(a, b), do: a + b
+    defn(add_two_nx(a, b), do: a + b)
 
     test "same shape and type" do
       assert add_two(1.0, 2.0) == Nx.tensor(3.0)
@@ -92,8 +92,8 @@ defmodule EXLA.DefnExprTest do
       end
     end
 
-    defn add_two_int(t), do: t + 2
-    defn add_two_float(t), do: t + 2.0
+    defn(add_two_int(t), do: t + 2)
+    defn(add_two_float(t), do: t + 2.0)
 
     test "constants" do
       tensors = [
@@ -143,7 +143,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "//2" do
-    defn divide_two(a, b), do: a / b
+    defn(divide_two(a, b), do: a / b)
 
     test "parameters" do
       tensors = [
@@ -161,8 +161,8 @@ defmodule EXLA.DefnExprTest do
       end
     end
 
-    defn divide_two_int(t), do: t / 2
-    defn divide_two_float(t), do: t / 2.0
+    defn(divide_two_int(t), do: t / 2)
+    defn(divide_two_float(t), do: t / 2.0)
 
     test "constants" do
       tensors = [
@@ -183,7 +183,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "remainder" do
-    defn remainder(a, b), do: Nx.remainder(a, b)
+    defn(remainder(a, b), do: Nx.remainder(a, b))
 
     test "integers" do
       left = Nx.tensor([-1023, 1023])
@@ -210,7 +210,7 @@ defmodule EXLA.DefnExprTest do
       {Nx.tensor([[1], [2]], type: {:f, 32}), Nx.tensor([[10, 20]], type: {:f, 32})}
     ]
 
-    defn subtract_two(a, b), do: a - b
+    defn(subtract_two(a, b), do: a - b)
 
     test "-" do
       for {left, right} <- @tensors do
@@ -219,7 +219,7 @@ defmodule EXLA.DefnExprTest do
       end
     end
 
-    defn multiply_two(a, b), do: a * b
+    defn(multiply_two(a, b), do: a * b)
 
     test "*" do
       for {left, right} <- @tensors do
@@ -228,7 +228,7 @@ defmodule EXLA.DefnExprTest do
       end
     end
 
-    defn unary_minus(a), do: -a
+    defn(unary_minus(a), do: -a)
 
     test "negate" do
       for t <- [
@@ -240,7 +240,7 @@ defmodule EXLA.DefnExprTest do
       end
     end
 
-    defn max_two(a, b), do: max(a, b)
+    defn(max_two(a, b), do: max(a, b))
 
     test "max" do
       for {left, right} <- @tensors do
@@ -249,7 +249,7 @@ defmodule EXLA.DefnExprTest do
       end
     end
 
-    defn min_two(a, b), do: min(a, b)
+    defn(min_two(a, b), do: min(a, b))
 
     test "min" do
       for {left, right} <- @tensors do
@@ -258,7 +258,7 @@ defmodule EXLA.DefnExprTest do
       end
     end
 
-    defn power_two(a, b), do: Nx.power(a, b)
+    defn(power_two(a, b), do: Nx.power(a, b))
 
     test "power" do
       for {left, right} <- @tensors do
@@ -267,7 +267,7 @@ defmodule EXLA.DefnExprTest do
       end
     end
 
-    defn atan2_two(a, b), do: Nx.atan2(a, b)
+    defn(atan2_two(a, b), do: Nx.atan2(a, b))
 
     test "atan2" do
       <<neg_zero::float>> = <<0x8000000000000000::64>>
@@ -278,7 +278,7 @@ defmodule EXLA.DefnExprTest do
       compare_tensors!(atan2_two(right, left), Nx.atan2(right, left))
     end
 
-    defn quotient_two(a, b), do: Nx.quotient(a, b)
+    defn(quotient_two(a, b), do: Nx.quotient(a, b))
 
     test "quotient" do
       int_tensors = [
@@ -301,35 +301,35 @@ defmodule EXLA.DefnExprTest do
     @left Nx.tensor([-2, -1, 0, 1, 2])
     @right Nx.tensor([[-2], [-1], [0], [1], [2]])
 
-    defn bitwise_and(a, b), do: a &&& b
+    defn(bitwise_and(a, b), do: a &&& b)
 
     test "bitwise_and" do
       assert Nx.shape(bitwise_and(@left, @right)) == {5, 5}
       assert bitwise_and(@left, @right) == Nx.bitwise_and(@left, @right)
     end
 
-    defn bitwise_or(a, b), do: a ||| b
+    defn(bitwise_or(a, b), do: a ||| b)
 
     test "bitwise_or" do
       assert Nx.shape(bitwise_or(@left, @right)) == {5, 5}
       assert bitwise_or(@left, @right) == Nx.bitwise_or(@left, @right)
     end
 
-    defn bitwise_not(a), do: ~~~a
+    defn(bitwise_not(a), do: ~~~a)
 
     test "bitwise_not" do
       assert Nx.shape(bitwise_not(@left)) == {5}
       assert bitwise_not(@left) == Nx.bitwise_not(@left)
     end
 
-    defn bitwise_pc(a), do: Nx.population_count(a)
+    defn(bitwise_pc(a), do: Nx.population_count(a))
 
     test "population_count" do
       assert Nx.shape(bitwise_pc(@left)) == {5}
       assert bitwise_pc(@left) == Nx.population_count(@left)
     end
 
-    defn bitwise_clz(a), do: Nx.count_leading_zeros(a)
+    defn(bitwise_clz(a), do: Nx.count_leading_zeros(a))
 
     test "count_leading_zeros" do
       assert Nx.shape(bitwise_clz(@left)) == {5}
@@ -339,7 +339,7 @@ defmodule EXLA.DefnExprTest do
     @left Nx.tensor([-2, -1, 0, 1, 2])
     @right Nx.tensor([[0], [1], [2], [3], [4]])
 
-    defn left_shift(a, b), do: a <<< b
+    defn(left_shift(a, b), do: a <<< b)
 
     test "left_shift" do
       assert Nx.shape(left_shift(@left, @right)) == {5, 5}
@@ -352,7 +352,7 @@ defmodule EXLA.DefnExprTest do
     @left_unsigned Nx.tensor([0, 1, 2, 253, 254, 255], type: {:u, 8})
     @right_unsigned Nx.tensor([[0], [1], [2], [3], [4], [5]], type: {:u, 8})
 
-    defn right_shift(a, b), do: a >>> b
+    defn(right_shift(a, b), do: a >>> b)
 
     test "right_shift" do
       assert Nx.shape(right_shift(@left_signed, @right_signed)) == {9, 9}
@@ -368,7 +368,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "exp" do
-    defn exp(t), do: Nx.exp(t)
+    defn(exp(t), do: Nx.exp(t))
 
     test "computes the exp across types" do
       assert Nx.tensor([1, 2, 3]) |> exp() ==
@@ -389,7 +389,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "equal" do
-    defn equal(a, b), do: Nx.equal(a, b)
+    defn(equal(a, b), do: Nx.equal(a, b))
 
     test "computes equality of scalars" do
       assert equal(Nx.tensor(1), Nx.tensor(2)) == Nx.tensor(0, type: {:u, 8})
@@ -406,7 +406,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "not equal" do
-    defn not_equal(a, b), do: Nx.not_equal(a, b)
+    defn(not_equal(a, b), do: Nx.not_equal(a, b))
 
     test "computes equality of scalars" do
       assert not_equal(Nx.tensor(1), Nx.tensor(2)) == Nx.tensor(1, type: {:u, 8})
@@ -423,7 +423,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "less" do
-    defn less(a, b), do: Nx.less(a, b)
+    defn(less(a, b), do: Nx.less(a, b))
 
     test "compares scalars" do
       assert less(Nx.tensor(1), Nx.tensor(2)) == Nx.tensor(1, type: {:u, 8})
@@ -440,7 +440,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "greater" do
-    defn greater(a, b), do: Nx.greater(a, b)
+    defn(greater(a, b), do: Nx.greater(a, b))
 
     test "compares scalars" do
       assert greater(Nx.tensor(1), Nx.tensor(2)) == Nx.tensor(0, type: {:u, 8})
@@ -457,7 +457,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "less equal" do
-    defn less_equal(a, b), do: Nx.less_equal(a, b)
+    defn(less_equal(a, b), do: Nx.less_equal(a, b))
 
     test "compares scalars" do
       assert less_equal(Nx.tensor(1), Nx.tensor(2)) == Nx.tensor(1, type: {:u, 8})
@@ -474,7 +474,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "greater equal" do
-    defn greater_equal(a, b), do: Nx.greater_equal(a, b)
+    defn(greater_equal(a, b), do: Nx.greater_equal(a, b))
 
     test "compares scalars" do
       assert greater_equal(Nx.tensor(1), Nx.tensor(2)) == Nx.tensor(0, type: {:u, 8})
@@ -492,7 +492,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "logical" do
-    defn logical_and(a, b), do: Nx.logical_and(a, b)
+    defn(logical_and(a, b), do: Nx.logical_and(a, b))
 
     test "and" do
       assert logical_and(Nx.tensor([-1, 0, 1]), Nx.tensor([[-1], [0], [1]])) ==
@@ -516,7 +516,7 @@ defmodule EXLA.DefnExprTest do
                )
     end
 
-    defn logical_or(a, b), do: Nx.logical_or(a, b)
+    defn(logical_or(a, b), do: Nx.logical_or(a, b))
 
     test "or" do
       assert logical_or(Nx.tensor([-1, 0, 1]), Nx.tensor([[-1], [0], [1]])) ==
@@ -540,7 +540,7 @@ defmodule EXLA.DefnExprTest do
                )
     end
 
-    defn logical_xor(a, b), do: Nx.logical_xor(a, b)
+    defn(logical_xor(a, b), do: Nx.logical_xor(a, b))
 
     test "xor" do
       assert logical_xor(Nx.tensor([-1, 0, 1]), Nx.tensor([[-1], [0], [1]])) ==
@@ -566,7 +566,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "select" do
-    defn select(pred, x, y), do: Nx.select(pred, x, y)
+    defn(select(pred, x, y), do: Nx.select(pred, x, y))
 
     test "selects one or the other with a scalar" do
       assert select(Nx.tensor(1), Nx.tensor([1, 2, 3]), Nx.tensor([4, 5, 6])) ==
@@ -607,9 +607,9 @@ defmodule EXLA.DefnExprTest do
             [:tan, :acosh, :asinh, :cosh, :sinh, :erf, :erfc] do
       exla_fun = :"unary_#{fun}"
       nx_fun = :"unary_#{fun}_nx"
-      defn unquote(exla_fun)(t), do: Nx.unquote(fun)(t)
+      defn(unquote(exla_fun)(t), do: Nx.unquote(fun)(t))
       @defn_compiler Nx.Defn.Evaluator
-      defn unquote(nx_fun)(t), do: Nx.unquote(fun)(t)
+      defn(unquote(nx_fun)(t), do: Nx.unquote(fun)(t))
 
       test "#{fun}" do
         compare_tensors!(unquote(exla_fun)(@float_tensor), unquote(nx_fun)(@float_tensor))
@@ -625,9 +625,9 @@ defmodule EXLA.DefnExprTest do
     for fun <- [:atanh, :acos, :asin, :atan, :erf_inv] do
       exla_fun = :"unary_#{fun}"
       nx_fun = :"unary_#{fun}_nx"
-      defn unquote(exla_fun)(t), do: Nx.unquote(fun)(t)
+      defn(unquote(exla_fun)(t), do: Nx.unquote(fun)(t))
       @defn_compiler Nx.Defn.Evaluator
-      defn unquote(nx_fun)(t), do: Nx.unquote(fun)(t)
+      defn(unquote(nx_fun)(t), do: Nx.unquote(fun)(t))
 
       test "#{fun}" do
         compare_tensors!(unquote(exla_fun)(@float_tensor), unquote(nx_fun)(@float_tensor))
@@ -646,9 +646,9 @@ defmodule EXLA.DefnExprTest do
     for fun <- funs do
       exla_fun = :"unary_#{fun}"
       nx_fun = :"unary_#{fun}_nx"
-      defn unquote(exla_fun)(t), do: Nx.unquote(fun)(t)
+      defn(unquote(exla_fun)(t), do: Nx.unquote(fun)(t))
       @defn_compiler Nx.Defn.Evaluator
-      defn unquote(nx_fun)(t), do: Nx.unquote(fun)(t)
+      defn(unquote(nx_fun)(t), do: Nx.unquote(fun)(t))
 
       test "#{fun}" do
         compare_tensors!(unquote(exla_fun)(@uint_tensor), unquote(nx_fun)(@uint_tensor))
@@ -659,7 +659,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "as_type" do
-    defn to_float(t), do: Nx.as_type(t, {:f, 32})
+    defn(to_float(t), do: Nx.as_type(t, {:f, 32}))
 
     test "converts tensor type" do
       assert to_float(Nx.tensor([1, 2, 3])) == Nx.tensor([1.0, 2.0, 3.0], type: {:f, 32})
@@ -667,7 +667,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "bitcast" do
-    defn bitcast_to_float(t), do: Nx.bitcast(t, {:f, 32})
+    defn(bitcast_to_float(t), do: Nx.bitcast(t, {:f, 32}))
 
     test "converts tensor type" do
       assert bitcast_to_float(Nx.tensor([0, 0, 0], type: {:s, 32})) == Nx.tensor([0.0, 0.0, 0.0])
@@ -675,7 +675,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "if" do
-    defn if3(a, b, c), do: if(a, do: b, else: c)
+    defn(if3(a, b, c), do: if(a, do: b, else: c))
 
     test "one param per branch" do
       assert if3(Nx.tensor(0), Nx.tensor(1, type: {:s, 16}), Nx.tensor(2, type: {:f, 32})) ==
@@ -694,7 +694,7 @@ defmodule EXLA.DefnExprTest do
                Nx.tensor([[1, 2], [1, 2]])
     end
 
-    defn if_params(a, b, c), do: if(a, do: b + c, else: b - c)
+    defn(if_params(a, b, c), do: if(a, do: b + c, else: b - c))
 
     test "two params per branch" do
       assert if_params(Nx.tensor(0), Nx.tensor(1), Nx.tensor(2)) == Nx.tensor(-1)
@@ -711,7 +711,7 @@ defmodule EXLA.DefnExprTest do
       assert if_shared(Nx.tensor(2), Nx.tensor(1), Nx.tensor(2)) == Nx.tensor(12)
     end
 
-    defn if_tuple(a, b, c), do: if(a, do: {{a, b}, c}, else: {{c, b}, a})
+    defn(if_tuple(a, b, c), do: if(a, do: {{a, b}, c}, else: {{c, b}, a}))
 
     test "with tuples" do
       assert if_tuple(Nx.tensor(0), Nx.tensor(10), Nx.tensor(20)) ==
@@ -752,7 +752,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "metadata" do
-    defn add_with_stop_grad(a, b), do: stop_grad(Nx.add(a, b))
+    defn(add_with_stop_grad(a, b), do: stop_grad(Nx.add(a, b)))
 
     test "ignores metadata nodes" do
       assert add_with_stop_grad(1, 2) == Nx.tensor(3)
@@ -792,9 +792,9 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "map" do
-    defn map_plus(t), do: Nx.map(t, fn x -> x + 1 end)
-    defn map_equal(t), do: Nx.map(t, [type: {:f, 64}], fn x -> Nx.equal(x, 1) end)
-    defn map_exp(t), do: Nx.map(t, [type: {:f, 64}], fn x -> Nx.exp(x) end)
+    defn(map_plus(t), do: Nx.map(t, fn x -> x + 1 end))
+    defn(map_equal(t), do: Nx.map(t, [type: {:f, 64}], fn x -> Nx.equal(x, 1) end))
+    defn(map_exp(t), do: Nx.map(t, [type: {:f, 64}], fn x -> Nx.exp(x) end))
 
     test "maps a function over the tensor" do
       assert map_plus(Nx.tensor([[1, 2, 3], [4, 5, 6]])) == Nx.tensor([[2, 3, 4], [5, 6, 7]])
@@ -816,11 +816,12 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "reduce" do
-    defn reduce(t), do: Nx.reduce(t, 1, fn a, b -> a * b end)
-    defn reduce_keep(t), do: Nx.reduce(t, 1, [keep_axes: true], fn a, b -> a * b end)
+    defn(reduce(t), do: Nx.reduce(t, 1, fn a, b -> a * b end))
+    defn(reduce_keep(t), do: Nx.reduce(t, 1, [keep_axes: true], fn a, b -> a * b end))
 
-    defn reduce_keep_2(t),
+    defn(reduce_keep_2(t),
       do: Nx.reduce(t, 1, [keep_axes: true, axes: [0, 2]], fn a, b -> a * b end)
+    )
 
     test "computes the reduce" do
       assert Nx.tensor([1, 2, 3]) |> reduce() == Nx.tensor(6)
@@ -841,20 +842,25 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "reduce window" do
-    defn reduce_window_valid_no_stride(t),
+    defn(reduce_window_valid_no_stride(t),
       do: Nx.reduce_window(t, 0, {2, 2}, fn a, b -> a + b end)
+    )
 
-    defn reduce_window_valid_stride(t),
+    defn(reduce_window_valid_stride(t),
       do: Nx.reduce_window(t, 0, {2, 2}, [strides: [2, 2]], fn a, b -> a + b end)
+    )
 
-    defn reduce_window_same_no_stride(t),
+    defn(reduce_window_same_no_stride(t),
       do: Nx.reduce_window(t, 0, {2, 2}, [padding: :same], fn a, b -> a + b end)
+    )
 
-    defn reduce_window_same_stride(t),
+    defn(reduce_window_same_stride(t),
       do: Nx.reduce_window(t, 0, {2, 2}, [padding: :same, strides: [2, 1]], fn a, b -> a + b end)
+    )
 
-    defn reduce_window_general_no_stride(t),
+    defn(reduce_window_general_no_stride(t),
       do: Nx.reduce_window(t, 0, {2, 2}, [padding: [{2, 1}, {1, 2}]], fn a, b -> a + b end)
+    )
 
     defn reduce_window_general_stride(t) do
       Nx.reduce_window(t, 0, {2, 2}, [padding: [{1, 2}, {2, 1}], strides: [2, 1]], fn a, b ->
@@ -1028,9 +1034,9 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "all?" do
-    defn all?(t), do: Nx.all?(t)
-    defn all_axis_0?(t), do: Nx.all?(t, axes: [0])
-    defn all_axis_1?(t), do: Nx.all?(t, axes: [1])
+    defn(all?(t), do: Nx.all?(t))
+    defn(all_axis_0?(t), do: Nx.all?(t, axes: [0]))
+    defn(all_axis_1?(t), do: Nx.all?(t, axes: [1]))
 
     test "computes the bitwise and across types" do
       assert all?(Nx.tensor([1, 2, 3])) == Nx.tensor(1, type: {:u, 8})
@@ -1047,9 +1053,9 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "any?" do
-    defn any?(t), do: Nx.any?(t)
-    defn any_axis_0?(t), do: Nx.any?(t, axes: [0])
-    defn any_axis_1?(t), do: Nx.any?(t, axes: [1])
+    defn(any?(t), do: Nx.any?(t))
+    defn(any_axis_0?(t), do: Nx.any?(t, axes: [0]))
+    defn(any_axis_1?(t), do: Nx.any?(t, axes: [1]))
 
     test "computes the bitwise and across types" do
       assert any?(Nx.tensor([-1, 0, 1])) == Nx.tensor(1, type: {:u, 8})
@@ -1064,7 +1070,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "sum" do
-    defn sum(t), do: Nx.sum(t)
+    defn(sum(t), do: Nx.sum(t))
 
     test "computes the sum across types" do
       assert Nx.tensor([1, 2, 3]) |> sum() == Nx.tensor(6)
@@ -1074,9 +1080,9 @@ defmodule EXLA.DefnExprTest do
       assert Nx.tensor([1.0, 2.0, 3.0], type: {:f, 32}) |> sum() == Nx.tensor(6, type: {:f, 32})
     end
 
-    defn sum_pos_axis(t), do: Nx.sum(t, axes: [1])
-    defn sum_neg_axis(t), do: Nx.sum(t, axes: [-3])
-    defn sum_pos_neg_axis(t), do: Nx.sum(t, axes: [1, -3])
+    defn(sum_pos_axis(t), do: Nx.sum(t, axes: [1]))
+    defn(sum_neg_axis(t), do: Nx.sum(t, axes: [-3]))
+    defn(sum_pos_neg_axis(t), do: Nx.sum(t, axes: [1, -3]))
 
     test "computes the sum on a given axis" do
       t = Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]])
@@ -1085,7 +1091,7 @@ defmodule EXLA.DefnExprTest do
       assert sum_pos_neg_axis(t) == Nx.sum(t, axes: [1, -3])
     end
 
-    defn sum_equal(t), do: Nx.sum(Nx.equal(t, 1.0))
+    defn(sum_equal(t), do: Nx.sum(Nx.equal(t, 1.0)))
 
     test "does not overflow" do
       assert sum_equal(Nx.tensor(1)) == Nx.tensor(1, type: {:u, 64})
@@ -1093,8 +1099,8 @@ defmodule EXLA.DefnExprTest do
       assert sum_equal(Nx.tensor([1, 2, 3])) == Nx.tensor(1, type: {:u, 64})
     end
 
-    defn sum_keep(t), do: Nx.sum(t, keep_axes: true)
-    defn sum_keep_2(t), do: Nx.sum(t, axes: [0, 2], keep_axes: true)
+    defn(sum_keep(t), do: Nx.sum(t, keep_axes: true))
+    defn(sum_keep_2(t), do: Nx.sum(t, axes: [0, 2], keep_axes: true))
 
     test "keeps dimensions if keep_axes" do
       assert Nx.tensor([1, 2, 3]) |> sum_keep() == Nx.tensor([6])
@@ -1106,7 +1112,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "product" do
-    defn product(t), do: Nx.product(t)
+    defn(product(t), do: Nx.product(t))
 
     test "computes the product across types" do
       assert Nx.tensor([1, 2, 3]) |> product() == Nx.tensor(6)
@@ -1118,9 +1124,9 @@ defmodule EXLA.DefnExprTest do
                Nx.tensor(6, type: {:f, 32})
     end
 
-    defn product_pos_axis(t), do: Nx.product(t, axes: [1])
-    defn product_neg_axis(t), do: Nx.product(t, axes: [-3])
-    defn product_pos_neg_axis(t), do: Nx.product(t, axes: [1, -3])
+    defn(product_pos_axis(t), do: Nx.product(t, axes: [1]))
+    defn(product_neg_axis(t), do: Nx.product(t, axes: [-3]))
+    defn(product_pos_neg_axis(t), do: Nx.product(t, axes: [1, -3]))
 
     test "computes the sum on a given axis" do
       t = Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]])
@@ -1129,7 +1135,7 @@ defmodule EXLA.DefnExprTest do
       assert product_pos_neg_axis(t) == Nx.product(t, axes: [1, -3])
     end
 
-    defn product_equal(t), do: Nx.product(Nx.equal(t, 1.0))
+    defn(product_equal(t), do: Nx.product(Nx.equal(t, 1.0)))
 
     test "does not overflow" do
       assert product_equal(Nx.tensor(1)) == Nx.tensor(1, type: {:u, 64})
@@ -1137,8 +1143,8 @@ defmodule EXLA.DefnExprTest do
       assert product_equal(Nx.tensor([1, 2, 3])) == Nx.tensor(0, type: {:u, 64})
     end
 
-    defn product_keep(t), do: Nx.product(t, keep_axes: true)
-    defn product_keep_2(t), do: Nx.product(t, axes: [0, 2], keep_axes: true)
+    defn(product_keep(t), do: Nx.product(t, keep_axes: true))
+    defn(product_keep_2(t), do: Nx.product(t, axes: [0, 2], keep_axes: true))
 
     test "keeps dimensions if keep_axes" do
       assert Nx.tensor([1, 2, 3]) |> product_keep() == Nx.tensor([6])
@@ -1150,7 +1156,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "mean" do
-    defn mean(t), do: Nx.mean(t)
+    defn(mean(t), do: Nx.mean(t))
 
     test "computes mean without axis" do
       assert mean(Nx.tensor(42)) == Nx.tensor(42.0)
@@ -1158,7 +1164,7 @@ defmodule EXLA.DefnExprTest do
       assert mean(Nx.tensor([1, 2, 3], type: {:u, 8})) == Nx.tensor(2.0, type: {:f, 32})
     end
 
-    defn mean_over_single_axis(t), do: Nx.mean(t, axes: [0])
+    defn(mean_over_single_axis(t), do: Nx.mean(t, axes: [0]))
 
     test "computes mean over a single axis" do
       assert mean_over_single_axis(Nx.tensor([1, 2, 3])) == Nx.tensor(2.0)
@@ -1170,7 +1176,7 @@ defmodule EXLA.DefnExprTest do
                ])
     end
 
-    defn mean_over_multiple_axes(t), do: Nx.mean(t, axes: [0, 2])
+    defn(mean_over_multiple_axes(t), do: Nx.mean(t, axes: [0, 2]))
 
     test "computes mean over multiple axes" do
       assert mean_over_multiple_axes(
@@ -1178,7 +1184,7 @@ defmodule EXLA.DefnExprTest do
              ) == Nx.tensor([5.0, 8.0])
     end
 
-    defn mean_over_negative_axis(t), do: Nx.mean(t, axes: [-1])
+    defn(mean_over_negative_axis(t), do: Nx.mean(t, axes: [-1]))
 
     test "computes mean over negative axes" do
       assert mean_over_negative_axis(
@@ -1186,7 +1192,7 @@ defmodule EXLA.DefnExprTest do
              ) == Nx.tensor([[2.0, 5.0], [8.0, 11.0]])
     end
 
-    defn mean_equal(t), do: Nx.mean(Nx.equal(t, 1.0))
+    defn(mean_equal(t), do: Nx.mean(Nx.equal(t, 1.0)))
 
     test "does not overflow" do
       assert mean_equal(Nx.tensor(1)) == Nx.tensor(1.0)
@@ -1194,8 +1200,8 @@ defmodule EXLA.DefnExprTest do
       assert mean_equal(Nx.tensor([1, 2, 3])) == Nx.tensor(0.3333333333333333)
     end
 
-    defn mean_keep(t), do: Nx.mean(t, keep_axes: true)
-    defn mean_keep_2(t), do: Nx.mean(t, axes: [0, 2], keep_axes: true)
+    defn(mean_keep(t), do: Nx.mean(t, keep_axes: true))
+    defn(mean_keep_2(t), do: Nx.mean(t, axes: [0, 2], keep_axes: true))
 
     test "keeps dimensions if keep_axes" do
       assert Nx.tensor([1, 2, 3]) |> mean_keep() == Nx.tensor([2.0])
@@ -1207,7 +1213,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "reduce_max" do
-    defn reduce_max(t), do: Nx.reduce_max(t)
+    defn(reduce_max(t), do: Nx.reduce_max(t))
 
     test "computes the maximum across types" do
       assert Nx.tensor([1, 2, 3]) |> reduce_max() == Nx.tensor(3)
@@ -1219,9 +1225,9 @@ defmodule EXLA.DefnExprTest do
                Nx.tensor(3, type: {:f, 32})
     end
 
-    defn reduce_max_pos_axis(t), do: Nx.reduce_max(t, axes: [1])
-    defn reduce_max_neg_axis(t), do: Nx.reduce_max(t, axes: [-3])
-    defn reduce_max_pos_neg_axis(t), do: Nx.reduce_max(t, axes: [1, -3])
+    defn(reduce_max_pos_axis(t), do: Nx.reduce_max(t, axes: [1]))
+    defn(reduce_max_neg_axis(t), do: Nx.reduce_max(t, axes: [-3]))
+    defn(reduce_max_pos_neg_axis(t), do: Nx.reduce_max(t, axes: [1, -3]))
 
     test "computes the max on a given axis" do
       t = Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]])
@@ -1230,8 +1236,8 @@ defmodule EXLA.DefnExprTest do
       assert reduce_max_pos_neg_axis(t) == Nx.reduce_max(t, axes: [1, -3])
     end
 
-    defn reduce_max_keep(t), do: Nx.reduce_max(t, keep_axes: true)
-    defn reduce_max_keep_2(t), do: Nx.reduce_max(t, axes: [0, 2], keep_axes: true)
+    defn(reduce_max_keep(t), do: Nx.reduce_max(t, keep_axes: true))
+    defn(reduce_max_keep_2(t), do: Nx.reduce_max(t, axes: [0, 2], keep_axes: true))
 
     test "keeps dimensions if keep_axes" do
       assert Nx.tensor([1, 2, 3]) |> reduce_max_keep() == Nx.tensor([3])
@@ -1243,7 +1249,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "reduce_min" do
-    defn reduce_min(t), do: Nx.reduce_min(t)
+    defn(reduce_min(t), do: Nx.reduce_min(t))
 
     test "computes the minimum across types" do
       assert Nx.tensor([1, 2, 3]) |> reduce_min() == Nx.tensor(1)
@@ -1255,9 +1261,9 @@ defmodule EXLA.DefnExprTest do
                Nx.tensor(1, type: {:f, 32})
     end
 
-    defn reduce_min_pos_axis(t), do: Nx.reduce_min(t, axes: [1])
-    defn reduce_min_neg_axis(t), do: Nx.reduce_min(t, axes: [-3])
-    defn reduce_min_pos_neg_axis(t), do: Nx.reduce_min(t, axes: [1, -3])
+    defn(reduce_min_pos_axis(t), do: Nx.reduce_min(t, axes: [1]))
+    defn(reduce_min_neg_axis(t), do: Nx.reduce_min(t, axes: [-3]))
+    defn(reduce_min_pos_neg_axis(t), do: Nx.reduce_min(t, axes: [1, -3]))
 
     test "computes the min on a given axis" do
       t = Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]])
@@ -1266,8 +1272,8 @@ defmodule EXLA.DefnExprTest do
       assert reduce_min_pos_neg_axis(t) == Nx.reduce_min(t, axes: [1, -3])
     end
 
-    defn reduce_min_keep(t), do: Nx.reduce_min(t, keep_axes: true)
-    defn reduce_min_keep_2(t), do: Nx.reduce_min(t, axes: [0, 2], keep_axes: true)
+    defn(reduce_min_keep(t), do: Nx.reduce_min(t, keep_axes: true))
+    defn(reduce_min_keep_2(t), do: Nx.reduce_min(t, axes: [0, 2], keep_axes: true))
 
     test "keeps dimensions if keep_axes" do
       assert Nx.tensor([1, 2, 3]) |> reduce_min_keep() == Nx.tensor([1])
@@ -1279,12 +1285,12 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "argmax/argmin" do
-    defn argmax(t), do: Nx.argmax(t)
-    defn argmin(t), do: Nx.argmin(t)
-    defn argmax_axis(t), do: Nx.argmax(t, axis: 1)
-    defn argmin_axis(t), do: Nx.argmin(t, axis: 1)
-    defn argmax_high(t), do: Nx.argmax(t, axis: 1, tie_break: :high)
-    defn argmin_high(t), do: Nx.argmin(t, axis: 1, tie_break: :high)
+    defn(argmax(t), do: Nx.argmax(t))
+    defn(argmin(t), do: Nx.argmin(t))
+    defn(argmax_axis(t), do: Nx.argmax(t, axis: 1))
+    defn(argmin_axis(t), do: Nx.argmin(t, axis: 1))
+    defn(argmax_high(t), do: Nx.argmax(t, axis: 1, tie_break: :high))
+    defn(argmin_high(t), do: Nx.argmin(t, axis: 1, tie_break: :high))
 
     test "computes the argmax across types" do
       assert argmax(Nx.tensor([1, 2, 3])) == Nx.tensor(2)
@@ -1323,13 +1329,15 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "window sum" do
-    defn window_sum1(t), do: Nx.window_sum(t, {1, 2, 1})
+    defn(window_sum1(t), do: Nx.window_sum(t, {1, 2, 1}))
 
-    defn window_sum2(t),
+    defn(window_sum2(t),
       do: Nx.window_sum(t, {2, 2, 1}, strides: [1, 2, 3], padding: [{0, 1}, {2, 0}, {1, 1}])
+    )
 
-    defn window_sum3(t),
+    defn(window_sum3(t),
       do: Nx.window_sum(t, {2, 1, 1}, strides: [2, 1, 1], padding: [{1, 1}, {0, 0}, {1, 1}])
+    )
 
     defn dilated_window_sum(t) do
       Nx.window_sum(t, {3, 2, 1}, strides: [1, 1, 1], padding: :same, window_dilations: [1, 2, 2])
@@ -1364,13 +1372,15 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "window mean" do
-    defn window_mean1(t), do: Nx.window_mean(t, {1, 2, 1})
+    defn(window_mean1(t), do: Nx.window_mean(t, {1, 2, 1}))
 
-    defn window_mean2(t),
+    defn(window_mean2(t),
       do: Nx.window_mean(t, {2, 2, 1}, strides: [1, 2, 3], padding: [{0, 1}, {2, 0}, {1, 1}])
+    )
 
-    defn window_mean3(t),
+    defn(window_mean3(t),
       do: Nx.window_mean(t, {2, 1, 1}, strides: [2, 1, 1], padding: [{1, 1}, {0, 0}, {1, 1}])
+    )
 
     defn dilated_window_mean(t) do
       Nx.window_mean(t, {3, 2, 1}, strides: [1, 1, 1], padding: :same, window_dilations: [1, 2, 2])
@@ -1408,13 +1418,15 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "window max" do
-    defn window_max1(t), do: Nx.window_max(t, {1, 2, 1})
+    defn(window_max1(t), do: Nx.window_max(t, {1, 2, 1}))
 
-    defn window_max2(t),
+    defn(window_max2(t),
       do: Nx.window_max(t, {2, 2, 1}, strides: [1, 2, 3], padding: [{0, 1}, {2, 0}, {1, 1}])
+    )
 
-    defn window_max3(t),
+    defn(window_max3(t),
       do: Nx.window_max(t, {2, 1, 1}, strides: [2, 1, 1], padding: [{1, 1}, {0, 0}, {1, 1}])
+    )
 
     defn dilated_window_max(t) do
       Nx.window_max(t, {3, 2, 1}, strides: [1, 1, 1], padding: :same, window_dilations: [1, 2, 2])
@@ -1464,13 +1476,15 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "window min" do
-    defn window_min1(t), do: Nx.window_min(t, {1, 2, 1})
+    defn(window_min1(t), do: Nx.window_min(t, {1, 2, 1}))
 
-    defn window_min2(t),
+    defn(window_min2(t),
       do: Nx.window_min(t, {2, 2, 1}, strides: [1, 2, 3], padding: [{0, 1}, {2, 0}, {1, 1}])
+    )
 
-    defn window_min3(t),
+    defn(window_min3(t),
       do: Nx.window_min(t, {2, 1, 1}, strides: [2, 1, 1], padding: [{1, 1}, {0, 0}, {1, 1}])
+    )
 
     defn dilated_window_min(t) do
       Nx.window_min(t, {3, 2, 1}, strides: [1, 1, 1], padding: :same, window_dilations: [1, 2, 2])
@@ -1520,13 +1534,15 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "window product" do
-    defn window_product1(t), do: Nx.window_product(t, {1, 2, 1})
+    defn(window_product1(t), do: Nx.window_product(t, {1, 2, 1}))
 
-    defn window_product2(t),
+    defn(window_product2(t),
       do: Nx.window_product(t, {2, 2, 1}, strides: [1, 2, 3], padding: [{0, 1}, {2, 0}, {1, 1}])
+    )
 
-    defn window_product3(t),
+    defn(window_product3(t),
       do: Nx.window_product(t, {2, 1, 1}, strides: [2, 1, 1], padding: [{1, 1}, {0, 0}, {1, 1}])
+    )
 
     defn dilated_window_product(t) do
       Nx.window_product(t, {3, 2, 1},
@@ -1565,7 +1581,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "dot product" do
-    defn dot(a, b), do: Nx.dot(a, b)
+    defn(dot(a, b), do: Nx.dot(a, b))
 
     test "computes the dot product of scalars" do
       assert dot(Nx.tensor(2), Nx.tensor(2)) == Nx.tensor(4)
@@ -1620,34 +1636,58 @@ defmodule EXLA.DefnExprTest do
                  type: {:s, 32}
                )
     end
+
+    defn(batched_dot(t1, t2), do: Nx.dot(t1, [1], [0], t2, [1], [0]))
+
+    test "computes a batched dot product" do
+      assert batched_dot(Nx.iota({3, 2, 3}, type: {:f, 32}), Nx.iota({3, 2, 2}, type: {:f, 32})) ==
+               Nx.tensor([
+                 [[6.0, 9.0], [8.0, 13.0], [10.0, 17.0]],
+                 [[78.0, 93.0], [88.0, 105.0], [98.0, 117.0]],
+                 [[246.0, 273.0], [264.0, 293.0], [282.0, 313.0]]
+               ])
+    end
+
+    defn(general_dot(t1, t2), do: Nx.dot(t1, [0, 1], [], t2, [1, 2], []))
+
+    test "computes a general dot product" do
+      assert general_dot(Nx.iota({4, 5, 2}, type: {:f, 32}), Nx.iota({2, 4, 5}, type: {:f, 32})) ==
+               Nx.tensor([[4940.0, 12540.0], [5130.0, 13130.0]])
+    end
   end
 
   describe "convolution" do
-    defn conv_valid_no_stride(inp, kernel), do: Nx.conv(inp, kernel)
+    defn(conv_valid_no_stride(inp, kernel), do: Nx.conv(inp, kernel))
 
-    defn conv_valid_stride(inp, kernel),
+    defn(conv_valid_stride(inp, kernel),
       do: Nx.conv(inp, kernel, strides: [2, 2], padding: :valid)
+    )
 
-    defn conv_same_no_stride(inp, kernel),
+    defn(conv_same_no_stride(inp, kernel),
       do: Nx.conv(inp, kernel, strides: [1, 1], padding: :same)
+    )
 
-    defn conv_same_stride(inp, kernel), do: Nx.conv(inp, kernel, strides: [3, 3], padding: :same)
+    defn(conv_same_stride(inp, kernel), do: Nx.conv(inp, kernel, strides: [3, 3], padding: :same))
 
-    defn conv_general_no_stride(inp, kernel),
+    defn(conv_general_no_stride(inp, kernel),
       do: Nx.conv(inp, kernel, strides: [1, 1], padding: [{-1, 2}, {3, -1}])
+    )
 
-    defn conv_general_stride(inp, kernel),
+    defn(conv_general_stride(inp, kernel),
       do: Nx.conv(inp, kernel, strides: [2, 1], padding: [{2, 2}, {-2, 4}])
+    )
 
-    defn conv_3d(inp, kernel), do: Nx.conv(inp, kernel, strides: [1, 2, 1], padding: :same)
+    defn(conv_3d(inp, kernel), do: Nx.conv(inp, kernel, strides: [1, 2, 1], padding: :same))
 
-    defn dilated_conv(inp, kernel),
+    defn(dilated_conv(inp, kernel),
       do: Nx.conv(inp, kernel, strides: [1, 1], padding: :same, kernel_dilation: [1, 2])
+    )
 
-    defn dilated_input_conv(inp, kernel),
+    defn(dilated_input_conv(inp, kernel),
       do: Nx.conv(inp, kernel, strides: [1, 1], padding: :same, input_dilation: [2, 1])
+    )
 
-    defn dilated_input_kernel_conv(inp, kernel),
+    defn(dilated_input_kernel_conv(inp, kernel),
       do:
         Nx.conv(inp, kernel,
           strides: [2, 1],
@@ -1655,12 +1695,15 @@ defmodule EXLA.DefnExprTest do
           kernel_dilation: [2, 1],
           input_dilation: [1, 2]
         )
+    )
 
-    defn grouped_conv_valid_no_stride(inp, kernel),
+    defn(grouped_conv_valid_no_stride(inp, kernel),
       do: Nx.conv(inp, kernel, strides: 1, padding: :valid, feature_group_size: 2)
+    )
 
-    defn grouped_conv_same_stride(inp, kernel),
+    defn(grouped_conv_same_stride(inp, kernel),
       do: Nx.conv(inp, kernel, strides: [2, 1, 2], padding: :same, feature_group_size: 4)
+    )
 
     defn conv_valid_no_stride_channels_last(inp, kernel) do
       Nx.conv(inp, kernel,
@@ -1907,7 +1950,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "outer product" do
-    defn outer(t1, t2), do: Nx.outer(t1, t2)
+    defn(outer(t1, t2), do: Nx.outer(t1, t2))
 
     test "computes the outer product of scalars" do
       assert outer(Nx.tensor(1), Nx.tensor(2)) == Nx.tensor([[2]])
@@ -1925,11 +1968,11 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "transpose" do
-    defn transpose(t), do: Nx.transpose(t)
-    defn transpose_scalar(t), do: Nx.transpose(t, axes: [])
-    defn transpose_perm1(t), do: Nx.transpose(t, axes: [2, 1, 0])
-    defn transpose_perm2(t), do: Nx.transpose(t, axes: [2, 0, 1])
-    defn transpose_perm3(t), do: Nx.transpose(t, axes: [0, 2, 1])
+    defn(transpose(t), do: Nx.transpose(t))
+    defn(transpose_scalar(t), do: Nx.transpose(t, axes: []))
+    defn(transpose_perm1(t), do: Nx.transpose(t, axes: [2, 1, 0]))
+    defn(transpose_perm2(t), do: Nx.transpose(t, axes: [2, 0, 1]))
+    defn(transpose_perm3(t), do: Nx.transpose(t, axes: [0, 2, 1]))
 
     test "transposes without axes" do
       assert transpose(Nx.tensor(1)) == Nx.tensor(1)
@@ -1981,7 +2024,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "softmax" do
-    defn softmax(t), do: Nx.exp(t) / Nx.sum(Nx.exp(t))
+    defn(softmax(t), do: Nx.exp(t) / Nx.sum(Nx.exp(t)))
 
     test "computes softmax" do
       assert compare_tensors!(
@@ -1997,13 +2040,13 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "reshape" do
-    defn reshape_with_shape(t), do: Nx.reshape(t, {2, 2})
+    defn(reshape_with_shape(t), do: Nx.reshape(t, {2, 2}))
 
     test "with shape" do
       assert reshape_with_shape(Nx.tensor([1, 2, 3, 4])) == Nx.tensor([[1, 2], [3, 4]])
     end
 
-    defn reshape_with_tensor(t, shape), do: Nx.reshape(t, shape)
+    defn(reshape_with_tensor(t, shape), do: Nx.reshape(t, shape))
 
     test "with tensor" do
       assert reshape_with_tensor(Nx.tensor([1, 2, 3, 4]), Nx.tensor([[0, 0], [0, 0]])) ==
@@ -2015,13 +2058,13 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "pad" do
-    defn pad_scalar(t), do: Nx.pad(t, 0, [])
-    defn pad_vector(t), do: Nx.pad(t, 0, [{1, 1, 0}])
-    defn pad_matrix(t), do: Nx.pad(t, 0, [{1, 1, 0}, {1, 1, 0}])
-    defn pad_tensor(t), do: Nx.pad(t, 0.0, [{1, 2, 0}, {1, 0, 0}, {0, 1, 0}])
-    defn pad_vector_negative_value(t), do: Nx.pad(t, 0.0, [{-1, -1, 0}])
-    defn pad_matrix_negative_value(t), do: Nx.pad(t, 0, [{0, 0, 0}, {-1, 1, 0}])
-    defn pad_tensor_negative_value(t), do: Nx.pad(t, 0, [{-1, 0, 0}, {-1, -1, 0}, {0, -1, 0}])
+    defn(pad_scalar(t), do: Nx.pad(t, 0, []))
+    defn(pad_vector(t), do: Nx.pad(t, 0, [{1, 1, 0}]))
+    defn(pad_matrix(t), do: Nx.pad(t, 0, [{1, 1, 0}, {1, 1, 0}]))
+    defn(pad_tensor(t), do: Nx.pad(t, 0.0, [{1, 2, 0}, {1, 0, 0}, {0, 1, 0}]))
+    defn(pad_vector_negative_value(t), do: Nx.pad(t, 0.0, [{-1, -1, 0}]))
+    defn(pad_matrix_negative_value(t), do: Nx.pad(t, 0, [{0, 0, 0}, {-1, 1, 0}]))
+    defn(pad_tensor_negative_value(t), do: Nx.pad(t, 0, [{-1, 0, 0}, {-1, -1, 0}, {0, -1, 0}]))
 
     test "with scalar" do
       assert pad_scalar(Nx.tensor(1)) == Nx.tensor(1)
@@ -2086,7 +2129,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "broadcast" do
-    defn broadcast_with_shape(t), do: Nx.broadcast(t, {2, 2})
+    defn(broadcast_with_shape(t), do: Nx.broadcast(t, {2, 2}))
 
     test "with shape" do
       assert broadcast_with_shape(Nx.tensor([1, 2])) == Nx.tensor([[1, 2], [1, 2]])
@@ -2094,7 +2137,7 @@ defmodule EXLA.DefnExprTest do
       assert broadcast_with_shape(Nx.tensor([[1], [2]])) == Nx.tensor([[1, 1], [2, 2]])
     end
 
-    defn broadcast_with_tensor(t, shape), do: Nx.broadcast(t, shape)
+    defn(broadcast_with_tensor(t, shape), do: Nx.broadcast(t, shape))
 
     test "with tensor" do
       tensors = [
@@ -2107,8 +2150,8 @@ defmodule EXLA.DefnExprTest do
       end
     end
 
-    defn broadcast_with_axes_2(t), do: Nx.broadcast(t, {3, 2}, axes: [0])
-    defn broadcast_with_axes_3(t), do: Nx.broadcast(t, {2, 3, 2}, axes: [1])
+    defn(broadcast_with_axes_2(t), do: Nx.broadcast(t, {3, 2}, axes: [0]))
+    defn(broadcast_with_axes_3(t), do: Nx.broadcast(t, {2, 3, 2}, axes: [1]))
 
     test "with axes" do
       assert broadcast_with_axes_2(Nx.tensor([1, 2, 3])) == Nx.tensor([[1, 1], [2, 2], [3, 3]])
@@ -2119,8 +2162,8 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "squeeze" do
-    defn squeeze(t), do: Nx.squeeze(t)
-    defn squeeze2(t), do: Nx.squeeze(t, axes: [0, 1])
+    defn(squeeze(t), do: Nx.squeeze(t))
+    defn(squeeze2(t), do: Nx.squeeze(t, axes: [0, 1]))
 
     test "with scalar" do
       assert squeeze(Nx.tensor(1)) == Nx.tensor(1)
@@ -2134,7 +2177,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "random uniform" do
-    defn random_uniform_fixed, do: Nx.random_uniform({30, 20})
+    defn(random_uniform_fixed, do: Nx.random_uniform({30, 20}))
 
     test "generates with shape" do
       t = random_uniform_fixed()
@@ -2146,8 +2189,8 @@ defmodule EXLA.DefnExprTest do
       end
     end
 
-    defn random_uniform_min_max_int, do: Nx.random_uniform({30, 20}, 5, 10)
-    defn random_uniform_min_max_float, do: Nx.random_uniform({30, 20}, 5.0, 10.0)
+    defn(random_uniform_min_max_int, do: Nx.random_uniform({30, 20}, 5, 10))
+    defn(random_uniform_min_max_float, do: Nx.random_uniform({30, 20}, 5.0, 10.0))
 
     test "generates with min/max" do
       t = random_uniform_min_max_int()
@@ -2167,8 +2210,8 @@ defmodule EXLA.DefnExprTest do
       end
     end
 
-    defn random_uniform_u32, do: Nx.random_uniform({30, 20}, 5, 10, type: {:u, 32})
-    defn random_uniform_f64, do: Nx.random_uniform({30, 20}, 5.0, 10.0, type: {:f, 64})
+    defn(random_uniform_u32, do: Nx.random_uniform({30, 20}, 5, 10, type: {:u, 32}))
+    defn(random_uniform_f64, do: Nx.random_uniform({30, 20}, 5.0, 10.0, type: {:f, 64}))
 
     test "generates with type" do
       t = random_uniform_u32()
@@ -2188,7 +2231,7 @@ defmodule EXLA.DefnExprTest do
       end
     end
 
-    defn random_uniform_tensor(min, max), do: Nx.random_uniform({30, 20}, min, max)
+    defn(random_uniform_tensor(min, max), do: Nx.random_uniform({30, 20}, min, max))
 
     test "generates with min/max tensor" do
       t = random_uniform_tensor(Nx.tensor(-100.0), Nx.tensor(100.0))
@@ -2198,7 +2241,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "random normal" do
-    defn random_normal_fixed, do: Nx.random_normal({30, 20})
+    defn(random_normal_fixed, do: Nx.random_normal({30, 20}))
 
     test "generates with shape" do
       t = random_uniform_fixed()
@@ -2206,7 +2249,7 @@ defmodule EXLA.DefnExprTest do
       assert Nx.type(t) == {:f, 32}
     end
 
-    defn random_normal_mu_sigma, do: Nx.random_normal({30, 20}, 5.0, 10.0)
+    defn(random_normal_mu_sigma, do: Nx.random_normal({30, 20}, 5.0, 10.0))
 
     test "generates with mu/sigma" do
       t = random_normal_mu_sigma()
@@ -2214,7 +2257,7 @@ defmodule EXLA.DefnExprTest do
       assert Nx.type(t) == {:f, 32}
     end
 
-    defn random_normal_f64, do: Nx.random_normal({30, 20}, 5.0, 10.0, type: {:f, 64})
+    defn(random_normal_f64, do: Nx.random_normal({30, 20}, 5.0, 10.0, type: {:f, 64}))
 
     test "generates with type" do
       t = random_normal_f64()
@@ -2222,7 +2265,7 @@ defmodule EXLA.DefnExprTest do
       assert Nx.type(t) == {:f, 64}
     end
 
-    defn random_normal_tensor(mu, sigma), do: Nx.random_normal({30, 20}, mu, sigma)
+    defn(random_normal_tensor(mu, sigma), do: Nx.random_normal({30, 20}, mu, sigma))
 
     test "generates with tensor mu/sigma" do
       t = random_normal_tensor(Nx.tensor(1.0), Nx.tensor(1.0))
@@ -2232,25 +2275,25 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "iota" do
-    defn iota_with_shape, do: Nx.iota({3, 4, 2, 3}, axis: 2)
+    defn(iota_with_shape, do: Nx.iota({3, 4, 2, 3}, axis: 2))
 
     test "generates with shape" do
       assert iota_with_shape() == Nx.iota({3, 4, 2, 3}, axis: 2)
     end
 
-    defn iota_with_type, do: Nx.iota({1, 2, 3}, axis: 1, type: {:f, 32})
+    defn(iota_with_type, do: Nx.iota({1, 2, 3}, axis: 1, type: {:f, 32}))
 
     test "generates with type" do
       assert iota_with_type() == Nx.iota({1, 2, 3}, axis: 1, type: {:f, 32})
     end
 
-    defn iota_no_axis, do: Nx.iota({2, 2, 2})
+    defn(iota_no_axis, do: Nx.iota({2, 2, 2}))
 
     test "generates without axis" do
       assert iota_no_axis() == Nx.iota({2, 2, 2})
     end
 
-    defn iota_neg_axis, do: Nx.iota({2, 2, 2}, axis: -2)
+    defn(iota_neg_axis, do: Nx.iota({2, 2, 2}, axis: -2))
 
     test "generates with negative axis" do
       assert iota_neg_axis() == Nx.iota({2, 2, 2}, axis: -2)
@@ -2258,13 +2301,13 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "eye" do
-    defn eye, do: Nx.eye(2)
+    defn(eye, do: Nx.eye(2))
 
     test "generates with shape" do
       assert eye() == Nx.tensor([[1, 0], [0, 1]])
     end
 
-    defn eye_with_type, do: Nx.eye(1, type: {:f, 32})
+    defn(eye_with_type, do: Nx.eye(1, type: {:f, 32}))
 
     test "generates with type" do
       assert eye_with_type() == Nx.tensor([[1]], type: {:f, 32})
@@ -2272,9 +2315,9 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "clip" do
-    defn clip_both(value), do: Nx.clip(value, 2, 4)
-    defn clip_mixed_types(value), do: Nx.clip(value, 2.0, 3)
-    defn clip_with_tensor(value), do: Nx.clip(value, Nx.tensor(2.0), Nx.max(1.0, 3.0))
+    defn(clip_both(value), do: Nx.clip(value, 2, 4))
+    defn(clip_mixed_types(value), do: Nx.clip(value, 2.0, 3))
+    defn(clip_with_tensor(value), do: Nx.clip(value, Nx.tensor(2.0), Nx.max(1.0, 3.0)))
 
     test "works with both set" do
       assert clip_both(Nx.tensor([[1, 2, 3], [4, 5, 6]])) == Nx.tensor([[2, 2, 3], [4, 4, 4]])
@@ -2297,9 +2340,9 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "slicing" do
-    defn slice1(t), do: Nx.slice(t, [0, 6, 2], [2, 1, 3])
-    defn slice2(t), do: Nx.slice(t, [1, 4, 10], [1, 1, 10], strides: [1, 2, 3])
-    defn slice3(t), do: Nx.slice(t, [0, 4, 11], [2, 3, 9], strides: [2, 1, 3])
+    defn(slice1(t), do: Nx.slice(t, [0, 6, 2], [2, 1, 3]))
+    defn(slice2(t), do: Nx.slice(t, [1, 4, 10], [1, 1, 10], strides: [1, 2, 3]))
+    defn(slice3(t), do: Nx.slice(t, [0, 4, 11], [2, 3, 9], strides: [2, 1, 3]))
 
     test "works without stride" do
       t = Nx.iota({900})
@@ -2324,10 +2367,10 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "reverse" do
-    defn reverse(t), do: Nx.reverse(t)
-    defn reverse1(t), do: Nx.reverse(t, axes: [1])
-    defn reverse2(t), do: Nx.reverse(t, axes: [0, 2])
-    defn reverse3(t), do: Nx.reverse(t, axes: [1, 2, 4])
+    defn(reverse(t), do: Nx.reverse(t))
+    defn(reverse1(t), do: Nx.reverse(t, axes: [1]))
+    defn(reverse2(t), do: Nx.reverse(t, axes: [0, 2]))
+    defn(reverse3(t), do: Nx.reverse(t, axes: [1, 2, 4]))
 
     test "works on all dims" do
       assert reverse(Nx.iota({10})) == Nx.tensor([9, 8, 7, 6, 5, 4, 3, 2, 1, 0])
@@ -2407,10 +2450,10 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "concatenate" do
-    defn concatenate0(t1, t2, t3), do: Nx.concatenate([t1, t2, t3], axis: 0)
-    defn concatenate1(t1, t2, t3), do: Nx.concatenate([t1, t2, t3], axis: 1)
-    defn concatenate2(t1, t2, t3), do: Nx.concatenate([t1, t2, t3], axis: 2)
-    defn concatenate1_inp(t1), do: Nx.concatenate([t1], axis: 2)
+    defn(concatenate0(t1, t2, t3), do: Nx.concatenate([t1, t2, t3], axis: 0))
+    defn(concatenate1(t1, t2, t3), do: Nx.concatenate([t1, t2, t3], axis: 1))
+    defn(concatenate2(t1, t2, t3), do: Nx.concatenate([t1, t2, t3], axis: 2))
+    defn(concatenate1_inp(t1), do: Nx.concatenate([t1], axis: 2))
 
     test "works 0th axis" do
       t1 = Nx.iota({2, 2, 2})
@@ -2539,7 +2582,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "decompositions" do
-    defn ts(a, b), do: Nx.LinAlg.triangular_solve(a, b)
+    defn(ts(a, b), do: Nx.LinAlg.triangular_solve(a, b))
 
     test "triangular_solve" do
       a = Nx.tensor([[3, 0, 0, 0], [2, 1, 0, 0], [1, 0, 1, 0], [1, 1, 1, 1]])
@@ -2547,8 +2590,8 @@ defmodule EXLA.DefnExprTest do
       assert compare_tensors!(Nx.dot(a, ts(a, b)), b)
     end
 
-    defn qr(t), do: Nx.LinAlg.qr(t)
-    defn qr_complete(t), do: Nx.LinAlg.qr(t, mode: :complete)
+    defn(qr(t), do: Nx.LinAlg.qr(t))
+    defn(qr_complete(t), do: Nx.LinAlg.qr(t, mode: :complete))
 
     test "qr" do
       input = Nx.iota({3, 2})
@@ -2565,7 +2608,7 @@ defmodule EXLA.DefnExprTest do
       assert compare_tensors!(Nx.dot(q, r), output)
     end
 
-    defn svd(t), do: Nx.LinAlg.svd(t)
+    defn(svd(t), do: Nx.LinAlg.svd(t))
 
     test "svd" do
       input = Nx.iota({3, 3})
@@ -2585,10 +2628,10 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "sort" do
-    defn sort0(t), do: Nx.sort(t, axis: 0)
-    defn sort1(t), do: Nx.sort(t, axis: 1)
-    defn sort1_asc(t), do: Nx.sort(t, axis: 1, comparator: :asc)
-    defn sort2(t), do: Nx.sort(t, axis: 2)
+    defn(sort0(t), do: Nx.sort(t, axis: 0))
+    defn(sort1(t), do: Nx.sort(t, axis: 1))
+    defn(sort1_asc(t), do: Nx.sort(t, axis: 1, comparator: :asc))
+    defn(sort2(t), do: Nx.sort(t, axis: 2))
 
     test "sorts a 1d tensor" do
       assert sort0(Nx.tensor([0, 5, 2, 1, 3, 4])) == Nx.tensor([0, 1, 2, 3, 4, 5])
@@ -2626,10 +2669,10 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "argsort" do
-    defn argsort0(t), do: Nx.argsort(t, axis: 0)
-    defn argsort1(t), do: Nx.argsort(t, axis: 1)
-    defn argsort1_asc(t), do: Nx.argsort(t, axis: 1, comparator: :asc)
-    defn argsort2(t), do: Nx.argsort(t, axis: 2)
+    defn(argsort0(t), do: Nx.argsort(t, axis: 0))
+    defn(argsort1(t), do: Nx.argsort(t, axis: 1))
+    defn(argsort1_asc(t), do: Nx.argsort(t, axis: 1, comparator: :asc))
+    defn(argsort2(t), do: Nx.argsort(t, axis: 2))
 
     test "sorts a 1d tensor and returns its indices" do
       assert argsort0(Nx.tensor([0, 5, 2, 1, 3, 4])) == Nx.tensor([0, 3, 2, 4, 5, 1])
@@ -2672,7 +2715,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "cholesky" do
-    defn cholesky(t), do: Nx.LinAlg.cholesky(t)
+    defn(cholesky(t), do: Nx.LinAlg.cholesky(t))
 
     test "works on 2x2 matrix" do
       lhs = cholesky(Nx.tensor([[20.0, 17.6], [17.6, 16.0]]))
@@ -2712,7 +2755,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "bfloat16" do
-    defn add(t1, t2), do: t1 + t2
+    defn(add(t1, t2), do: t1 + t2)
 
     test "accepts bfloat16 input" do
       lhs = Nx.tensor([1.0, 2.0, 3.0], type: {:bf, 16})
@@ -2723,10 +2766,10 @@ defmodule EXLA.DefnExprTest do
 
   describe "precision" do
     @defn_compiler {EXLA, precision: :bad}
-    defn bad_precision(t1, t2), do: Nx.dot(t1, t2)
+    defn(bad_precision(t1, t2), do: Nx.dot(t1, t2))
 
     @defn_compiler {EXLA, precision: :high}
-    defn good_precision(t1, t2), do: Nx.dot(t1, t2)
+    defn(good_precision(t1, t2), do: Nx.dot(t1, t2))
 
     test "raises on bad precision" do
       assert_raise ArgumentError,

--- a/exla/test/exla/defn_expr_test.exs
+++ b/exla/test/exla/defn_expr_test.exs
@@ -5,7 +5,7 @@ defmodule EXLA.DefnExprTest do
   @default_defn_compiler EXLA
 
   describe "tuples" do
-    defn(add_subtract_tuple(a, b), do: {a + b, a - b})
+    defn add_subtract_tuple(a, b), do: {a + b, a - b}
 
     test "on results" do
       assert add_subtract_tuple(2, 3) == {Nx.tensor(5), Nx.tensor(-1)}
@@ -14,7 +14,7 @@ defmodule EXLA.DefnExprTest do
                {Nx.tensor([9, 10, 11]), Nx.tensor([-11, -10, -9])}
     end
 
-    defn(pattern_tuple({a, b}), do: a + b)
+    defn pattern_tuple({a, b}), do: a + b
 
     test "on patterns" do
       assert pattern_tuple({2, 3}) == Nx.tensor(5)
@@ -23,7 +23,7 @@ defmodule EXLA.DefnExprTest do
                Nx.tensor([[4, 5], [5, 6]])
     end
 
-    defn(calls_pattern_tuple(a, b), do: pattern_tuple({a, b}))
+    defn calls_pattern_tuple(a, b), do: pattern_tuple({a, b})
 
     test "on inlined tuples" do
       assert calls_pattern_tuple(2, 3) == Nx.tensor(5)
@@ -35,10 +35,10 @@ defmodule EXLA.DefnExprTest do
 
   describe "tensor constants" do
     @two 2
-    defn(add_two_attribute(t), do: t + @two)
+    defn add_two_attribute(t), do: t + @two
 
     @two_per_two Nx.tensor([[1, 2], [3, 4]])
-    defn(add_2x2_attribute(t), do: t + @two_per_two)
+    defn add_2x2_attribute(t), do: t + @two_per_two
 
     test "expands module attributes to scalars" do
       assert add_two_attribute(1) == Nx.tensor(3)
@@ -52,9 +52,9 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "+/2" do
-    defn(add_two(a, b), do: a + b)
+    defn add_two(a, b), do: a + b
     @defn_compiler Nx.Defn.Evaluator
-    defn(add_two_nx(a, b), do: a + b)
+    defn add_two_nx(a, b), do: a + b
 
     test "same shape and type" do
       assert add_two(1.0, 2.0) == Nx.tensor(3.0)
@@ -92,8 +92,8 @@ defmodule EXLA.DefnExprTest do
       end
     end
 
-    defn(add_two_int(t), do: t + 2)
-    defn(add_two_float(t), do: t + 2.0)
+    defn add_two_int(t), do: t + 2
+    defn add_two_float(t), do: t + 2.0
 
     test "constants" do
       tensors = [
@@ -143,7 +143,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "//2" do
-    defn(divide_two(a, b), do: a / b)
+    defn divide_two(a, b), do: a / b
 
     test "parameters" do
       tensors = [
@@ -161,8 +161,8 @@ defmodule EXLA.DefnExprTest do
       end
     end
 
-    defn(divide_two_int(t), do: t / 2)
-    defn(divide_two_float(t), do: t / 2.0)
+    defn divide_two_int(t), do: t / 2
+    defn divide_two_float(t), do: t / 2.0
 
     test "constants" do
       tensors = [
@@ -183,7 +183,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "remainder" do
-    defn(remainder(a, b), do: Nx.remainder(a, b))
+    defn remainder(a, b), do: Nx.remainder(a, b)
 
     test "integers" do
       left = Nx.tensor([-1023, 1023])
@@ -210,7 +210,7 @@ defmodule EXLA.DefnExprTest do
       {Nx.tensor([[1], [2]], type: {:f, 32}), Nx.tensor([[10, 20]], type: {:f, 32})}
     ]
 
-    defn(subtract_two(a, b), do: a - b)
+    defn subtract_two(a, b), do: a - b
 
     test "-" do
       for {left, right} <- @tensors do
@@ -219,7 +219,7 @@ defmodule EXLA.DefnExprTest do
       end
     end
 
-    defn(multiply_two(a, b), do: a * b)
+    defn multiply_two(a, b), do: a * b
 
     test "*" do
       for {left, right} <- @tensors do
@@ -228,7 +228,7 @@ defmodule EXLA.DefnExprTest do
       end
     end
 
-    defn(unary_minus(a), do: -a)
+    defn unary_minus(a), do: -a
 
     test "negate" do
       for t <- [
@@ -240,7 +240,7 @@ defmodule EXLA.DefnExprTest do
       end
     end
 
-    defn(max_two(a, b), do: max(a, b))
+    defn max_two(a, b), do: max(a, b)
 
     test "max" do
       for {left, right} <- @tensors do
@@ -249,7 +249,7 @@ defmodule EXLA.DefnExprTest do
       end
     end
 
-    defn(min_two(a, b), do: min(a, b))
+    defn min_two(a, b), do: min(a, b)
 
     test "min" do
       for {left, right} <- @tensors do
@@ -258,7 +258,7 @@ defmodule EXLA.DefnExprTest do
       end
     end
 
-    defn(power_two(a, b), do: Nx.power(a, b))
+    defn power_two(a, b), do: Nx.power(a, b)
 
     test "power" do
       for {left, right} <- @tensors do
@@ -267,7 +267,7 @@ defmodule EXLA.DefnExprTest do
       end
     end
 
-    defn(atan2_two(a, b), do: Nx.atan2(a, b))
+    defn atan2_two(a, b), do: Nx.atan2(a, b)
 
     test "atan2" do
       <<neg_zero::float>> = <<0x8000000000000000::64>>
@@ -278,7 +278,7 @@ defmodule EXLA.DefnExprTest do
       compare_tensors!(atan2_two(right, left), Nx.atan2(right, left))
     end
 
-    defn(quotient_two(a, b), do: Nx.quotient(a, b))
+    defn quotient_two(a, b), do: Nx.quotient(a, b)
 
     test "quotient" do
       int_tensors = [
@@ -301,35 +301,35 @@ defmodule EXLA.DefnExprTest do
     @left Nx.tensor([-2, -1, 0, 1, 2])
     @right Nx.tensor([[-2], [-1], [0], [1], [2]])
 
-    defn(bitwise_and(a, b), do: a &&& b)
+    defn bitwise_and(a, b), do: a &&& b
 
     test "bitwise_and" do
       assert Nx.shape(bitwise_and(@left, @right)) == {5, 5}
       assert bitwise_and(@left, @right) == Nx.bitwise_and(@left, @right)
     end
 
-    defn(bitwise_or(a, b), do: a ||| b)
+    defn bitwise_or(a, b), do: a ||| b
 
     test "bitwise_or" do
       assert Nx.shape(bitwise_or(@left, @right)) == {5, 5}
       assert bitwise_or(@left, @right) == Nx.bitwise_or(@left, @right)
     end
 
-    defn(bitwise_not(a), do: ~~~a)
+    defn bitwise_not(a), do: ~~~a
 
     test "bitwise_not" do
       assert Nx.shape(bitwise_not(@left)) == {5}
       assert bitwise_not(@left) == Nx.bitwise_not(@left)
     end
 
-    defn(bitwise_pc(a), do: Nx.population_count(a))
+    defn bitwise_pc(a), do: Nx.population_count(a)
 
     test "population_count" do
       assert Nx.shape(bitwise_pc(@left)) == {5}
       assert bitwise_pc(@left) == Nx.population_count(@left)
     end
 
-    defn(bitwise_clz(a), do: Nx.count_leading_zeros(a))
+    defn bitwise_clz(a), do: Nx.count_leading_zeros(a)
 
     test "count_leading_zeros" do
       assert Nx.shape(bitwise_clz(@left)) == {5}
@@ -339,7 +339,7 @@ defmodule EXLA.DefnExprTest do
     @left Nx.tensor([-2, -1, 0, 1, 2])
     @right Nx.tensor([[0], [1], [2], [3], [4]])
 
-    defn(left_shift(a, b), do: a <<< b)
+    defn left_shift(a, b), do: a <<< b
 
     test "left_shift" do
       assert Nx.shape(left_shift(@left, @right)) == {5, 5}
@@ -352,7 +352,7 @@ defmodule EXLA.DefnExprTest do
     @left_unsigned Nx.tensor([0, 1, 2, 253, 254, 255], type: {:u, 8})
     @right_unsigned Nx.tensor([[0], [1], [2], [3], [4], [5]], type: {:u, 8})
 
-    defn(right_shift(a, b), do: a >>> b)
+    defn right_shift(a, b), do: a >>> b
 
     test "right_shift" do
       assert Nx.shape(right_shift(@left_signed, @right_signed)) == {9, 9}
@@ -368,7 +368,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "exp" do
-    defn(exp(t), do: Nx.exp(t))
+    defn exp(t), do: Nx.exp(t)
 
     test "computes the exp across types" do
       assert Nx.tensor([1, 2, 3]) |> exp() ==
@@ -389,7 +389,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "equal" do
-    defn(equal(a, b), do: Nx.equal(a, b))
+    defn equal(a, b), do: Nx.equal(a, b)
 
     test "computes equality of scalars" do
       assert equal(Nx.tensor(1), Nx.tensor(2)) == Nx.tensor(0, type: {:u, 8})
@@ -406,7 +406,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "not equal" do
-    defn(not_equal(a, b), do: Nx.not_equal(a, b))
+    defn not_equal(a, b), do: Nx.not_equal(a, b)
 
     test "computes equality of scalars" do
       assert not_equal(Nx.tensor(1), Nx.tensor(2)) == Nx.tensor(1, type: {:u, 8})
@@ -423,7 +423,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "less" do
-    defn(less(a, b), do: Nx.less(a, b))
+    defn less(a, b), do: Nx.less(a, b)
 
     test "compares scalars" do
       assert less(Nx.tensor(1), Nx.tensor(2)) == Nx.tensor(1, type: {:u, 8})
@@ -440,7 +440,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "greater" do
-    defn(greater(a, b), do: Nx.greater(a, b))
+    defn greater(a, b), do: Nx.greater(a, b)
 
     test "compares scalars" do
       assert greater(Nx.tensor(1), Nx.tensor(2)) == Nx.tensor(0, type: {:u, 8})
@@ -457,7 +457,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "less equal" do
-    defn(less_equal(a, b), do: Nx.less_equal(a, b))
+    defn less_equal(a, b), do: Nx.less_equal(a, b)
 
     test "compares scalars" do
       assert less_equal(Nx.tensor(1), Nx.tensor(2)) == Nx.tensor(1, type: {:u, 8})
@@ -474,7 +474,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "greater equal" do
-    defn(greater_equal(a, b), do: Nx.greater_equal(a, b))
+    defn greater_equal(a, b), do: Nx.greater_equal(a, b)
 
     test "compares scalars" do
       assert greater_equal(Nx.tensor(1), Nx.tensor(2)) == Nx.tensor(0, type: {:u, 8})
@@ -492,7 +492,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "logical" do
-    defn(logical_and(a, b), do: Nx.logical_and(a, b))
+    defn logical_and(a, b), do: Nx.logical_and(a, b)
 
     test "and" do
       assert logical_and(Nx.tensor([-1, 0, 1]), Nx.tensor([[-1], [0], [1]])) ==
@@ -516,7 +516,7 @@ defmodule EXLA.DefnExprTest do
                )
     end
 
-    defn(logical_or(a, b), do: Nx.logical_or(a, b))
+    defn logical_or(a, b), do: Nx.logical_or(a, b)
 
     test "or" do
       assert logical_or(Nx.tensor([-1, 0, 1]), Nx.tensor([[-1], [0], [1]])) ==
@@ -540,7 +540,7 @@ defmodule EXLA.DefnExprTest do
                )
     end
 
-    defn(logical_xor(a, b), do: Nx.logical_xor(a, b))
+    defn logical_xor(a, b), do: Nx.logical_xor(a, b)
 
     test "xor" do
       assert logical_xor(Nx.tensor([-1, 0, 1]), Nx.tensor([[-1], [0], [1]])) ==
@@ -566,7 +566,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "select" do
-    defn(select(pred, x, y), do: Nx.select(pred, x, y))
+    defn select(pred, x, y), do: Nx.select(pred, x, y)
 
     test "selects one or the other with a scalar" do
       assert select(Nx.tensor(1), Nx.tensor([1, 2, 3]), Nx.tensor([4, 5, 6])) ==
@@ -607,9 +607,9 @@ defmodule EXLA.DefnExprTest do
             [:tan, :acosh, :asinh, :cosh, :sinh, :erf, :erfc] do
       exla_fun = :"unary_#{fun}"
       nx_fun = :"unary_#{fun}_nx"
-      defn(unquote(exla_fun)(t), do: Nx.unquote(fun)(t))
+      defn unquote(exla_fun)(t), do: Nx.unquote(fun)(t)
       @defn_compiler Nx.Defn.Evaluator
-      defn(unquote(nx_fun)(t), do: Nx.unquote(fun)(t))
+      defn unquote(nx_fun)(t), do: Nx.unquote(fun)(t)
 
       test "#{fun}" do
         compare_tensors!(unquote(exla_fun)(@float_tensor), unquote(nx_fun)(@float_tensor))
@@ -625,9 +625,9 @@ defmodule EXLA.DefnExprTest do
     for fun <- [:atanh, :acos, :asin, :atan, :erf_inv] do
       exla_fun = :"unary_#{fun}"
       nx_fun = :"unary_#{fun}_nx"
-      defn(unquote(exla_fun)(t), do: Nx.unquote(fun)(t))
+      defn unquote(exla_fun)(t), do: Nx.unquote(fun)(t)
       @defn_compiler Nx.Defn.Evaluator
-      defn(unquote(nx_fun)(t), do: Nx.unquote(fun)(t))
+      defn unquote(nx_fun)(t), do: Nx.unquote(fun)(t)
 
       test "#{fun}" do
         compare_tensors!(unquote(exla_fun)(@float_tensor), unquote(nx_fun)(@float_tensor))
@@ -646,9 +646,9 @@ defmodule EXLA.DefnExprTest do
     for fun <- funs do
       exla_fun = :"unary_#{fun}"
       nx_fun = :"unary_#{fun}_nx"
-      defn(unquote(exla_fun)(t), do: Nx.unquote(fun)(t))
+      defn unquote(exla_fun)(t), do: Nx.unquote(fun)(t)
       @defn_compiler Nx.Defn.Evaluator
-      defn(unquote(nx_fun)(t), do: Nx.unquote(fun)(t))
+      defn unquote(nx_fun)(t), do: Nx.unquote(fun)(t)
 
       test "#{fun}" do
         compare_tensors!(unquote(exla_fun)(@uint_tensor), unquote(nx_fun)(@uint_tensor))
@@ -659,7 +659,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "as_type" do
-    defn(to_float(t), do: Nx.as_type(t, {:f, 32}))
+    defn to_float(t), do: Nx.as_type(t, {:f, 32})
 
     test "converts tensor type" do
       assert to_float(Nx.tensor([1, 2, 3])) == Nx.tensor([1.0, 2.0, 3.0], type: {:f, 32})
@@ -667,7 +667,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "bitcast" do
-    defn(bitcast_to_float(t), do: Nx.bitcast(t, {:f, 32}))
+    defn bitcast_to_float(t), do: Nx.bitcast(t, {:f, 32})
 
     test "converts tensor type" do
       assert bitcast_to_float(Nx.tensor([0, 0, 0], type: {:s, 32})) == Nx.tensor([0.0, 0.0, 0.0])
@@ -675,7 +675,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "if" do
-    defn(if3(a, b, c), do: if(a, do: b, else: c))
+    defn if3(a, b, c), do: if(a, do: b, else: c)
 
     test "one param per branch" do
       assert if3(Nx.tensor(0), Nx.tensor(1, type: {:s, 16}), Nx.tensor(2, type: {:f, 32})) ==
@@ -694,7 +694,7 @@ defmodule EXLA.DefnExprTest do
                Nx.tensor([[1, 2], [1, 2]])
     end
 
-    defn(if_params(a, b, c), do: if(a, do: b + c, else: b - c))
+    defn if_params(a, b, c), do: if(a, do: b + c, else: b - c)
 
     test "two params per branch" do
       assert if_params(Nx.tensor(0), Nx.tensor(1), Nx.tensor(2)) == Nx.tensor(-1)
@@ -711,7 +711,7 @@ defmodule EXLA.DefnExprTest do
       assert if_shared(Nx.tensor(2), Nx.tensor(1), Nx.tensor(2)) == Nx.tensor(12)
     end
 
-    defn(if_tuple(a, b, c), do: if(a, do: {{a, b}, c}, else: {{c, b}, a}))
+    defn if_tuple(a, b, c), do: if(a, do: {{a, b}, c}, else: {{c, b}, a})
 
     test "with tuples" do
       assert if_tuple(Nx.tensor(0), Nx.tensor(10), Nx.tensor(20)) ==
@@ -752,7 +752,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "metadata" do
-    defn(add_with_stop_grad(a, b), do: stop_grad(Nx.add(a, b)))
+    defn add_with_stop_grad(a, b), do: stop_grad(Nx.add(a, b))
 
     test "ignores metadata nodes" do
       assert add_with_stop_grad(1, 2) == Nx.tensor(3)
@@ -792,9 +792,9 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "map" do
-    defn(map_plus(t), do: Nx.map(t, fn x -> x + 1 end))
-    defn(map_equal(t), do: Nx.map(t, [type: {:f, 64}], fn x -> Nx.equal(x, 1) end))
-    defn(map_exp(t), do: Nx.map(t, [type: {:f, 64}], fn x -> Nx.exp(x) end))
+    defn map_plus(t), do: Nx.map(t, fn x -> x + 1 end)
+    defn map_equal(t), do: Nx.map(t, [type: {:f, 64}], fn x -> Nx.equal(x, 1) end)
+    defn map_exp(t), do: Nx.map(t, [type: {:f, 64}], fn x -> Nx.exp(x) end)
 
     test "maps a function over the tensor" do
       assert map_plus(Nx.tensor([[1, 2, 3], [4, 5, 6]])) == Nx.tensor([[2, 3, 4], [5, 6, 7]])
@@ -816,12 +816,11 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "reduce" do
-    defn(reduce(t), do: Nx.reduce(t, 1, fn a, b -> a * b end))
-    defn(reduce_keep(t), do: Nx.reduce(t, 1, [keep_axes: true], fn a, b -> a * b end))
+    defn reduce(t), do: Nx.reduce(t, 1, fn a, b -> a * b end)
+    defn reduce_keep(t), do: Nx.reduce(t, 1, [keep_axes: true], fn a, b -> a * b end)
 
-    defn(reduce_keep_2(t),
+    defn reduce_keep_2(t),
       do: Nx.reduce(t, 1, [keep_axes: true, axes: [0, 2]], fn a, b -> a * b end)
-    )
 
     test "computes the reduce" do
       assert Nx.tensor([1, 2, 3]) |> reduce() == Nx.tensor(6)
@@ -842,25 +841,20 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "reduce window" do
-    defn(reduce_window_valid_no_stride(t),
+    defn reduce_window_valid_no_stride(t),
       do: Nx.reduce_window(t, 0, {2, 2}, fn a, b -> a + b end)
-    )
 
-    defn(reduce_window_valid_stride(t),
+    defn reduce_window_valid_stride(t),
       do: Nx.reduce_window(t, 0, {2, 2}, [strides: [2, 2]], fn a, b -> a + b end)
-    )
 
-    defn(reduce_window_same_no_stride(t),
+    defn reduce_window_same_no_stride(t),
       do: Nx.reduce_window(t, 0, {2, 2}, [padding: :same], fn a, b -> a + b end)
-    )
 
-    defn(reduce_window_same_stride(t),
+    defn reduce_window_same_stride(t),
       do: Nx.reduce_window(t, 0, {2, 2}, [padding: :same, strides: [2, 1]], fn a, b -> a + b end)
-    )
 
-    defn(reduce_window_general_no_stride(t),
+    defn reduce_window_general_no_stride(t),
       do: Nx.reduce_window(t, 0, {2, 2}, [padding: [{2, 1}, {1, 2}]], fn a, b -> a + b end)
-    )
 
     defn reduce_window_general_stride(t) do
       Nx.reduce_window(t, 0, {2, 2}, [padding: [{1, 2}, {2, 1}], strides: [2, 1]], fn a, b ->
@@ -1034,9 +1028,9 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "all?" do
-    defn(all?(t), do: Nx.all?(t))
-    defn(all_axis_0?(t), do: Nx.all?(t, axes: [0]))
-    defn(all_axis_1?(t), do: Nx.all?(t, axes: [1]))
+    defn all?(t), do: Nx.all?(t)
+    defn all_axis_0?(t), do: Nx.all?(t, axes: [0])
+    defn all_axis_1?(t), do: Nx.all?(t, axes: [1])
 
     test "computes the bitwise and across types" do
       assert all?(Nx.tensor([1, 2, 3])) == Nx.tensor(1, type: {:u, 8})
@@ -1053,9 +1047,9 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "any?" do
-    defn(any?(t), do: Nx.any?(t))
-    defn(any_axis_0?(t), do: Nx.any?(t, axes: [0]))
-    defn(any_axis_1?(t), do: Nx.any?(t, axes: [1]))
+    defn any?(t), do: Nx.any?(t)
+    defn any_axis_0?(t), do: Nx.any?(t, axes: [0])
+    defn any_axis_1?(t), do: Nx.any?(t, axes: [1])
 
     test "computes the bitwise and across types" do
       assert any?(Nx.tensor([-1, 0, 1])) == Nx.tensor(1, type: {:u, 8})
@@ -1070,7 +1064,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "sum" do
-    defn(sum(t), do: Nx.sum(t))
+    defn sum(t), do: Nx.sum(t)
 
     test "computes the sum across types" do
       assert Nx.tensor([1, 2, 3]) |> sum() == Nx.tensor(6)
@@ -1080,9 +1074,9 @@ defmodule EXLA.DefnExprTest do
       assert Nx.tensor([1.0, 2.0, 3.0], type: {:f, 32}) |> sum() == Nx.tensor(6, type: {:f, 32})
     end
 
-    defn(sum_pos_axis(t), do: Nx.sum(t, axes: [1]))
-    defn(sum_neg_axis(t), do: Nx.sum(t, axes: [-3]))
-    defn(sum_pos_neg_axis(t), do: Nx.sum(t, axes: [1, -3]))
+    defn sum_pos_axis(t), do: Nx.sum(t, axes: [1])
+    defn sum_neg_axis(t), do: Nx.sum(t, axes: [-3])
+    defn sum_pos_neg_axis(t), do: Nx.sum(t, axes: [1, -3])
 
     test "computes the sum on a given axis" do
       t = Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]])
@@ -1091,7 +1085,7 @@ defmodule EXLA.DefnExprTest do
       assert sum_pos_neg_axis(t) == Nx.sum(t, axes: [1, -3])
     end
 
-    defn(sum_equal(t), do: Nx.sum(Nx.equal(t, 1.0)))
+    defn sum_equal(t), do: Nx.sum(Nx.equal(t, 1.0))
 
     test "does not overflow" do
       assert sum_equal(Nx.tensor(1)) == Nx.tensor(1, type: {:u, 64})
@@ -1099,8 +1093,8 @@ defmodule EXLA.DefnExprTest do
       assert sum_equal(Nx.tensor([1, 2, 3])) == Nx.tensor(1, type: {:u, 64})
     end
 
-    defn(sum_keep(t), do: Nx.sum(t, keep_axes: true))
-    defn(sum_keep_2(t), do: Nx.sum(t, axes: [0, 2], keep_axes: true))
+    defn sum_keep(t), do: Nx.sum(t, keep_axes: true)
+    defn sum_keep_2(t), do: Nx.sum(t, axes: [0, 2], keep_axes: true)
 
     test "keeps dimensions if keep_axes" do
       assert Nx.tensor([1, 2, 3]) |> sum_keep() == Nx.tensor([6])
@@ -1112,7 +1106,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "product" do
-    defn(product(t), do: Nx.product(t))
+    defn product(t), do: Nx.product(t)
 
     test "computes the product across types" do
       assert Nx.tensor([1, 2, 3]) |> product() == Nx.tensor(6)
@@ -1124,9 +1118,9 @@ defmodule EXLA.DefnExprTest do
                Nx.tensor(6, type: {:f, 32})
     end
 
-    defn(product_pos_axis(t), do: Nx.product(t, axes: [1]))
-    defn(product_neg_axis(t), do: Nx.product(t, axes: [-3]))
-    defn(product_pos_neg_axis(t), do: Nx.product(t, axes: [1, -3]))
+    defn product_pos_axis(t), do: Nx.product(t, axes: [1])
+    defn product_neg_axis(t), do: Nx.product(t, axes: [-3])
+    defn product_pos_neg_axis(t), do: Nx.product(t, axes: [1, -3])
 
     test "computes the sum on a given axis" do
       t = Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]])
@@ -1135,7 +1129,7 @@ defmodule EXLA.DefnExprTest do
       assert product_pos_neg_axis(t) == Nx.product(t, axes: [1, -3])
     end
 
-    defn(product_equal(t), do: Nx.product(Nx.equal(t, 1.0)))
+    defn product_equal(t), do: Nx.product(Nx.equal(t, 1.0))
 
     test "does not overflow" do
       assert product_equal(Nx.tensor(1)) == Nx.tensor(1, type: {:u, 64})
@@ -1143,8 +1137,8 @@ defmodule EXLA.DefnExprTest do
       assert product_equal(Nx.tensor([1, 2, 3])) == Nx.tensor(0, type: {:u, 64})
     end
 
-    defn(product_keep(t), do: Nx.product(t, keep_axes: true))
-    defn(product_keep_2(t), do: Nx.product(t, axes: [0, 2], keep_axes: true))
+    defn product_keep(t), do: Nx.product(t, keep_axes: true)
+    defn product_keep_2(t), do: Nx.product(t, axes: [0, 2], keep_axes: true)
 
     test "keeps dimensions if keep_axes" do
       assert Nx.tensor([1, 2, 3]) |> product_keep() == Nx.tensor([6])
@@ -1156,7 +1150,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "mean" do
-    defn(mean(t), do: Nx.mean(t))
+    defn mean(t), do: Nx.mean(t)
 
     test "computes mean without axis" do
       assert mean(Nx.tensor(42)) == Nx.tensor(42.0)
@@ -1164,7 +1158,7 @@ defmodule EXLA.DefnExprTest do
       assert mean(Nx.tensor([1, 2, 3], type: {:u, 8})) == Nx.tensor(2.0, type: {:f, 32})
     end
 
-    defn(mean_over_single_axis(t), do: Nx.mean(t, axes: [0]))
+    defn mean_over_single_axis(t), do: Nx.mean(t, axes: [0])
 
     test "computes mean over a single axis" do
       assert mean_over_single_axis(Nx.tensor([1, 2, 3])) == Nx.tensor(2.0)
@@ -1176,7 +1170,7 @@ defmodule EXLA.DefnExprTest do
                ])
     end
 
-    defn(mean_over_multiple_axes(t), do: Nx.mean(t, axes: [0, 2]))
+    defn mean_over_multiple_axes(t), do: Nx.mean(t, axes: [0, 2])
 
     test "computes mean over multiple axes" do
       assert mean_over_multiple_axes(
@@ -1184,7 +1178,7 @@ defmodule EXLA.DefnExprTest do
              ) == Nx.tensor([5.0, 8.0])
     end
 
-    defn(mean_over_negative_axis(t), do: Nx.mean(t, axes: [-1]))
+    defn mean_over_negative_axis(t), do: Nx.mean(t, axes: [-1])
 
     test "computes mean over negative axes" do
       assert mean_over_negative_axis(
@@ -1192,7 +1186,7 @@ defmodule EXLA.DefnExprTest do
              ) == Nx.tensor([[2.0, 5.0], [8.0, 11.0]])
     end
 
-    defn(mean_equal(t), do: Nx.mean(Nx.equal(t, 1.0)))
+    defn mean_equal(t), do: Nx.mean(Nx.equal(t, 1.0))
 
     test "does not overflow" do
       assert mean_equal(Nx.tensor(1)) == Nx.tensor(1.0)
@@ -1200,8 +1194,8 @@ defmodule EXLA.DefnExprTest do
       assert mean_equal(Nx.tensor([1, 2, 3])) == Nx.tensor(0.3333333333333333)
     end
 
-    defn(mean_keep(t), do: Nx.mean(t, keep_axes: true))
-    defn(mean_keep_2(t), do: Nx.mean(t, axes: [0, 2], keep_axes: true))
+    defn mean_keep(t), do: Nx.mean(t, keep_axes: true)
+    defn mean_keep_2(t), do: Nx.mean(t, axes: [0, 2], keep_axes: true)
 
     test "keeps dimensions if keep_axes" do
       assert Nx.tensor([1, 2, 3]) |> mean_keep() == Nx.tensor([2.0])
@@ -1213,7 +1207,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "reduce_max" do
-    defn(reduce_max(t), do: Nx.reduce_max(t))
+    defn reduce_max(t), do: Nx.reduce_max(t)
 
     test "computes the maximum across types" do
       assert Nx.tensor([1, 2, 3]) |> reduce_max() == Nx.tensor(3)
@@ -1225,9 +1219,9 @@ defmodule EXLA.DefnExprTest do
                Nx.tensor(3, type: {:f, 32})
     end
 
-    defn(reduce_max_pos_axis(t), do: Nx.reduce_max(t, axes: [1]))
-    defn(reduce_max_neg_axis(t), do: Nx.reduce_max(t, axes: [-3]))
-    defn(reduce_max_pos_neg_axis(t), do: Nx.reduce_max(t, axes: [1, -3]))
+    defn reduce_max_pos_axis(t), do: Nx.reduce_max(t, axes: [1])
+    defn reduce_max_neg_axis(t), do: Nx.reduce_max(t, axes: [-3])
+    defn reduce_max_pos_neg_axis(t), do: Nx.reduce_max(t, axes: [1, -3])
 
     test "computes the max on a given axis" do
       t = Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]])
@@ -1236,8 +1230,8 @@ defmodule EXLA.DefnExprTest do
       assert reduce_max_pos_neg_axis(t) == Nx.reduce_max(t, axes: [1, -3])
     end
 
-    defn(reduce_max_keep(t), do: Nx.reduce_max(t, keep_axes: true))
-    defn(reduce_max_keep_2(t), do: Nx.reduce_max(t, axes: [0, 2], keep_axes: true))
+    defn reduce_max_keep(t), do: Nx.reduce_max(t, keep_axes: true)
+    defn reduce_max_keep_2(t), do: Nx.reduce_max(t, axes: [0, 2], keep_axes: true)
 
     test "keeps dimensions if keep_axes" do
       assert Nx.tensor([1, 2, 3]) |> reduce_max_keep() == Nx.tensor([3])
@@ -1249,7 +1243,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "reduce_min" do
-    defn(reduce_min(t), do: Nx.reduce_min(t))
+    defn reduce_min(t), do: Nx.reduce_min(t)
 
     test "computes the minimum across types" do
       assert Nx.tensor([1, 2, 3]) |> reduce_min() == Nx.tensor(1)
@@ -1261,9 +1255,9 @@ defmodule EXLA.DefnExprTest do
                Nx.tensor(1, type: {:f, 32})
     end
 
-    defn(reduce_min_pos_axis(t), do: Nx.reduce_min(t, axes: [1]))
-    defn(reduce_min_neg_axis(t), do: Nx.reduce_min(t, axes: [-3]))
-    defn(reduce_min_pos_neg_axis(t), do: Nx.reduce_min(t, axes: [1, -3]))
+    defn reduce_min_pos_axis(t), do: Nx.reduce_min(t, axes: [1])
+    defn reduce_min_neg_axis(t), do: Nx.reduce_min(t, axes: [-3])
+    defn reduce_min_pos_neg_axis(t), do: Nx.reduce_min(t, axes: [1, -3])
 
     test "computes the min on a given axis" do
       t = Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]])
@@ -1272,8 +1266,8 @@ defmodule EXLA.DefnExprTest do
       assert reduce_min_pos_neg_axis(t) == Nx.reduce_min(t, axes: [1, -3])
     end
 
-    defn(reduce_min_keep(t), do: Nx.reduce_min(t, keep_axes: true))
-    defn(reduce_min_keep_2(t), do: Nx.reduce_min(t, axes: [0, 2], keep_axes: true))
+    defn reduce_min_keep(t), do: Nx.reduce_min(t, keep_axes: true)
+    defn reduce_min_keep_2(t), do: Nx.reduce_min(t, axes: [0, 2], keep_axes: true)
 
     test "keeps dimensions if keep_axes" do
       assert Nx.tensor([1, 2, 3]) |> reduce_min_keep() == Nx.tensor([1])
@@ -1285,12 +1279,12 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "argmax/argmin" do
-    defn(argmax(t), do: Nx.argmax(t))
-    defn(argmin(t), do: Nx.argmin(t))
-    defn(argmax_axis(t), do: Nx.argmax(t, axis: 1))
-    defn(argmin_axis(t), do: Nx.argmin(t, axis: 1))
-    defn(argmax_high(t), do: Nx.argmax(t, axis: 1, tie_break: :high))
-    defn(argmin_high(t), do: Nx.argmin(t, axis: 1, tie_break: :high))
+    defn argmax(t), do: Nx.argmax(t)
+    defn argmin(t), do: Nx.argmin(t)
+    defn argmax_axis(t), do: Nx.argmax(t, axis: 1)
+    defn argmin_axis(t), do: Nx.argmin(t, axis: 1)
+    defn argmax_high(t), do: Nx.argmax(t, axis: 1, tie_break: :high)
+    defn argmin_high(t), do: Nx.argmin(t, axis: 1, tie_break: :high)
 
     test "computes the argmax across types" do
       assert argmax(Nx.tensor([1, 2, 3])) == Nx.tensor(2)
@@ -1329,15 +1323,13 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "window sum" do
-    defn(window_sum1(t), do: Nx.window_sum(t, {1, 2, 1}))
+    defn window_sum1(t), do: Nx.window_sum(t, {1, 2, 1})
 
-    defn(window_sum2(t),
+    defn window_sum2(t),
       do: Nx.window_sum(t, {2, 2, 1}, strides: [1, 2, 3], padding: [{0, 1}, {2, 0}, {1, 1}])
-    )
 
-    defn(window_sum3(t),
+    defn window_sum3(t),
       do: Nx.window_sum(t, {2, 1, 1}, strides: [2, 1, 1], padding: [{1, 1}, {0, 0}, {1, 1}])
-    )
 
     defn dilated_window_sum(t) do
       Nx.window_sum(t, {3, 2, 1}, strides: [1, 1, 1], padding: :same, window_dilations: [1, 2, 2])
@@ -1372,15 +1364,13 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "window mean" do
-    defn(window_mean1(t), do: Nx.window_mean(t, {1, 2, 1}))
+    defn window_mean1(t), do: Nx.window_mean(t, {1, 2, 1})
 
-    defn(window_mean2(t),
+    defn window_mean2(t),
       do: Nx.window_mean(t, {2, 2, 1}, strides: [1, 2, 3], padding: [{0, 1}, {2, 0}, {1, 1}])
-    )
 
-    defn(window_mean3(t),
+    defn window_mean3(t),
       do: Nx.window_mean(t, {2, 1, 1}, strides: [2, 1, 1], padding: [{1, 1}, {0, 0}, {1, 1}])
-    )
 
     defn dilated_window_mean(t) do
       Nx.window_mean(t, {3, 2, 1}, strides: [1, 1, 1], padding: :same, window_dilations: [1, 2, 2])
@@ -1418,15 +1408,13 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "window max" do
-    defn(window_max1(t), do: Nx.window_max(t, {1, 2, 1}))
+    defn window_max1(t), do: Nx.window_max(t, {1, 2, 1})
 
-    defn(window_max2(t),
+    defn window_max2(t),
       do: Nx.window_max(t, {2, 2, 1}, strides: [1, 2, 3], padding: [{0, 1}, {2, 0}, {1, 1}])
-    )
 
-    defn(window_max3(t),
+    defn window_max3(t),
       do: Nx.window_max(t, {2, 1, 1}, strides: [2, 1, 1], padding: [{1, 1}, {0, 0}, {1, 1}])
-    )
 
     defn dilated_window_max(t) do
       Nx.window_max(t, {3, 2, 1}, strides: [1, 1, 1], padding: :same, window_dilations: [1, 2, 2])
@@ -1476,15 +1464,13 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "window min" do
-    defn(window_min1(t), do: Nx.window_min(t, {1, 2, 1}))
+    defn window_min1(t), do: Nx.window_min(t, {1, 2, 1})
 
-    defn(window_min2(t),
+    defn window_min2(t),
       do: Nx.window_min(t, {2, 2, 1}, strides: [1, 2, 3], padding: [{0, 1}, {2, 0}, {1, 1}])
-    )
 
-    defn(window_min3(t),
+    defn window_min3(t),
       do: Nx.window_min(t, {2, 1, 1}, strides: [2, 1, 1], padding: [{1, 1}, {0, 0}, {1, 1}])
-    )
 
     defn dilated_window_min(t) do
       Nx.window_min(t, {3, 2, 1}, strides: [1, 1, 1], padding: :same, window_dilations: [1, 2, 2])
@@ -1534,15 +1520,13 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "window product" do
-    defn(window_product1(t), do: Nx.window_product(t, {1, 2, 1}))
+    defn window_product1(t), do: Nx.window_product(t, {1, 2, 1})
 
-    defn(window_product2(t),
+    defn window_product2(t),
       do: Nx.window_product(t, {2, 2, 1}, strides: [1, 2, 3], padding: [{0, 1}, {2, 0}, {1, 1}])
-    )
 
-    defn(window_product3(t),
+    defn window_product3(t),
       do: Nx.window_product(t, {2, 1, 1}, strides: [2, 1, 1], padding: [{1, 1}, {0, 0}, {1, 1}])
-    )
 
     defn dilated_window_product(t) do
       Nx.window_product(t, {3, 2, 1},
@@ -1581,7 +1565,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "dot product" do
-    defn(dot(a, b), do: Nx.dot(a, b))
+    defn dot(a, b), do: Nx.dot(a, b)
 
     test "computes the dot product of scalars" do
       assert dot(Nx.tensor(2), Nx.tensor(2)) == Nx.tensor(4)
@@ -1637,7 +1621,7 @@ defmodule EXLA.DefnExprTest do
                )
     end
 
-    defn(batched_dot(t1, t2), do: Nx.dot(t1, [1], [0], t2, [1], [0]))
+   defn batched_dot(t1, t2), do: Nx.dot(t1, [1], [0], t2, [1], [0])
 
     test "computes a batched dot product" do
       assert batched_dot(Nx.iota({3, 2, 3}, type: {:f, 32}), Nx.iota({3, 2, 2}, type: {:f, 32})) ==
@@ -1648,7 +1632,7 @@ defmodule EXLA.DefnExprTest do
                ])
     end
 
-    defn(general_dot(t1, t2), do: Nx.dot(t1, [0, 1], [], t2, [1, 2], []))
+    defn general_dot(t1, t2), do: Nx.dot(t1, [0, 1], [], t2, [1, 2], [])
 
     test "computes a general dot product" do
       assert general_dot(Nx.iota({4, 5, 2}, type: {:f, 32}), Nx.iota({2, 4, 5}, type: {:f, 32})) ==
@@ -1657,37 +1641,31 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "convolution" do
-    defn(conv_valid_no_stride(inp, kernel), do: Nx.conv(inp, kernel))
+    defn conv_valid_no_stride(inp, kernel), do: Nx.conv(inp, kernel)
 
-    defn(conv_valid_stride(inp, kernel),
+    defn conv_valid_stride(inp, kernel),
       do: Nx.conv(inp, kernel, strides: [2, 2], padding: :valid)
-    )
 
-    defn(conv_same_no_stride(inp, kernel),
+    defn conv_same_no_stride(inp, kernel),
       do: Nx.conv(inp, kernel, strides: [1, 1], padding: :same)
-    )
 
-    defn(conv_same_stride(inp, kernel), do: Nx.conv(inp, kernel, strides: [3, 3], padding: :same))
+    defn conv_same_stride(inp, kernel), do: Nx.conv(inp, kernel, strides: [3, 3], padding: :same)
 
-    defn(conv_general_no_stride(inp, kernel),
+    defn conv_general_no_stride(inp, kernel),
       do: Nx.conv(inp, kernel, strides: [1, 1], padding: [{-1, 2}, {3, -1}])
-    )
 
-    defn(conv_general_stride(inp, kernel),
+    defn conv_general_stride(inp, kernel),
       do: Nx.conv(inp, kernel, strides: [2, 1], padding: [{2, 2}, {-2, 4}])
-    )
 
-    defn(conv_3d(inp, kernel), do: Nx.conv(inp, kernel, strides: [1, 2, 1], padding: :same))
+    defn conv_3d(inp, kernel), do: Nx.conv(inp, kernel, strides: [1, 2, 1], padding: :same)
 
-    defn(dilated_conv(inp, kernel),
+    defn dilated_conv(inp, kernel),
       do: Nx.conv(inp, kernel, strides: [1, 1], padding: :same, kernel_dilation: [1, 2])
-    )
 
-    defn(dilated_input_conv(inp, kernel),
+    defn dilated_input_conv(inp, kernel),
       do: Nx.conv(inp, kernel, strides: [1, 1], padding: :same, input_dilation: [2, 1])
-    )
 
-    defn(dilated_input_kernel_conv(inp, kernel),
+    defn dilated_input_kernel_conv(inp, kernel),
       do:
         Nx.conv(inp, kernel,
           strides: [2, 1],
@@ -1695,15 +1673,12 @@ defmodule EXLA.DefnExprTest do
           kernel_dilation: [2, 1],
           input_dilation: [1, 2]
         )
-    )
 
-    defn(grouped_conv_valid_no_stride(inp, kernel),
+    defn grouped_conv_valid_no_stride(inp, kernel),
       do: Nx.conv(inp, kernel, strides: 1, padding: :valid, feature_group_size: 2)
-    )
 
-    defn(grouped_conv_same_stride(inp, kernel),
+    defn grouped_conv_same_stride(inp, kernel),
       do: Nx.conv(inp, kernel, strides: [2, 1, 2], padding: :same, feature_group_size: 4)
-    )
 
     defn conv_valid_no_stride_channels_last(inp, kernel) do
       Nx.conv(inp, kernel,
@@ -1950,7 +1925,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "outer product" do
-    defn(outer(t1, t2), do: Nx.outer(t1, t2))
+    defn outer(t1, t2), do: Nx.outer(t1, t2)
 
     test "computes the outer product of scalars" do
       assert outer(Nx.tensor(1), Nx.tensor(2)) == Nx.tensor([[2]])
@@ -1968,11 +1943,11 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "transpose" do
-    defn(transpose(t), do: Nx.transpose(t))
-    defn(transpose_scalar(t), do: Nx.transpose(t, axes: []))
-    defn(transpose_perm1(t), do: Nx.transpose(t, axes: [2, 1, 0]))
-    defn(transpose_perm2(t), do: Nx.transpose(t, axes: [2, 0, 1]))
-    defn(transpose_perm3(t), do: Nx.transpose(t, axes: [0, 2, 1]))
+    defn transpose(t), do: Nx.transpose(t)
+    defn transpose_scalar(t), do: Nx.transpose(t, axes: [])
+    defn transpose_perm1(t), do: Nx.transpose(t, axes: [2, 1, 0])
+    defn transpose_perm2(t), do: Nx.transpose(t, axes: [2, 0, 1])
+    defn transpose_perm3(t), do: Nx.transpose(t, axes: [0, 2, 1])
 
     test "transposes without axes" do
       assert transpose(Nx.tensor(1)) == Nx.tensor(1)
@@ -2024,7 +1999,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "softmax" do
-    defn(softmax(t), do: Nx.exp(t) / Nx.sum(Nx.exp(t)))
+    defn softmax(t), do: Nx.exp(t) / Nx.sum(Nx.exp(t))
 
     test "computes softmax" do
       assert compare_tensors!(
@@ -2040,13 +2015,13 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "reshape" do
-    defn(reshape_with_shape(t), do: Nx.reshape(t, {2, 2}))
+    defn reshape_with_shape(t), do: Nx.reshape(t, {2, 2})
 
     test "with shape" do
       assert reshape_with_shape(Nx.tensor([1, 2, 3, 4])) == Nx.tensor([[1, 2], [3, 4]])
     end
 
-    defn(reshape_with_tensor(t, shape), do: Nx.reshape(t, shape))
+    defn reshape_with_tensor(t, shape), do: Nx.reshape(t, shape)
 
     test "with tensor" do
       assert reshape_with_tensor(Nx.tensor([1, 2, 3, 4]), Nx.tensor([[0, 0], [0, 0]])) ==
@@ -2058,13 +2033,13 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "pad" do
-    defn(pad_scalar(t), do: Nx.pad(t, 0, []))
-    defn(pad_vector(t), do: Nx.pad(t, 0, [{1, 1, 0}]))
-    defn(pad_matrix(t), do: Nx.pad(t, 0, [{1, 1, 0}, {1, 1, 0}]))
-    defn(pad_tensor(t), do: Nx.pad(t, 0.0, [{1, 2, 0}, {1, 0, 0}, {0, 1, 0}]))
-    defn(pad_vector_negative_value(t), do: Nx.pad(t, 0.0, [{-1, -1, 0}]))
-    defn(pad_matrix_negative_value(t), do: Nx.pad(t, 0, [{0, 0, 0}, {-1, 1, 0}]))
-    defn(pad_tensor_negative_value(t), do: Nx.pad(t, 0, [{-1, 0, 0}, {-1, -1, 0}, {0, -1, 0}]))
+    defn pad_scalar(t), do: Nx.pad(t, 0, [])
+    defn pad_vector(t), do: Nx.pad(t, 0, [{1, 1, 0}])
+    defn pad_matrix(t), do: Nx.pad(t, 0, [{1, 1, 0}, {1, 1, 0}])
+    defn pad_tensor(t), do: Nx.pad(t, 0.0, [{1, 2, 0}, {1, 0, 0}, {0, 1, 0}])
+    defn pad_vector_negative_value(t), do: Nx.pad(t, 0.0, [{-1, -1, 0}])
+    defn pad_matrix_negative_value(t), do: Nx.pad(t, 0, [{0, 0, 0}, {-1, 1, 0}])
+    defn pad_tensor_negative_value(t), do: Nx.pad(t, 0, [{-1, 0, 0}, {-1, -1, 0}, {0, -1, 0}])
 
     test "with scalar" do
       assert pad_scalar(Nx.tensor(1)) == Nx.tensor(1)
@@ -2129,7 +2104,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "broadcast" do
-    defn(broadcast_with_shape(t), do: Nx.broadcast(t, {2, 2}))
+    defn broadcast_with_shape(t), do: Nx.broadcast(t, {2, 2})
 
     test "with shape" do
       assert broadcast_with_shape(Nx.tensor([1, 2])) == Nx.tensor([[1, 2], [1, 2]])
@@ -2137,7 +2112,7 @@ defmodule EXLA.DefnExprTest do
       assert broadcast_with_shape(Nx.tensor([[1], [2]])) == Nx.tensor([[1, 1], [2, 2]])
     end
 
-    defn(broadcast_with_tensor(t, shape), do: Nx.broadcast(t, shape))
+    defn broadcast_with_tensor(t, shape), do: Nx.broadcast(t, shape)
 
     test "with tensor" do
       tensors = [
@@ -2150,8 +2125,8 @@ defmodule EXLA.DefnExprTest do
       end
     end
 
-    defn(broadcast_with_axes_2(t), do: Nx.broadcast(t, {3, 2}, axes: [0]))
-    defn(broadcast_with_axes_3(t), do: Nx.broadcast(t, {2, 3, 2}, axes: [1]))
+    defn broadcast_with_axes_2(t), do: Nx.broadcast(t, {3, 2}, axes: [0])
+    defn broadcast_with_axes_3(t), do: Nx.broadcast(t, {2, 3, 2}, axes: [1])
 
     test "with axes" do
       assert broadcast_with_axes_2(Nx.tensor([1, 2, 3])) == Nx.tensor([[1, 1], [2, 2], [3, 3]])
@@ -2162,8 +2137,8 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "squeeze" do
-    defn(squeeze(t), do: Nx.squeeze(t))
-    defn(squeeze2(t), do: Nx.squeeze(t, axes: [0, 1]))
+    defn squeeze(t), do: Nx.squeeze(t)
+    defn squeeze2(t), do: Nx.squeeze(t, axes: [0, 1])
 
     test "with scalar" do
       assert squeeze(Nx.tensor(1)) == Nx.tensor(1)
@@ -2177,7 +2152,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "random uniform" do
-    defn(random_uniform_fixed, do: Nx.random_uniform({30, 20}))
+    defn random_uniform_fixed, do: Nx.random_uniform({30, 20})
 
     test "generates with shape" do
       t = random_uniform_fixed()
@@ -2189,8 +2164,8 @@ defmodule EXLA.DefnExprTest do
       end
     end
 
-    defn(random_uniform_min_max_int, do: Nx.random_uniform({30, 20}, 5, 10))
-    defn(random_uniform_min_max_float, do: Nx.random_uniform({30, 20}, 5.0, 10.0))
+    defn random_uniform_min_max_int, do: Nx.random_uniform({30, 20}, 5, 10)
+    defn random_uniform_min_max_float, do: Nx.random_uniform({30, 20}, 5.0, 10.0)
 
     test "generates with min/max" do
       t = random_uniform_min_max_int()
@@ -2210,8 +2185,8 @@ defmodule EXLA.DefnExprTest do
       end
     end
 
-    defn(random_uniform_u32, do: Nx.random_uniform({30, 20}, 5, 10, type: {:u, 32}))
-    defn(random_uniform_f64, do: Nx.random_uniform({30, 20}, 5.0, 10.0, type: {:f, 64}))
+    defn random_uniform_u32, do: Nx.random_uniform({30, 20}, 5, 10, type: {:u, 32})
+    defn random_uniform_f64, do: Nx.random_uniform({30, 20}, 5.0, 10.0, type: {:f, 64})
 
     test "generates with type" do
       t = random_uniform_u32()
@@ -2231,7 +2206,7 @@ defmodule EXLA.DefnExprTest do
       end
     end
 
-    defn(random_uniform_tensor(min, max), do: Nx.random_uniform({30, 20}, min, max))
+    defn random_uniform_tensor(min, max), do: Nx.random_uniform({30, 20}, min, max)
 
     test "generates with min/max tensor" do
       t = random_uniform_tensor(Nx.tensor(-100.0), Nx.tensor(100.0))
@@ -2241,7 +2216,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "random normal" do
-    defn(random_normal_fixed, do: Nx.random_normal({30, 20}))
+    defn random_normal_fixed, do: Nx.random_normal({30, 20})
 
     test "generates with shape" do
       t = random_uniform_fixed()
@@ -2249,7 +2224,7 @@ defmodule EXLA.DefnExprTest do
       assert Nx.type(t) == {:f, 32}
     end
 
-    defn(random_normal_mu_sigma, do: Nx.random_normal({30, 20}, 5.0, 10.0))
+    defn random_normal_mu_sigma, do: Nx.random_normal({30, 20}, 5.0, 10.0)
 
     test "generates with mu/sigma" do
       t = random_normal_mu_sigma()
@@ -2257,7 +2232,7 @@ defmodule EXLA.DefnExprTest do
       assert Nx.type(t) == {:f, 32}
     end
 
-    defn(random_normal_f64, do: Nx.random_normal({30, 20}, 5.0, 10.0, type: {:f, 64}))
+    defn random_normal_f64, do: Nx.random_normal({30, 20}, 5.0, 10.0, type: {:f, 64})
 
     test "generates with type" do
       t = random_normal_f64()
@@ -2265,7 +2240,7 @@ defmodule EXLA.DefnExprTest do
       assert Nx.type(t) == {:f, 64}
     end
 
-    defn(random_normal_tensor(mu, sigma), do: Nx.random_normal({30, 20}, mu, sigma))
+    defn random_normal_tensor(mu, sigma), do: Nx.random_normal({30, 20}, mu, sigma)
 
     test "generates with tensor mu/sigma" do
       t = random_normal_tensor(Nx.tensor(1.0), Nx.tensor(1.0))
@@ -2275,25 +2250,25 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "iota" do
-    defn(iota_with_shape, do: Nx.iota({3, 4, 2, 3}, axis: 2))
+    defn iota_with_shape, do: Nx.iota({3, 4, 2, 3}, axis: 2)
 
     test "generates with shape" do
       assert iota_with_shape() == Nx.iota({3, 4, 2, 3}, axis: 2)
     end
 
-    defn(iota_with_type, do: Nx.iota({1, 2, 3}, axis: 1, type: {:f, 32}))
+    defn iota_with_type, do: Nx.iota({1, 2, 3}, axis: 1, type: {:f, 32})
 
     test "generates with type" do
       assert iota_with_type() == Nx.iota({1, 2, 3}, axis: 1, type: {:f, 32})
     end
 
-    defn(iota_no_axis, do: Nx.iota({2, 2, 2}))
+    defn iota_no_axis, do: Nx.iota({2, 2, 2})
 
     test "generates without axis" do
       assert iota_no_axis() == Nx.iota({2, 2, 2})
     end
 
-    defn(iota_neg_axis, do: Nx.iota({2, 2, 2}, axis: -2))
+    defn iota_neg_axis, do: Nx.iota({2, 2, 2}, axis: -2)
 
     test "generates with negative axis" do
       assert iota_neg_axis() == Nx.iota({2, 2, 2}, axis: -2)
@@ -2301,13 +2276,13 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "eye" do
-    defn(eye, do: Nx.eye(2))
+    defn eye, do: Nx.eye(2)
 
     test "generates with shape" do
       assert eye() == Nx.tensor([[1, 0], [0, 1]])
     end
 
-    defn(eye_with_type, do: Nx.eye(1, type: {:f, 32}))
+    defn eye_with_type, do: Nx.eye(1, type: {:f, 32})
 
     test "generates with type" do
       assert eye_with_type() == Nx.tensor([[1]], type: {:f, 32})
@@ -2315,9 +2290,9 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "clip" do
-    defn(clip_both(value), do: Nx.clip(value, 2, 4))
-    defn(clip_mixed_types(value), do: Nx.clip(value, 2.0, 3))
-    defn(clip_with_tensor(value), do: Nx.clip(value, Nx.tensor(2.0), Nx.max(1.0, 3.0)))
+    defn clip_both(value), do: Nx.clip(value, 2, 4)
+    defn clip_mixed_types(value), do: Nx.clip(value, 2.0, 3)
+    defn clip_with_tensor(value), do: Nx.clip(value, Nx.tensor(2.0), Nx.max(1.0, 3.0))
 
     test "works with both set" do
       assert clip_both(Nx.tensor([[1, 2, 3], [4, 5, 6]])) == Nx.tensor([[2, 2, 3], [4, 4, 4]])
@@ -2340,9 +2315,9 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "slicing" do
-    defn(slice1(t), do: Nx.slice(t, [0, 6, 2], [2, 1, 3]))
-    defn(slice2(t), do: Nx.slice(t, [1, 4, 10], [1, 1, 10], strides: [1, 2, 3]))
-    defn(slice3(t), do: Nx.slice(t, [0, 4, 11], [2, 3, 9], strides: [2, 1, 3]))
+    defn slice1(t), do: Nx.slice(t, [0, 6, 2], [2, 1, 3])
+    defn slice2(t), do: Nx.slice(t, [1, 4, 10], [1, 1, 10], strides: [1, 2, 3])
+    defn slice3(t), do: Nx.slice(t, [0, 4, 11], [2, 3, 9], strides: [2, 1, 3])
 
     test "works without stride" do
       t = Nx.iota({900})
@@ -2367,10 +2342,10 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "reverse" do
-    defn(reverse(t), do: Nx.reverse(t))
-    defn(reverse1(t), do: Nx.reverse(t, axes: [1]))
-    defn(reverse2(t), do: Nx.reverse(t, axes: [0, 2]))
-    defn(reverse3(t), do: Nx.reverse(t, axes: [1, 2, 4]))
+    defn reverse(t), do: Nx.reverse(t)
+    defn reverse1(t), do: Nx.reverse(t, axes: [1])
+    defn reverse2(t), do: Nx.reverse(t, axes: [0, 2])
+    defn reverse3(t), do: Nx.reverse(t, axes: [1, 2, 4])
 
     test "works on all dims" do
       assert reverse(Nx.iota({10})) == Nx.tensor([9, 8, 7, 6, 5, 4, 3, 2, 1, 0])
@@ -2450,10 +2425,10 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "concatenate" do
-    defn(concatenate0(t1, t2, t3), do: Nx.concatenate([t1, t2, t3], axis: 0))
-    defn(concatenate1(t1, t2, t3), do: Nx.concatenate([t1, t2, t3], axis: 1))
-    defn(concatenate2(t1, t2, t3), do: Nx.concatenate([t1, t2, t3], axis: 2))
-    defn(concatenate1_inp(t1), do: Nx.concatenate([t1], axis: 2))
+    defn concatenate0(t1, t2, t3), do: Nx.concatenate([t1, t2, t3], axis: 0)
+    defn concatenate1(t1, t2, t3), do: Nx.concatenate([t1, t2, t3], axis: 1)
+    defn concatenate2(t1, t2, t3), do: Nx.concatenate([t1, t2, t3], axis: 2)
+    defn concatenate1_inp(t1), do: Nx.concatenate([t1], axis: 2)
 
     test "works 0th axis" do
       t1 = Nx.iota({2, 2, 2})
@@ -2582,7 +2557,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "decompositions" do
-    defn(ts(a, b), do: Nx.LinAlg.triangular_solve(a, b))
+    defn ts(a, b), do: Nx.LinAlg.triangular_solve(a, b)
 
     test "triangular_solve" do
       a = Nx.tensor([[3, 0, 0, 0], [2, 1, 0, 0], [1, 0, 1, 0], [1, 1, 1, 1]])
@@ -2590,8 +2565,8 @@ defmodule EXLA.DefnExprTest do
       assert compare_tensors!(Nx.dot(a, ts(a, b)), b)
     end
 
-    defn(qr(t), do: Nx.LinAlg.qr(t))
-    defn(qr_complete(t), do: Nx.LinAlg.qr(t, mode: :complete))
+    defn qr(t), do: Nx.LinAlg.qr(t)
+    defn qr_complete(t), do: Nx.LinAlg.qr(t, mode: :complete)
 
     test "qr" do
       input = Nx.iota({3, 2})
@@ -2608,7 +2583,7 @@ defmodule EXLA.DefnExprTest do
       assert compare_tensors!(Nx.dot(q, r), output)
     end
 
-    defn(svd(t), do: Nx.LinAlg.svd(t))
+    defn svd(t), do: Nx.LinAlg.svd(t)
 
     test "svd" do
       input = Nx.iota({3, 3})
@@ -2628,10 +2603,10 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "sort" do
-    defn(sort0(t), do: Nx.sort(t, axis: 0))
-    defn(sort1(t), do: Nx.sort(t, axis: 1))
-    defn(sort1_asc(t), do: Nx.sort(t, axis: 1, comparator: :asc))
-    defn(sort2(t), do: Nx.sort(t, axis: 2))
+    defn sort0(t), do: Nx.sort(t, axis: 0)
+    defn sort1(t), do: Nx.sort(t, axis: 1)
+    defn sort1_asc(t), do: Nx.sort(t, axis: 1, comparator: :asc)
+    defn sort2(t), do: Nx.sort(t, axis: 2)
 
     test "sorts a 1d tensor" do
       assert sort0(Nx.tensor([0, 5, 2, 1, 3, 4])) == Nx.tensor([0, 1, 2, 3, 4, 5])
@@ -2669,10 +2644,10 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "argsort" do
-    defn(argsort0(t), do: Nx.argsort(t, axis: 0))
-    defn(argsort1(t), do: Nx.argsort(t, axis: 1))
-    defn(argsort1_asc(t), do: Nx.argsort(t, axis: 1, comparator: :asc))
-    defn(argsort2(t), do: Nx.argsort(t, axis: 2))
+    defn argsort0(t), do: Nx.argsort(t, axis: 0)
+    defn argsort1(t), do: Nx.argsort(t, axis: 1)
+    defn argsort1_asc(t), do: Nx.argsort(t, axis: 1, comparator: :asc)
+    defn argsort2(t), do: Nx.argsort(t, axis: 2)
 
     test "sorts a 1d tensor and returns its indices" do
       assert argsort0(Nx.tensor([0, 5, 2, 1, 3, 4])) == Nx.tensor([0, 3, 2, 4, 5, 1])
@@ -2715,7 +2690,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "cholesky" do
-    defn(cholesky(t), do: Nx.LinAlg.cholesky(t))
+    defn cholesky(t), do: Nx.LinAlg.cholesky(t)
 
     test "works on 2x2 matrix" do
       lhs = cholesky(Nx.tensor([[20.0, 17.6], [17.6, 16.0]]))
@@ -2755,7 +2730,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "bfloat16" do
-    defn(add(t1, t2), do: t1 + t2)
+    defn add(t1, t2), do: t1 + t2
 
     test "accepts bfloat16 input" do
       lhs = Nx.tensor([1.0, 2.0, 3.0], type: {:bf, 16})
@@ -2766,10 +2741,10 @@ defmodule EXLA.DefnExprTest do
 
   describe "precision" do
     @defn_compiler {EXLA, precision: :bad}
-    defn(bad_precision(t1, t2), do: Nx.dot(t1, t2))
+    defn bad_precision(t1, t2), do: Nx.dot(t1, t2)
 
     @defn_compiler {EXLA, precision: :high}
-    defn(good_precision(t1, t2), do: Nx.dot(t1, t2))
+    defn good_precision(t1, t2), do: Nx.dot(t1, t2)
 
     test "raises on bad precision" do
       assert_raise ArgumentError,

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -6317,27 +6317,45 @@ defmodule Nx do
     case {tuple_size(s1), tuple_size(s2)} do
       {0, _} -> multiply(t1, t2)
       {_, 0} -> multiply(t1, t2)
-      {n, 1} -> dot(t1, [n - 1], t2, [0])
-      {1, m} -> dot(t1, [0], t2, [m - 2])
-      {n, m} when n >= 2 and m >= 2 -> dot(t1, [n - 1], t2, [m - 2])
+      {n, 1} -> dot(t1, [n - 1], [], t2, [0], [])
+      {1, m} -> dot(t1, [0], [], t2, [m - 2], [])
+      {n, m} when n >= 2 and m >= 2 -> dot(t1, [n - 1], [], t2, [m - 2], [])
     end
   end
 
   @doc """
-  Computes the dot product of two tensors over the given axes.
+  Computes the generalized dot product bewteen two tensors, given
+  the contracting and batch axes.
 
   The dot product is computed by multiplying the values from `t1`
-  given by `axes1` against the values from `t2` given by `axes2`.
-  For instance, the first axis in `axes1` will be matched against
-  the first axis in `axes2` and so on. The axes given by `axes1`
-  and `axes2` are effectively removed from the final tensor, which
-  is why they are often called the contraction axes.
+  given by `contract_axes1` against the values from `t2` given by
+  `contract_axes2`, considering batch axes of `batch_axes1` and
+  `batch_axes2`. For instance, the first axis in `contract_axes1`
+  will be matched against the first axis in `contract_axes2` and
+  so on. The axes given by `contract_axes1` and `contract_axes2`
+  are effectively removed from the final tensor, which is why they
+  are often called the contraction axes.
+
+  If no contracting axes are given, the final product works like
+  `Nx.outer/2`.
+
+  Specifying batch axes will compute a vectorized dot product
+  along the given batch dimensions. The length of `batch_axes1`
+  and `batch_axes2` must match. Additionally, `batch_axes1` and
+  `batch_axes2` must be a list of successive dimension numbers,
+  where each batch axis matches the dimension of the corresponding
+  batch axis in the other input.
+
+  The contracting axes must be dot-product compatible and the
+  batch dimensions must always have the same number of elements.
 
   ## Examples
 
+  ### Contracting along axes
+
       iex> t1 = Nx.tensor([[1, 2], [3, 4]], names: [:x, :y])
       iex> t2 = Nx.tensor([[10, 20], [30, 40]], names: [:height, :width])
-      iex> Nx.dot(t1, [0], t2, [0])
+      iex> Nx.dot(t1, [0], [], t2, [0], [])
       #Nx.Tensor<
         s64[y: 2][width: 2]
         [
@@ -6345,7 +6363,7 @@ defmodule Nx do
           [140, 200]
         ]
       >
-      iex> Nx.dot(t1, [0], t2, [1])
+      iex> Nx.dot(t1, [0], [], t2, [1], [])
       #Nx.Tensor<
         s64[y: 2][height: 2]
         [
@@ -6353,7 +6371,7 @@ defmodule Nx do
           [100, 220]
         ]
       >
-      iex> Nx.dot(t1, [1], t2, [0])
+      iex> Nx.dot(t1, [1], [], t2, [0], [])
       #Nx.Tensor<
         s64[x: 2][width: 2]
         [
@@ -6361,7 +6379,7 @@ defmodule Nx do
           [150, 220]
         ]
       >
-      iex> Nx.dot(t1, [1], t2, [1])
+      iex> Nx.dot(t1, [1], [], t2, [1], [])
       #Nx.Tensor<
         s64[x: 2][height: 2]
         [
@@ -6369,7 +6387,7 @@ defmodule Nx do
           [110, 250]
         ]
       >
-      iex> Nx.dot(t1, [0, 1], t2, [0, 1])
+      iex> Nx.dot(t1, [0, 1], [], t2, [0, 1], [])
       #Nx.Tensor<
         s64
         300
@@ -6379,7 +6397,7 @@ defmodule Nx do
 
       iex> t1 = Nx.tensor([[1, 2], [3, 4]])
       iex> t2 = Nx.tensor([[10, 20], [30, 40]])
-      iex> Nx.dot(t1, [], t2, [])
+      iex> Nx.dot(t1, [], [], t2, [], [])
       #Nx.Tensor<
         s64[2][2][2][2]
         [
@@ -6405,19 +6423,6 @@ defmodule Nx do
           ]
         ]
       >
-
-  """
-  @doc type: :ndim
-  def dot(t1, axes1, t2, axes2), do: dot(t1, axes1, [], t2, axes2, [])
-
-  @doc """
-  Computes the generalized dot product bewteen two tensors, given the contracting
-  and batch axes.
-
-  The contracting axes must be dot-product compatible and the batch dimensions must
-  always have the same number of elements.
-
-  ## Examples
 
   ### Dot product between two batched tensors
 

--- a/nx/lib/nx/defn/grad.ex
+++ b/nx/lib/nx/defn/grad.ex
@@ -394,12 +394,12 @@ defmodule Nx.Defn.Grad do
 
     gx =
       g
-      |> Nx.dot(contract_gx, y, contract_y)
+      |> Nx.dot(contract_gx, [], y, contract_y, [])
       |> Nx.transpose(axes: argsort(contract_x ++ transpose_x))
 
     gy =
       g
-      |> Nx.dot(contract_gy, x, contract_x)
+      |> Nx.dot(contract_gy, [], x, contract_x, [])
       |> Nx.transpose(axes: argsort(contract_y ++ transpose_y))
 
     grad_pairs([{x, gx}, {y, gy}], g, cache)

--- a/nx/test/nx/defn_test.exs
+++ b/nx/test/nx/defn_test.exs
@@ -26,14 +26,14 @@ defmodule Nx.DefnTest do
 
   describe "constants" do
     @tensor [1, 2, 3]
-    defn list_constant, do: Nx.tensor(@tensor)
+    defn(list_constant, do: Nx.tensor(@tensor))
 
     test "from list" do
       assert %T{data: %Expr{op: :tensor}} = list_constant()
     end
 
     @tensor Nx.to_binary(Nx.tensor([1, 2, 3]))
-    defn binary_constant, do: Nx.from_binary(@tensor, {:s, 64})
+    defn(binary_constant, do: Nx.from_binary(@tensor, {:s, 64}))
 
     test "from binary" do
       assert %T{data: %Expr{op: :tensor}} = binary_constant()
@@ -81,7 +81,7 @@ defmodule Nx.DefnTest do
   end
 
   describe "anonymous functions args" do
-    defn calls_binary_fun(fun, a, b), do: fun.(a, b)
+    defn(calls_binary_fun(fun, a, b), do: fun.(a, b))
 
     test "calls anonymous function directly" do
       assert %T{shape: {}, type: {:f, 32}, data: %Expr{op: :add, args: [left, right]}} =
@@ -91,14 +91,14 @@ defmodule Nx.DefnTest do
       assert %T{data: %Expr{op: :parameter, args: [1]}, type: {:f, 32}} = right
     end
 
-    defn calls_reduce_fun(fun, t), do: Nx.reduce(t, 0, fun)
+    defn(calls_reduce_fun(fun, t), do: Nx.reduce(t, 0, fun))
 
     test "calls anonymous function via reduce" do
       assert %T{shape: {}, type: {:s, 64}, data: %Expr{op: :reduce}} =
                calls_reduce_fun(&Nx.add/2, Nx.tensor([1, 2, 3]))
     end
 
-    defn calls_tuple_fun({funa, funb}, a, b), do: {funa.(a, b), funb.(a, b)}
+    defn(calls_tuple_fun({funa, funb}, a, b), do: {funa.(a, b), funb.(a, b)})
 
     test "calls anonymous function from tuples" do
       assert {%T{shape: {}, type: {:f, 32}, data: %Expr{op: :add, args: [left, right]}},
@@ -115,7 +115,7 @@ defmodule Nx.DefnTest do
   end
 
   describe "unary ops" do
-    defn exp(t), do: Nx.exp(t)
+    defn(exp(t), do: Nx.exp(t))
 
     test "to expr" do
       assert %T{shape: {3}, type: {:f, 32}, data: %Expr{op: :exp, args: [_]}} =
@@ -130,9 +130,9 @@ defmodule Nx.DefnTest do
   end
 
   describe "binary ops" do
-    defn add(t1, t2), do: Nx.add(t1, t2)
-    defn add_two_int(t), do: Nx.add(t, 2)
-    defn add_two_float(t), do: Nx.add(t, 2)
+    defn(add(t1, t2), do: Nx.add(t1, t2))
+    defn(add_two_int(t), do: Nx.add(t, 2))
+    defn(add_two_float(t), do: Nx.add(t, 2))
 
     test "to expr" do
       assert %T{shape: {3}, type: {:s, 64}, data: %Expr{op: :add, args: [_, _]}} =
@@ -158,10 +158,10 @@ defmodule Nx.DefnTest do
   end
 
   describe "aggregate axes ops" do
-    defn sum_all(t), do: Nx.sum(t)
-    defn sum_pos(t), do: Nx.sum(t, axes: [0, 1])
-    defn sum_neg(t), do: Nx.sum(t, axes: [-1, -2])
-    defn sum_keep(t), do: Nx.sum(t, axes: [0, 1], keep_axes: true)
+    defn(sum_all(t), do: Nx.sum(t))
+    defn(sum_pos(t), do: Nx.sum(t, axes: [0, 1]))
+    defn(sum_neg(t), do: Nx.sum(t, axes: [-1, -2]))
+    defn(sum_keep(t), do: Nx.sum(t, axes: [0, 1], keep_axes: true))
 
     test "to expr" do
       assert %T{
@@ -203,10 +203,10 @@ defmodule Nx.DefnTest do
   end
 
   describe "creation ops" do
-    defn iota(t), do: Nx.iota(t)
-    defn eye, do: Nx.eye(2)
-    defn random_uniform(t), do: Nx.random_uniform(t, 0.0, 2.0)
-    defn random_normal(t), do: Nx.random_normal(t, 0.0, 1.0)
+    defn(iota(t), do: Nx.iota(t))
+    defn(eye, do: Nx.eye(2))
+    defn(random_uniform(t), do: Nx.random_uniform(t, 0.0, 2.0))
+    defn(random_normal(t), do: Nx.random_normal(t, 0.0, 1.0))
 
     test "iota" do
       assert %T{shape: {3}, data: %Expr{op: :iota, args: [nil]}} = iota(Nx.tensor([1, 2, 3]))
@@ -230,12 +230,12 @@ defmodule Nx.DefnTest do
   end
 
   describe "tensor ops" do
-    defn dot2(t1, t2), do: Nx.dot(t1, t2)
-    defn dot4(t1, t2), do: Nx.dot(t1, [-2], t2, [-1])
-    defn outer(t1, t2), do: Nx.outer(t1, t2)
-    defn transpose_1(t), do: Nx.transpose(t)
-    defn transpose_2(t), do: Nx.transpose(t, axes: [-1, -2])
-    defn reshape(t), do: Nx.reshape(t, {2, 3})
+    defn(dot2(t1, t2), do: Nx.dot(t1, t2))
+    defn(dot6(t1, t2), do: Nx.dot(t1, [-2], [], t2, [-1], []))
+    defn(outer(t1, t2), do: Nx.outer(t1, t2))
+    defn(transpose_1(t), do: Nx.transpose(t))
+    defn(transpose_2(t), do: Nx.transpose(t, axes: [-1, -2]))
+    defn(reshape(t), do: Nx.reshape(t, {2, 3}))
 
     test "dot product" do
       assert %T{data: %Expr{op: :dot, args: [_, [0], _, _, [0], _]}, shape: {2}} =
@@ -247,8 +247,8 @@ defmodule Nx.DefnTest do
       assert %T{data: %Expr{op: :dot, args: [_, [1], _, _, [0], _]}, shape: {2, 2}} =
                dot2(Nx.tensor([[1, 2, 3], [1, 2, 3]]), Nx.tensor([[1, 2], [3, 4], [5, 6]]))
 
-      assert %T{data: %Expr{op: :dot, args: [_, [0], _, _, [1], _]}, shape: {3, 3}} =
-               dot4(Nx.tensor([[1, 2, 3], [1, 2, 3]]), Nx.tensor([[1, 2], [3, 4], [5, 6]]))
+      assert %T{data: %Expr{op: :dot, args: [_, [0], [], _, [1], []]}, shape: {3, 3}} =
+               dot6(Nx.tensor([[1, 2, 3], [1, 2, 3]]), Nx.tensor([[1, 2], [3, 4], [5, 6]]))
     end
 
     test "outer product" do
@@ -271,8 +271,8 @@ defmodule Nx.DefnTest do
   end
 
   describe "broadcast" do
-    defn broadcast(t), do: Nx.broadcast(t, {3, 3, 3})
-    defn broadcast_axes(t), do: Nx.broadcast(t, {3, 2}, axes: [-2])
+    defn(broadcast(t), do: Nx.broadcast(t, {3, 3, 3}))
+    defn(broadcast_axes(t), do: Nx.broadcast(t, {3, 2}, axes: [-2]))
 
     test "with and without axes" do
       assert %T{data: %Expr{op: :broadcast, args: [_, _, [2]]}, shape: {3, 3, 3}} =
@@ -282,27 +282,34 @@ defmodule Nx.DefnTest do
                broadcast_axes(Nx.tensor([1, 2, 3]))
     end
 
-    defn broadcast_collapse1(t),
+    defn(broadcast_collapse1(t),
       do: t |> Nx.broadcast({5, 3}) |> Nx.broadcast({7, 5, 3})
+    )
 
-    defn broadcast_collapse2(t),
+    defn(broadcast_collapse2(t),
       do: t |> Nx.broadcast({3, 5}, axes: [0]) |> Nx.broadcast({3, 5, 7}, axes: [0, 1])
+    )
 
-    defn broadcast_collapse3(t),
+    defn(broadcast_collapse3(t),
       do: t |> Nx.broadcast({3, 5}, axes: [0]) |> Nx.broadcast({3, 7, 5}, axes: [0, 2])
+    )
 
-    defn broadcast_collapse4(t),
+    defn(broadcast_collapse4(t),
       do: t |> Nx.broadcast({3, 5}, axes: [0]) |> Nx.broadcast({7, 3, 5}, axes: [1, 2])
+    )
 
-    defn broadcast_collapse5(t),
+    defn(broadcast_collapse5(t),
       do: t |> Nx.broadcast({5, 3}) |> Nx.broadcast({7, 5, 3, 9}, axes: [1, 2])
+    )
 
-    defn broadcast_collapse6(t),
+    defn(broadcast_collapse6(t),
       do: t |> Nx.broadcast({5, 3, 7}, axes: [1]) |> Nx.broadcast({9, 5, 3, 7}, axes: [1, 2, 3])
+    )
 
-    defn broadcast_collapse7(t),
+    defn(broadcast_collapse7(t),
       do:
         t |> Nx.broadcast({3, 5, 7}, axes: [0, 2]) |> Nx.broadcast({3, 9, 5, 7}, axes: [0, 2, 3])
+    )
 
     test "collapses" do
       assert %T{data: %Expr{op: :broadcast, args: [_, {7, 5, 3}, [1]]}, shape: {7, 5, 3}} =
@@ -329,16 +336,16 @@ defmodule Nx.DefnTest do
   end
 
   describe "squeeze" do
-    defn squeeze(t), do: Nx.squeeze(t)
+    defn(squeeze(t), do: Nx.squeeze(t))
 
     test "sized one dimensions" do
       assert %T{data: %Expr{op: :squeeze, args: [_, [0, 2, 4]]}, shape: {3, 2}} =
                squeeze(Nx.iota({1, 3, 1, 2, 1}))
     end
 
-    defn squeeze_collapse1(t), do: t |> Nx.squeeze(axes: [0, 2]) |> Nx.squeeze(axes: [0, 2])
-    defn squeeze_collapse2(t), do: t |> Nx.squeeze(axes: [3, 1]) |> Nx.squeeze(axes: [2])
-    defn squeeze_collapse3(t), do: t |> Nx.squeeze(axes: [2]) |> Nx.squeeze(axes: [3, 1])
+    defn(squeeze_collapse1(t), do: t |> Nx.squeeze(axes: [0, 2]) |> Nx.squeeze(axes: [0, 2]))
+    defn(squeeze_collapse2(t), do: t |> Nx.squeeze(axes: [3, 1]) |> Nx.squeeze(axes: [2]))
+    defn(squeeze_collapse3(t), do: t |> Nx.squeeze(axes: [2]) |> Nx.squeeze(axes: [3, 1]))
 
     test "with explicit dimensions are collapsed" do
       assert %T{data: %Expr{op: :squeeze, args: [_, [0, 1, 2, 4]]}, shape: {1}, names: [:d]} =
@@ -353,7 +360,7 @@ defmodule Nx.DefnTest do
   end
 
   describe "conditional ops" do
-    defn select(t1, t2, t3), do: Nx.select(t1, t2, t3)
+    defn(select(t1, t2, t3), do: Nx.select(t1, t2, t3))
 
     test "select with tensor predicate" do
       assert %{data: %Expr{op: :select, args: [_, _, _]}, shape: {2, 2}} =
@@ -370,14 +377,15 @@ defmodule Nx.DefnTest do
   end
 
   describe "reduce ops" do
-    defn reduce(t1, acc), do: Nx.reduce(t1, acc, fn x, y -> x + y end)
+    defn(reduce(t1, acc), do: Nx.reduce(t1, acc, fn x, y -> x + y end))
 
-    defn reduce_invalid(t1, amplifier), do: Nx.reduce(t1, 0, fn x, y -> x * amplifier + y end)
+    defn(reduce_invalid(t1, amplifier), do: Nx.reduce(t1, 0, fn x, y -> x * amplifier + y end))
 
-    defn reduce_non_scalar(t1), do: Nx.reduce(t1, 0, fn x, y -> Nx.broadcast(x * y, {1, 1}) end)
+    defn(reduce_non_scalar(t1), do: Nx.reduce(t1, 0, fn x, y -> Nx.broadcast(x * y, {1, 1}) end))
 
-    defn reduce_with_opts(t1, acc),
+    defn(reduce_with_opts(t1, acc),
       do: Nx.reduce(t1, acc, [type: {:f, 64}, axes: [-1]], fn x, y -> x + y end)
+    )
 
     test "reduces with function" do
       assert %{
@@ -411,87 +419,87 @@ defmodule Nx.DefnTest do
   end
 
   describe "operators" do
-    defn add_two(a, b), do: a + b
+    defn(add_two(a, b), do: a + b)
 
     test "+" do
       assert %T{data: %Expr{op: :add, args: [_, _]}} = add_two(1, 2)
     end
 
-    defn subtract_two(a, b), do: a - b
+    defn(subtract_two(a, b), do: a - b)
 
     test "-" do
       assert %T{data: %Expr{op: :subtract, args: [_, _]}} = subtract_two(1, 2)
     end
 
-    defn multiply_two(a, b), do: a * b
+    defn(multiply_two(a, b), do: a * b)
 
     test "*" do
       assert %T{data: %Expr{op: :multiply, args: [_, _]}} = multiply_two(1, 2)
     end
 
-    defn divide_two(a, b), do: a / b
+    defn(divide_two(a, b), do: a / b)
 
     test "/" do
       assert %T{data: %Expr{op: :divide, args: [_, _]}} = divide_two(1, 2)
     end
 
-    defn land_two(a, b), do: a and b
+    defn(land_two(a, b), do: a and b)
 
     test "and" do
       assert %T{data: %Expr{op: :logical_and, args: [_, _]}} = land_two(1, 2)
     end
 
-    defn lor_two(a, b), do: a or b
+    defn(lor_two(a, b), do: a or b)
 
     test "or" do
       assert %T{data: %Expr{op: :logical_or, args: [_, _]}} = lor_two(1, 2)
     end
 
-    defn lnot(a), do: not a
+    defn(lnot(a), do: not a)
 
     test "not" do
       assert %T{data: %Expr{op: :equal, args: [_, _]}} = lnot(1)
     end
 
-    defn band_two(a, b), do: a &&& b
+    defn(band_two(a, b), do: a &&& b)
 
     test "&&&" do
       assert %T{data: %Expr{op: :bitwise_and, args: [_, _]}} = band_two(1, 2)
     end
 
-    defn bor_two(a, b), do: a ||| b
+    defn(bor_two(a, b), do: a ||| b)
 
     test "|||" do
       assert %T{data: %Expr{op: :bitwise_or, args: [_, _]}} = bor_two(1, 2)
     end
 
-    defn bsl_two(a, b), do: a <<< b
+    defn(bsl_two(a, b), do: a <<< b)
 
     test "<<<" do
       assert %T{data: %Expr{op: :left_shift, args: [_, _]}} = bsl_two(1, 2)
     end
 
-    defn bsr_two(a, b), do: a >>> b
+    defn(bsr_two(a, b), do: a >>> b)
 
     test ">>>" do
       assert %T{data: %Expr{op: :right_shift, args: [_, _]}} = bsr_two(1, 2)
     end
 
-    defn add_two_with_pipe(a, b), do: a |> Nx.add(b)
+    defn(add_two_with_pipe(a, b), do: a |> Nx.add(b))
 
     test "|>" do
       assert %T{data: %Expr{op: :add, args: [_, _]}} = add_two_with_pipe(1, 2)
     end
 
-    defn unary_plus(a), do: +a
-    defn unary_minus(a), do: -a
+    defn(unary_plus(a), do: +a)
+    defn(unary_minus(a), do: -a)
 
     test "unary plus and minus" do
       assert %T{data: %Expr{op: :parameter, args: [_]}} = unary_plus(1)
       assert %T{data: %Expr{op: :negate, args: [_]}} = unary_minus(1)
     end
 
-    defn unary_bnot(a), do: ~~~a
+    defn(unary_bnot(a), do: ~~~a)
 
     test "~~~" do
       assert %T{data: %Expr{op: :bitwise_not, args: [_]}} = unary_bnot(1)
@@ -515,9 +523,9 @@ defmodule Nx.DefnTest do
       assert %T{data: %Expr{op: :min, args: [_, _]}} = min_two(1, 2)
     end
 
-    defn maxu(a), do: rewrite_types(a, max_unsigned_type: {:u, 32})
-    defn maxs(a), do: rewrite_types(a, max_signed_type: {:s, 32})
-    defn maxf(a), do: rewrite_types(a, max_float_type: {:f, 32})
+    defn(maxu(a), do: rewrite_types(a, max_unsigned_type: {:u, 32}))
+    defn(maxs(a), do: rewrite_types(a, max_signed_type: {:s, 32}))
+    defn(maxf(a), do: rewrite_types(a, max_float_type: {:f, 32}))
 
     test "max_*_type/2" do
       assert %T{data: %Expr{op: :as_type, args: [_]}} = maxu(Nx.tensor(1, type: {:u, 64}))
@@ -527,7 +535,7 @@ defmodule Nx.DefnTest do
   end
 
   describe "access" do
-    defn single_access(t), do: {t[0], t[-1]}
+    defn(single_access(t), do: {t[0], t[-1]})
 
     test "single dimensional single access" do
       {zero, minus_one} = single_access(Nx.tensor([1, 2, 3, 4, 5]))
@@ -555,7 +563,7 @@ defmodule Nx.DefnTest do
              } = slice
     end
 
-    defn multi_access(t), do: t[1][2][3]
+    defn(multi_access(t), do: t[1][2][3])
 
     test "multi dimensional multi-access with integers is collapsed" do
       assert %T{data: %Expr{op: :squeeze, args: [slice, [0, 1, 2]]}, shape: {}} =
@@ -567,7 +575,7 @@ defmodule Nx.DefnTest do
              } = slice
     end
 
-    defn range_access(t), do: t[1][1..2]
+    defn(range_access(t), do: t[1][1..2])
 
     test "multi dimensional multi-access with ranges is collapsed" do
       assert %T{data: %Expr{op: :squeeze, args: [slice, [0]]}, shape: {2, 5}} =
@@ -579,7 +587,7 @@ defmodule Nx.DefnTest do
              } = slice
     end
 
-    defn keyword_access(t), do: t[[z: 1..-2]][[y: 1..2]]
+    defn(keyword_access(t), do: t[[z: 1..-2]][[y: 1..2]])
 
     test "multi dimensional multi-access with keywords is collapsed" do
       assert %T{
@@ -588,7 +596,7 @@ defmodule Nx.DefnTest do
              } = keyword_access(Nx.iota({3, 4, 5}, names: [:x, :y, :z]))
     end
 
-    defn elixir_access(a, opts \\ []), do: Nx.sum(a, axes: opts[:axes])
+    defn(elixir_access(a, opts \\ []), do: Nx.sum(a, axes: opts[:axes]))
 
     test "also works for other Elixir data structures" do
       assert %T{data: %Expr{op: :sum, args: [_, [axes: [1], keep_axes: false]]}} =
@@ -651,7 +659,7 @@ defmodule Nx.DefnTest do
 
     dynamic_name = String.to_atom(Enum.join(~w(dynamic name add two), "_"))
     operator = :add
-    defn unquote(dynamic_name)(left, right), do: Nx.unquote(operator)(left, right)
+    defn(unquote(dynamic_name)(left, right), do: Nx.unquote(operator)(left, right))
 
     test "dynamic name" do
       assert %T{data: %Expr{op: :add, args: [_, _]}} = dynamic_name_add_two(1, 2)
@@ -686,16 +694,16 @@ defmodule Nx.DefnTest do
 
   describe "remote functions" do
     defmodule Remote do
-      defn add_two(c, d), do: c + d
+      defn(add_two(c, d), do: c + d)
     end
 
-    defn add_two_remote(a, b), do: Remote.add_two(a, b)
+    defn(add_two_remote(a, b), do: Remote.add_two(a, b))
 
     test "public" do
       assert %T{data: %Expr{op: :add, args: [_, _]}} = add_two_remote(1, 2)
     end
 
-    defn add_two_unknown(a, b), do: Nx.DefnTest.unknown(a, b)
+    defn(add_two_unknown(a, b), do: Nx.DefnTest.unknown(a, b))
 
     test "invalid remote" do
       assert_raise UndefinedFunctionError,
@@ -705,8 +713,8 @@ defmodule Nx.DefnTest do
   end
 
   describe "if" do
-    defn if3(a, b, c), do: if(a, do: b, else: c)
-    defn if2(a, b), do: if(a, do: b)
+    defn(if3(a, b, c), do: if(a, do: b, else: c))
+    defn(if2(a, b), do: if(a, do: b))
 
     test "converges types" do
       assert %T{data: %Expr{op: :cond}, shape: {}, type: {:f, 32}} =
@@ -733,7 +741,7 @@ defmodule Nx.DefnTest do
   end
 
   describe "lu" do
-    defn lu(t), do: Nx.LinAlg.lu(t)
+    defn(lu(t), do: Nx.LinAlg.lu(t))
 
     test "returns tuples" do
       assert {p, l, u} = lu(Nx.iota({3, 3}))
@@ -745,7 +753,7 @@ defmodule Nx.DefnTest do
   end
 
   describe "qr" do
-    defn qr(t), do: Nx.LinAlg.qr(t)
+    defn(qr(t), do: Nx.LinAlg.qr(t))
 
     test "returns tuples" do
       assert {left, right} = qr(Nx.iota({3, 2}))
@@ -756,7 +764,7 @@ defmodule Nx.DefnTest do
   end
 
   describe "svd" do
-    defn svd(t), do: Nx.LinAlg.svd(t)
+    defn(svd(t), do: Nx.LinAlg.svd(t))
 
     test "returns tuples" do
       assert {u, s, vt} = svd(Nx.iota({3, 3}))
@@ -878,7 +886,7 @@ defmodule Nx.DefnTest do
       final_back_and_forth(a)
     end
 
-    defn final_back_and_forth(a), do: Nx.tanh(a)
+    defn(final_back_and_forth(a), do: Nx.tanh(a))
 
     test "back and forth between Elixir and defn" do
       assert transform_back_and_forth(Nx.tensor(1)) ==
@@ -896,7 +904,7 @@ defmodule Nx.DefnTest do
   end
 
   describe "jit" do
-    defn defn_jit({a, b}, c), do: a + b - c
+    defn(defn_jit({a, b}, c), do: a + b - c)
 
     def elixir_jit({a, b}, c) do
       true = Process.get(Nx.Defn.Compiler) in [Nx.Defn.Evaluator, Identity]
@@ -929,7 +937,7 @@ defmodule Nx.DefnTest do
                    end
     end
 
-    defn jit_iota(), do: Nx.iota({3, 3})
+    defn(jit_iota(), do: Nx.iota({3, 3}))
 
     @tag :capture_log
     test "uses the default backend on iota" do
@@ -940,7 +948,7 @@ defmodule Nx.DefnTest do
   end
 
   describe "async" do
-    defn defn_async({a, b}, c), do: a + b - c
+    defn(defn_async({a, b}, c), do: a + b - c)
 
     def elixir_async({a, b}, c) do
       true = Process.get(Nx.Defn.Compiler) in [Nx.Defn.Evaluator, Identity]
@@ -986,7 +994,7 @@ defmodule Nx.DefnTest do
       assert catch_exit(Nx.Async.await!(async)) == {:noproc, {Nx.Async, :await!, [async]}}
     end
 
-    defn async_iota(), do: Nx.iota({3, 3})
+    defn(async_iota(), do: Nx.iota({3, 3}))
 
     @tag :capture_log
     test "uses the default backend on iota" do
@@ -1018,7 +1026,7 @@ defmodule Nx.DefnTest do
                    fn ->
                      defmodule Sample do
                        import Nx.Defn
-                       defn add(1, 2), do: 3
+                       defn(add(1, 2), do: 3)
                      end
                    end
     end
@@ -1029,7 +1037,7 @@ defmodule Nx.DefnTest do
                    fn ->
                      defmodule Sample do
                        import Nx.Defn
-                       defn add(a, a), do: 3
+                       defn(add(a, a), do: 3)
                      end
                    end
     end
@@ -1040,7 +1048,7 @@ defmodule Nx.DefnTest do
                    fn ->
                      defmodule Sample do
                        import Nx.Defn
-                       defn add(a), do: {b, b} = a
+                       defn(add(a), do: {b, b} = a)
                      end
                    end
     end
@@ -1052,7 +1060,7 @@ defmodule Nx.DefnTest do
                      defmodule Sample do
                        @defn_compiler "unknown"
                        import Nx.Defn
-                       defn add(a, b), do: a + b
+                       defn(add(a, b), do: a + b)
                      end
                    end
     end
@@ -1064,7 +1072,7 @@ defmodule Nx.DefnTest do
                      defmodule Sample do
                        @default_defn_compiler "unknown"
                        import Nx.Defn
-                       defn add(a, b), do: a + b
+                       defn(add(a, b), do: a + b)
                      end
                    end
     end
@@ -1073,7 +1081,7 @@ defmodule Nx.DefnTest do
   @default_defn_compiler Nx.Defn.Evaluator
 
   describe "default arguments" do
-    defn sum_axis_opts(a, opts \\ []), do: Nx.sum(a, opts)
+    defn(sum_axis_opts(a, opts \\ []), do: Nx.sum(a, opts))
 
     test "are supported" do
       assert sum_axis_opts(Nx.tensor([[1, 2], [3, 4]])) == Nx.tensor(10)
@@ -1081,7 +1089,7 @@ defmodule Nx.DefnTest do
       assert sum_axis_opts(Nx.tensor([[1, 2], [3, 4]]), axes: [1]) == Nx.tensor([3, 7])
     end
 
-    defn random_opts(opts \\ []), do: Nx.random_uniform({}, 0, 1, opts)
+    defn(random_opts(opts \\ []), do: Nx.random_uniform({}, 0, 1, opts))
 
     test "exclusively" do
       assert random_opts([]).type == {:s, 64}
@@ -1089,7 +1097,7 @@ defmodule Nx.DefnTest do
     end
 
     @defn_compiler Identity
-    defn sum_axis_expr(a, opts \\ []), do: Nx.sum(a, opts)
+    defn(sum_axis_expr(a, opts \\ []), do: Nx.sum(a, opts))
 
     test "have their own cache key" do
       sum_axis_expr(Nx.tensor([[1, 2], [3, 4]]), axes: [0])
@@ -1106,8 +1114,8 @@ defmodule Nx.DefnTest do
   end
 
   describe "private definitions" do
-    defnp private(a, b), do: a + b
-    defn calls_private(a, b), do: private(a, b)
+    defnp(private(a, b), do: a + b)
+    defn(calls_private(a, b), do: private(a, b))
 
     test "are supported" do
       assert private(1, 2) == Nx.tensor(3)

--- a/nx/test/nx/defn_test.exs
+++ b/nx/test/nx/defn_test.exs
@@ -26,14 +26,14 @@ defmodule Nx.DefnTest do
 
   describe "constants" do
     @tensor [1, 2, 3]
-    defn(list_constant, do: Nx.tensor(@tensor))
+    defn list_constant, do: Nx.tensor(@tensor)
 
     test "from list" do
       assert %T{data: %Expr{op: :tensor}} = list_constant()
     end
 
     @tensor Nx.to_binary(Nx.tensor([1, 2, 3]))
-    defn(binary_constant, do: Nx.from_binary(@tensor, {:s, 64}))
+    defn binary_constant, do: Nx.from_binary(@tensor, {:s, 64})
 
     test "from binary" do
       assert %T{data: %Expr{op: :tensor}} = binary_constant()
@@ -81,7 +81,7 @@ defmodule Nx.DefnTest do
   end
 
   describe "anonymous functions args" do
-    defn(calls_binary_fun(fun, a, b), do: fun.(a, b))
+    defn calls_binary_fun(fun, a, b), do: fun.(a, b)
 
     test "calls anonymous function directly" do
       assert %T{shape: {}, type: {:f, 32}, data: %Expr{op: :add, args: [left, right]}} =
@@ -91,14 +91,14 @@ defmodule Nx.DefnTest do
       assert %T{data: %Expr{op: :parameter, args: [1]}, type: {:f, 32}} = right
     end
 
-    defn(calls_reduce_fun(fun, t), do: Nx.reduce(t, 0, fun))
+    defn calls_reduce_fun(fun, t), do: Nx.reduce(t, 0, fun)
 
     test "calls anonymous function via reduce" do
       assert %T{shape: {}, type: {:s, 64}, data: %Expr{op: :reduce}} =
                calls_reduce_fun(&Nx.add/2, Nx.tensor([1, 2, 3]))
     end
 
-    defn(calls_tuple_fun({funa, funb}, a, b), do: {funa.(a, b), funb.(a, b)})
+    defn calls_tuple_fun({funa, funb}, a, b), do: {funa.(a, b), funb.(a, b)}
 
     test "calls anonymous function from tuples" do
       assert {%T{shape: {}, type: {:f, 32}, data: %Expr{op: :add, args: [left, right]}},
@@ -115,7 +115,7 @@ defmodule Nx.DefnTest do
   end
 
   describe "unary ops" do
-    defn(exp(t), do: Nx.exp(t))
+    defn exp(t), do: Nx.exp(t)
 
     test "to expr" do
       assert %T{shape: {3}, type: {:f, 32}, data: %Expr{op: :exp, args: [_]}} =
@@ -130,9 +130,9 @@ defmodule Nx.DefnTest do
   end
 
   describe "binary ops" do
-    defn(add(t1, t2), do: Nx.add(t1, t2))
-    defn(add_two_int(t), do: Nx.add(t, 2))
-    defn(add_two_float(t), do: Nx.add(t, 2))
+    defn add(t1, t2), do: Nx.add(t1, t2)
+    defn add_two_int(t), do: Nx.add(t, 2)
+    defn add_two_float(t), do: Nx.add(t, 2)
 
     test "to expr" do
       assert %T{shape: {3}, type: {:s, 64}, data: %Expr{op: :add, args: [_, _]}} =
@@ -158,10 +158,10 @@ defmodule Nx.DefnTest do
   end
 
   describe "aggregate axes ops" do
-    defn(sum_all(t), do: Nx.sum(t))
-    defn(sum_pos(t), do: Nx.sum(t, axes: [0, 1]))
-    defn(sum_neg(t), do: Nx.sum(t, axes: [-1, -2]))
-    defn(sum_keep(t), do: Nx.sum(t, axes: [0, 1], keep_axes: true))
+    defn sum_all(t), do: Nx.sum(t)
+    defn sum_pos(t), do: Nx.sum(t, axes: [0, 1])
+    defn sum_neg(t), do: Nx.sum(t, axes: [-1, -2])
+    defn sum_keep(t), do: Nx.sum(t, axes: [0, 1], keep_axes: true)
 
     test "to expr" do
       assert %T{
@@ -203,10 +203,10 @@ defmodule Nx.DefnTest do
   end
 
   describe "creation ops" do
-    defn(iota(t), do: Nx.iota(t))
-    defn(eye, do: Nx.eye(2))
-    defn(random_uniform(t), do: Nx.random_uniform(t, 0.0, 2.0))
-    defn(random_normal(t), do: Nx.random_normal(t, 0.0, 1.0))
+    defn iota(t), do: Nx.iota(t)
+    defn eye, do: Nx.eye(2)
+    defn random_uniform(t), do: Nx.random_uniform(t, 0.0, 2.0)
+    defn random_normal(t), do: Nx.random_normal(t, 0.0, 1.0)
 
     test "iota" do
       assert %T{shape: {3}, data: %Expr{op: :iota, args: [nil]}} = iota(Nx.tensor([1, 2, 3]))
@@ -230,12 +230,12 @@ defmodule Nx.DefnTest do
   end
 
   describe "tensor ops" do
-    defn(dot2(t1, t2), do: Nx.dot(t1, t2))
-    defn(dot6(t1, t2), do: Nx.dot(t1, [-2], [], t2, [-1], []))
-    defn(outer(t1, t2), do: Nx.outer(t1, t2))
-    defn(transpose_1(t), do: Nx.transpose(t))
-    defn(transpose_2(t), do: Nx.transpose(t, axes: [-1, -2]))
-    defn(reshape(t), do: Nx.reshape(t, {2, 3}))
+    defn dot2(t1, t2), do: Nx.dot(t1, t2)
+    defn dot6(t1, t2), do: Nx.dot(t1, [-2], [], t2, [-1], [])
+    defn outer(t1, t2), do: Nx.outer(t1, t2)
+    defn transpose_1(t), do: Nx.transpose(t)
+    defn transpose_2(t), do: Nx.transpose(t, axes: [-1, -2])
+    defn reshape(t), do: Nx.reshape(t, {2, 3})
 
     test "dot product" do
       assert %T{data: %Expr{op: :dot, args: [_, [0], _, _, [0], _]}, shape: {2}} =
@@ -271,8 +271,8 @@ defmodule Nx.DefnTest do
   end
 
   describe "broadcast" do
-    defn(broadcast(t), do: Nx.broadcast(t, {3, 3, 3}))
-    defn(broadcast_axes(t), do: Nx.broadcast(t, {3, 2}, axes: [-2]))
+    defn broadcast(t), do: Nx.broadcast(t, {3, 3, 3})
+    defn broadcast_axes(t), do: Nx.broadcast(t, {3, 2}, axes: [-2])
 
     test "with and without axes" do
       assert %T{data: %Expr{op: :broadcast, args: [_, _, [2]]}, shape: {3, 3, 3}} =
@@ -282,34 +282,27 @@ defmodule Nx.DefnTest do
                broadcast_axes(Nx.tensor([1, 2, 3]))
     end
 
-    defn(broadcast_collapse1(t),
+    defn broadcast_collapse1(t),
       do: t |> Nx.broadcast({5, 3}) |> Nx.broadcast({7, 5, 3})
-    )
 
-    defn(broadcast_collapse2(t),
+    defn broadcast_collapse2(t),
       do: t |> Nx.broadcast({3, 5}, axes: [0]) |> Nx.broadcast({3, 5, 7}, axes: [0, 1])
-    )
 
-    defn(broadcast_collapse3(t),
+    defn broadcast_collapse3(t),
       do: t |> Nx.broadcast({3, 5}, axes: [0]) |> Nx.broadcast({3, 7, 5}, axes: [0, 2])
-    )
 
-    defn(broadcast_collapse4(t),
+    defn broadcast_collapse4(t),
       do: t |> Nx.broadcast({3, 5}, axes: [0]) |> Nx.broadcast({7, 3, 5}, axes: [1, 2])
-    )
 
-    defn(broadcast_collapse5(t),
+    defn broadcast_collapse5(t),
       do: t |> Nx.broadcast({5, 3}) |> Nx.broadcast({7, 5, 3, 9}, axes: [1, 2])
-    )
 
-    defn(broadcast_collapse6(t),
+    defn broadcast_collapse6(t),
       do: t |> Nx.broadcast({5, 3, 7}, axes: [1]) |> Nx.broadcast({9, 5, 3, 7}, axes: [1, 2, 3])
-    )
 
-    defn(broadcast_collapse7(t),
+    defn broadcast_collapse7(t),
       do:
         t |> Nx.broadcast({3, 5, 7}, axes: [0, 2]) |> Nx.broadcast({3, 9, 5, 7}, axes: [0, 2, 3])
-    )
 
     test "collapses" do
       assert %T{data: %Expr{op: :broadcast, args: [_, {7, 5, 3}, [1]]}, shape: {7, 5, 3}} =
@@ -336,16 +329,16 @@ defmodule Nx.DefnTest do
   end
 
   describe "squeeze" do
-    defn(squeeze(t), do: Nx.squeeze(t))
+    defn squeeze(t), do: Nx.squeeze(t)
 
     test "sized one dimensions" do
       assert %T{data: %Expr{op: :squeeze, args: [_, [0, 2, 4]]}, shape: {3, 2}} =
                squeeze(Nx.iota({1, 3, 1, 2, 1}))
     end
 
-    defn(squeeze_collapse1(t), do: t |> Nx.squeeze(axes: [0, 2]) |> Nx.squeeze(axes: [0, 2]))
-    defn(squeeze_collapse2(t), do: t |> Nx.squeeze(axes: [3, 1]) |> Nx.squeeze(axes: [2]))
-    defn(squeeze_collapse3(t), do: t |> Nx.squeeze(axes: [2]) |> Nx.squeeze(axes: [3, 1]))
+    defn squeeze_collapse1(t), do: t |> Nx.squeeze(axes: [0, 2]) |> Nx.squeeze(axes: [0, 2])
+    defn squeeze_collapse2(t), do: t |> Nx.squeeze(axes: [3, 1]) |> Nx.squeeze(axes: [2])
+    defn squeeze_collapse3(t), do: t |> Nx.squeeze(axes: [2]) |> Nx.squeeze(axes: [3, 1])
 
     test "with explicit dimensions are collapsed" do
       assert %T{data: %Expr{op: :squeeze, args: [_, [0, 1, 2, 4]]}, shape: {1}, names: [:d]} =
@@ -360,7 +353,7 @@ defmodule Nx.DefnTest do
   end
 
   describe "conditional ops" do
-    defn(select(t1, t2, t3), do: Nx.select(t1, t2, t3))
+    defn select(t1, t2, t3), do: Nx.select(t1, t2, t3)
 
     test "select with tensor predicate" do
       assert %{data: %Expr{op: :select, args: [_, _, _]}, shape: {2, 2}} =
@@ -377,15 +370,14 @@ defmodule Nx.DefnTest do
   end
 
   describe "reduce ops" do
-    defn(reduce(t1, acc), do: Nx.reduce(t1, acc, fn x, y -> x + y end))
+    defn reduce(t1, acc), do: Nx.reduce(t1, acc, fn x, y -> x + y end)
 
-    defn(reduce_invalid(t1, amplifier), do: Nx.reduce(t1, 0, fn x, y -> x * amplifier + y end))
+    defn reduce_invalid(t1, amplifier), do: Nx.reduce(t1, 0, fn x, y -> x * amplifier + y end)
 
-    defn(reduce_non_scalar(t1), do: Nx.reduce(t1, 0, fn x, y -> Nx.broadcast(x * y, {1, 1}) end))
+    defn reduce_non_scalar(t1), do: Nx.reduce(t1, 0, fn x, y -> Nx.broadcast(x * y, {1, 1}) end)
 
-    defn(reduce_with_opts(t1, acc),
+    defn reduce_with_opts(t1, acc),
       do: Nx.reduce(t1, acc, [type: {:f, 64}, axes: [-1]], fn x, y -> x + y end)
-    )
 
     test "reduces with function" do
       assert %{
@@ -419,87 +411,87 @@ defmodule Nx.DefnTest do
   end
 
   describe "operators" do
-    defn(add_two(a, b), do: a + b)
+    defn add_two(a, b), do: a + b
 
     test "+" do
       assert %T{data: %Expr{op: :add, args: [_, _]}} = add_two(1, 2)
     end
 
-    defn(subtract_two(a, b), do: a - b)
+    defn subtract_two(a, b), do: a - b
 
     test "-" do
       assert %T{data: %Expr{op: :subtract, args: [_, _]}} = subtract_two(1, 2)
     end
 
-    defn(multiply_two(a, b), do: a * b)
+    defn multiply_two(a, b), do: a * b
 
     test "*" do
       assert %T{data: %Expr{op: :multiply, args: [_, _]}} = multiply_two(1, 2)
     end
 
-    defn(divide_two(a, b), do: a / b)
+    defn divide_two(a, b), do: a / b
 
     test "/" do
       assert %T{data: %Expr{op: :divide, args: [_, _]}} = divide_two(1, 2)
     end
 
-    defn(land_two(a, b), do: a and b)
+    defn land_two(a, b), do: a and b
 
     test "and" do
       assert %T{data: %Expr{op: :logical_and, args: [_, _]}} = land_two(1, 2)
     end
 
-    defn(lor_two(a, b), do: a or b)
+    defn lor_two(a, b), do: a or b
 
     test "or" do
       assert %T{data: %Expr{op: :logical_or, args: [_, _]}} = lor_two(1, 2)
     end
 
-    defn(lnot(a), do: not a)
+    defn lnot(a), do: not a
 
     test "not" do
       assert %T{data: %Expr{op: :equal, args: [_, _]}} = lnot(1)
     end
 
-    defn(band_two(a, b), do: a &&& b)
+    defn band_two(a, b), do: a &&& b
 
     test "&&&" do
       assert %T{data: %Expr{op: :bitwise_and, args: [_, _]}} = band_two(1, 2)
     end
 
-    defn(bor_two(a, b), do: a ||| b)
+    defn bor_two(a, b), do: a ||| b
 
     test "|||" do
       assert %T{data: %Expr{op: :bitwise_or, args: [_, _]}} = bor_two(1, 2)
     end
 
-    defn(bsl_two(a, b), do: a <<< b)
+    defn bsl_two(a, b), do: a <<< b
 
     test "<<<" do
       assert %T{data: %Expr{op: :left_shift, args: [_, _]}} = bsl_two(1, 2)
     end
 
-    defn(bsr_two(a, b), do: a >>> b)
+    defn bsr_two(a, b), do: a >>> b
 
     test ">>>" do
       assert %T{data: %Expr{op: :right_shift, args: [_, _]}} = bsr_two(1, 2)
     end
 
-    defn(add_two_with_pipe(a, b), do: a |> Nx.add(b))
+    defn add_two_with_pipe(a, b), do: a |> Nx.add(b)
 
     test "|>" do
       assert %T{data: %Expr{op: :add, args: [_, _]}} = add_two_with_pipe(1, 2)
     end
 
-    defn(unary_plus(a), do: +a)
-    defn(unary_minus(a), do: -a)
+    defn unary_plus(a), do: +a
+    defn unary_minus(a), do: -a
 
     test "unary plus and minus" do
       assert %T{data: %Expr{op: :parameter, args: [_]}} = unary_plus(1)
       assert %T{data: %Expr{op: :negate, args: [_]}} = unary_minus(1)
     end
 
-    defn(unary_bnot(a), do: ~~~a)
+    defn unary_bnot(a), do: ~~~a
 
     test "~~~" do
       assert %T{data: %Expr{op: :bitwise_not, args: [_]}} = unary_bnot(1)
@@ -523,9 +515,9 @@ defmodule Nx.DefnTest do
       assert %T{data: %Expr{op: :min, args: [_, _]}} = min_two(1, 2)
     end
 
-    defn(maxu(a), do: rewrite_types(a, max_unsigned_type: {:u, 32}))
-    defn(maxs(a), do: rewrite_types(a, max_signed_type: {:s, 32}))
-    defn(maxf(a), do: rewrite_types(a, max_float_type: {:f, 32}))
+    defn maxu(a), do: rewrite_types(a, max_unsigned_type: {:u, 32})
+    defn maxs(a), do: rewrite_types(a, max_signed_type: {:s, 32})
+    defn maxf(a), do: rewrite_types(a, max_float_type: {:f, 32})
 
     test "max_*_type/2" do
       assert %T{data: %Expr{op: :as_type, args: [_]}} = maxu(Nx.tensor(1, type: {:u, 64}))
@@ -535,7 +527,7 @@ defmodule Nx.DefnTest do
   end
 
   describe "access" do
-    defn(single_access(t), do: {t[0], t[-1]})
+    defn single_access(t), do: {t[0], t[-1]}
 
     test "single dimensional single access" do
       {zero, minus_one} = single_access(Nx.tensor([1, 2, 3, 4, 5]))
@@ -563,7 +555,7 @@ defmodule Nx.DefnTest do
              } = slice
     end
 
-    defn(multi_access(t), do: t[1][2][3])
+    defn multi_access(t), do: t[1][2][3]
 
     test "multi dimensional multi-access with integers is collapsed" do
       assert %T{data: %Expr{op: :squeeze, args: [slice, [0, 1, 2]]}, shape: {}} =
@@ -575,7 +567,7 @@ defmodule Nx.DefnTest do
              } = slice
     end
 
-    defn(range_access(t), do: t[1][1..2])
+    defn range_access(t), do: t[1][1..2]
 
     test "multi dimensional multi-access with ranges is collapsed" do
       assert %T{data: %Expr{op: :squeeze, args: [slice, [0]]}, shape: {2, 5}} =
@@ -587,7 +579,7 @@ defmodule Nx.DefnTest do
              } = slice
     end
 
-    defn(keyword_access(t), do: t[[z: 1..-2]][[y: 1..2]])
+    defn keyword_access(t), do: t[[z: 1..-2]][[y: 1..2]]
 
     test "multi dimensional multi-access with keywords is collapsed" do
       assert %T{
@@ -596,7 +588,7 @@ defmodule Nx.DefnTest do
              } = keyword_access(Nx.iota({3, 4, 5}, names: [:x, :y, :z]))
     end
 
-    defn(elixir_access(a, opts \\ []), do: Nx.sum(a, axes: opts[:axes]))
+    defn elixir_access(a, opts \\ []), do: Nx.sum(a, axes: opts[:axes])
 
     test "also works for other Elixir data structures" do
       assert %T{data: %Expr{op: :sum, args: [_, [axes: [1], keep_axes: false]]}} =
@@ -659,7 +651,7 @@ defmodule Nx.DefnTest do
 
     dynamic_name = String.to_atom(Enum.join(~w(dynamic name add two), "_"))
     operator = :add
-    defn(unquote(dynamic_name)(left, right), do: Nx.unquote(operator)(left, right))
+    defn unquote(dynamic_name)(left, right), do: Nx.unquote(operator)(left, right)
 
     test "dynamic name" do
       assert %T{data: %Expr{op: :add, args: [_, _]}} = dynamic_name_add_two(1, 2)
@@ -694,16 +686,16 @@ defmodule Nx.DefnTest do
 
   describe "remote functions" do
     defmodule Remote do
-      defn(add_two(c, d), do: c + d)
+      defn add_two(c, d), do: c + d
     end
 
-    defn(add_two_remote(a, b), do: Remote.add_two(a, b))
+    defn add_two_remote(a, b), do: Remote.add_two(a, b)
 
     test "public" do
       assert %T{data: %Expr{op: :add, args: [_, _]}} = add_two_remote(1, 2)
     end
 
-    defn(add_two_unknown(a, b), do: Nx.DefnTest.unknown(a, b))
+    defn add_two_unknown(a, b), do: Nx.DefnTest.unknown(a, b)
 
     test "invalid remote" do
       assert_raise UndefinedFunctionError,
@@ -713,8 +705,8 @@ defmodule Nx.DefnTest do
   end
 
   describe "if" do
-    defn(if3(a, b, c), do: if(a, do: b, else: c))
-    defn(if2(a, b), do: if(a, do: b))
+    defn if3(a, b, c), do: if(a, do: b, else: c)
+    defn if2(a, b), do: if(a, do: b)
 
     test "converges types" do
       assert %T{data: %Expr{op: :cond}, shape: {}, type: {:f, 32}} =
@@ -741,7 +733,7 @@ defmodule Nx.DefnTest do
   end
 
   describe "lu" do
-    defn(lu(t), do: Nx.LinAlg.lu(t))
+    defn lu(t), do: Nx.LinAlg.lu(t)
 
     test "returns tuples" do
       assert {p, l, u} = lu(Nx.iota({3, 3}))
@@ -753,7 +745,7 @@ defmodule Nx.DefnTest do
   end
 
   describe "qr" do
-    defn(qr(t), do: Nx.LinAlg.qr(t))
+    defn qr(t), do: Nx.LinAlg.qr(t)
 
     test "returns tuples" do
       assert {left, right} = qr(Nx.iota({3, 2}))
@@ -764,7 +756,7 @@ defmodule Nx.DefnTest do
   end
 
   describe "svd" do
-    defn(svd(t), do: Nx.LinAlg.svd(t))
+    defn svd(t), do: Nx.LinAlg.svd(t)
 
     test "returns tuples" do
       assert {u, s, vt} = svd(Nx.iota({3, 3}))
@@ -886,7 +878,7 @@ defmodule Nx.DefnTest do
       final_back_and_forth(a)
     end
 
-    defn(final_back_and_forth(a), do: Nx.tanh(a))
+    defn final_back_and_forth(a), do: Nx.tanh(a)
 
     test "back and forth between Elixir and defn" do
       assert transform_back_and_forth(Nx.tensor(1)) ==
@@ -904,7 +896,7 @@ defmodule Nx.DefnTest do
   end
 
   describe "jit" do
-    defn(defn_jit({a, b}, c), do: a + b - c)
+    defn defn_jit({a, b}, c), do: a + b - c
 
     def elixir_jit({a, b}, c) do
       true = Process.get(Nx.Defn.Compiler) in [Nx.Defn.Evaluator, Identity]
@@ -937,7 +929,7 @@ defmodule Nx.DefnTest do
                    end
     end
 
-    defn(jit_iota(), do: Nx.iota({3, 3}))
+    defn jit_iota(), do: Nx.iota({3, 3})
 
     @tag :capture_log
     test "uses the default backend on iota" do
@@ -948,7 +940,7 @@ defmodule Nx.DefnTest do
   end
 
   describe "async" do
-    defn(defn_async({a, b}, c), do: a + b - c)
+    defn defn_async({a, b}, c), do: a + b - c
 
     def elixir_async({a, b}, c) do
       true = Process.get(Nx.Defn.Compiler) in [Nx.Defn.Evaluator, Identity]
@@ -994,7 +986,7 @@ defmodule Nx.DefnTest do
       assert catch_exit(Nx.Async.await!(async)) == {:noproc, {Nx.Async, :await!, [async]}}
     end
 
-    defn(async_iota(), do: Nx.iota({3, 3}))
+    defn async_iota(), do: Nx.iota({3, 3})
 
     @tag :capture_log
     test "uses the default backend on iota" do
@@ -1026,7 +1018,7 @@ defmodule Nx.DefnTest do
                    fn ->
                      defmodule Sample do
                        import Nx.Defn
-                       defn(add(1, 2), do: 3)
+                       defn add(1, 2), do: 3
                      end
                    end
     end
@@ -1037,7 +1029,7 @@ defmodule Nx.DefnTest do
                    fn ->
                      defmodule Sample do
                        import Nx.Defn
-                       defn(add(a, a), do: 3)
+                       defn add(a, a), do: 3
                      end
                    end
     end
@@ -1048,7 +1040,7 @@ defmodule Nx.DefnTest do
                    fn ->
                      defmodule Sample do
                        import Nx.Defn
-                       defn(add(a), do: {b, b} = a)
+                       defn add(a), do: {b, b} = a
                      end
                    end
     end
@@ -1060,7 +1052,7 @@ defmodule Nx.DefnTest do
                      defmodule Sample do
                        @defn_compiler "unknown"
                        import Nx.Defn
-                       defn(add(a, b), do: a + b)
+                       defn add(a, b), do: a + b
                      end
                    end
     end
@@ -1072,7 +1064,7 @@ defmodule Nx.DefnTest do
                      defmodule Sample do
                        @default_defn_compiler "unknown"
                        import Nx.Defn
-                       defn(add(a, b), do: a + b)
+                       defn add(a, b), do: a + b
                      end
                    end
     end
@@ -1081,7 +1073,7 @@ defmodule Nx.DefnTest do
   @default_defn_compiler Nx.Defn.Evaluator
 
   describe "default arguments" do
-    defn(sum_axis_opts(a, opts \\ []), do: Nx.sum(a, opts))
+    defn sum_axis_opts(a, opts \\ []), do: Nx.sum(a, opts)
 
     test "are supported" do
       assert sum_axis_opts(Nx.tensor([[1, 2], [3, 4]])) == Nx.tensor(10)
@@ -1089,7 +1081,7 @@ defmodule Nx.DefnTest do
       assert sum_axis_opts(Nx.tensor([[1, 2], [3, 4]]), axes: [1]) == Nx.tensor([3, 7])
     end
 
-    defn(random_opts(opts \\ []), do: Nx.random_uniform({}, 0, 1, opts))
+    defn random_opts(opts \\ []), do: Nx.random_uniform({}, 0, 1, opts)
 
     test "exclusively" do
       assert random_opts([]).type == {:s, 64}
@@ -1097,7 +1089,7 @@ defmodule Nx.DefnTest do
     end
 
     @defn_compiler Identity
-    defn(sum_axis_expr(a, opts \\ []), do: Nx.sum(a, opts))
+    defn sum_axis_expr(a, opts \\ []), do: Nx.sum(a, opts)
 
     test "have their own cache key" do
       sum_axis_expr(Nx.tensor([[1, 2], [3, 4]]), axes: [0])
@@ -1114,8 +1106,8 @@ defmodule Nx.DefnTest do
   end
 
   describe "private definitions" do
-    defnp(private(a, b), do: a + b)
-    defn(calls_private(a, b), do: private(a, b))
+    defnp private(a, b), do: a + b
+    defn calls_private(a, b), do: private(a, b)
 
     test "are supported" do
       assert private(1, 2) == Nx.tensor(3)


### PR DESCRIPTION
Removes `dot/4` as well in favor of the general `dot/6` and supports `dot/6` in EXLA.