### PR TITLE
Add batch dot gradient

### DIFF
--- a/nx/lib/nx/binary_backend.ex
+++ b/nx/lib/nx/binary_backend.ex
@@ -506,7 +506,8 @@ defmodule Nx.BinaryBackend do
     {right_batch_shape, _right_batch_names} =
       Nx.Shape.contract(right_shape, right_batch_axes, right_names, false)
 
-    batch_item_length = Nx.size(left_batch_shape)
+    left_batch_item_length = Nx.size(left_batch_shape)
+    right_batch_item_length = Nx.size(right_batch_shape)
 
     batch_count = Nx.Shape.batch_count(left_shape, left_batch_axes)
 
@@ -517,13 +518,14 @@ defmodule Nx.BinaryBackend do
 
     bin_result =
       for index <- range do
-        offset = index * batch_item_length
+        left_offset = index * left_batch_item_length
+        right_offset = index * right_batch_item_length
 
-        left_offset_bits = offset * left_size
-        right_offset_bits = offset * right_size
+        left_offset_bits = left_offset * left_size
+        right_offset_bits = right_offset * right_size
 
-        left_batch_item_bits = batch_item_length * left_size
-        right_batch_item_bits = batch_item_length * right_size
+        left_batch_item_bits = left_batch_item_length * left_size
+        right_batch_item_bits = right_batch_item_length * right_size
 
         <<_::bitstring-size(left_offset_bits),
           left_batch_item_binary::bitstring-size(left_batch_item_bits),

--- a/nx/test/nx/defn/grad_test.exs
+++ b/nx/test/nx/defn/grad_test.exs
@@ -396,6 +396,20 @@ defmodule Nx.Defn.GradTest do
              ) ==
                Nx.tensor([25.0, 115.0, 205.0])
     end
+
+    defn grad_batched_dot_rule_lhs(t1, t2) do
+      grad(t1, &Nx.sum(Nx.dot(&1, [1], [0], t2, [2], [0])))
+    end
+
+    test "computes the gradient with dot with batching" do
+      assert grad_batched_dot_rule_lhs(Nx.iota({3, 2, 4}, type: {:f, 32}), Nx.iota({3, 3, 2}, type: {:f, 32})) ==
+        Nx.tensor([[[ 6.0,  6.0,  6.0,  6.0],
+                    [ 9.0,  9.0,  9.0,  9.0]],
+                   [[24.0, 24.0, 24.0, 24.0],
+                    [27.0, 27.0, 27.0, 27.0]],
+                   [[42.0, 42.0, 42.0, 42.0],
+                    [45.0, 45.0, 45.0, 45.0]]])
+    end
   end
 
   describe "conv rule" do

--- a/nx/test/nx_test.exs
+++ b/nx/test/nx_test.exs
@@ -971,6 +971,14 @@ defmodule NxTest do
     end
   end
 
+  describe "dot/6" do
+    test "works with batched dot and different size non-batch dims" do
+      t1 = Nx.iota({3, 2, 4, 1})
+      t2 = Nx.iota({3, 4, 2, 2})
+      assert Nx.dot(t1, [1, 2], [0], t2, [2, 1], [0]) == Nx.tensor([[[280, 308]], [[2200, 2292]], [[6168, 6324]]])
+    end
+  end
+
   describe "reverse/2" do
     test "does nothing when tensor is scalar" do
       t = Nx.tensor(1)


### PR DESCRIPTION
Adds batched dot product gradient. I also suggest we refactor `dot/6` to accept successive batch dimensions starting at 0, it's the same behavior as XLA. We can keep most of the logic, since the successive batch dimensions are basically squeezed, it just retains a different output shape