### PR TITLE
Fix p-norm throwing ArithmeticError for zero vectors

### DIFF
--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -248,6 +248,7 @@ defmodule Nx.LinAlg do
 
   defp norm_integer(%{type: type} = t, ord, opts) when is_integer(ord) do
     output_type = Nx.Type.to_floating(type)
+    inv_ord = Nx.tensor(1 / ord, type: output_type)
 
     # We extract this result to a variable because it's used both for
     # getting the normalization coefficient and for the main pipe chain
@@ -259,18 +260,12 @@ defmodule Nx.LinAlg do
     # avoids numerical overflow.
     numerical_stability_coefficient = Nx.reduce_max(abs_t)
 
-    if numerical_stability_coefficient == Nx.tensor(0, type: type) do
-      Nx.tensor(0, type: output_type)
-    else
-      inv_ord = Nx.tensor(1 / ord, type: output_type)
-
-      abs_t
-      |> Nx.divide(numerical_stability_coefficient)
-      |> Nx.power(ord)
-      |> Nx.sum(opts)
-      |> Nx.power(inv_ord)
-      |> Nx.multiply(numerical_stability_coefficient)
-    end
+    abs_t
+    |> Nx.divide(numerical_stability_coefficient)
+    |> Nx.power(ord)
+    |> Nx.sum(opts)
+    |> Nx.power(inv_ord)
+    |> Nx.multiply(numerical_stability_coefficient)
   end
 
   @doc """

--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -248,7 +248,6 @@ defmodule Nx.LinAlg do
 
   defp norm_integer(%{type: type} = t, ord, opts) when is_integer(ord) do
     output_type = Nx.Type.to_floating(type)
-    inv_ord = Nx.tensor(1 / ord, type: output_type)
 
     # We extract this result to a variable because it's used both for
     # getting the normalization coefficient and for the main pipe chain
@@ -258,14 +257,20 @@ defmodule Nx.LinAlg do
     # The idea is that by dividing the tensor by it, large values of
     # tensor entries and large values of p are reduced, which in turn
     # avoids numerical overflow.
-    numerical_stability_coefficient = Nx.reduce_max(t)
+    numerical_stability_coefficient = Nx.reduce_max(abs_t)
 
-    abs_t
-    |> Nx.divide(numerical_stability_coefficient)
-    |> Nx.power(ord)
-    |> Nx.sum(opts)
-    |> Nx.power(inv_ord)
-    |> Nx.multiply(numerical_stability_coefficient)
+    if numerical_stability_coefficient == Nx.tensor(0, type: type) do
+      Nx.tensor(0, type: output_type)
+    else
+      inv_ord = Nx.tensor(1 / ord, type: output_type)
+
+      abs_t
+      |> Nx.divide(numerical_stability_coefficient)
+      |> Nx.power(ord)
+      |> Nx.sum(opts)
+      |> Nx.power(inv_ord)
+      |> Nx.multiply(numerical_stability_coefficient)
+    end
   end
 
   @doc """

--- a/nx/test/nx/lin_alg_test.exs
+++ b/nx/test/nx/lin_alg_test.exs
@@ -31,6 +31,26 @@ defmodule Nx.LinAlgTest do
         Nx.LinAlg.norm(t, ord: -3)
       end)
     end
+
+    test "returns 0 for a zero vector" do
+      t = Nx.broadcast(0.0, {2})
+      ords = [nil, :inf, :neg_inf, 0, 1, 2, 3]
+
+      Enum.each(ords, fn ord ->
+        float_norm = t |> Nx.LinAlg.norm(ord: ord) |> Nx.as_type({:f, 32})
+        assert float_norm == Nx.tensor(0.0)
+      end)
+    end
+
+    test "returns 0 for a zero matrix" do
+      t = Nx.broadcast(0.0, {2, 2})
+      ords = [nil, :nuclear, :frobenius, :inf, :neg_inf, 1, -1, 2, -2]
+
+      Enum.each(ords, fn ord ->
+        float_norm = t |> Nx.LinAlg.norm(ord: ord) |> Nx.as_type({:f, 32})
+        assert float_norm == Nx.tensor(0.0)
+      end)
+    end
   end
 
   describe "qr" do

--- a/nx/test/nx/lin_alg_test.exs
+++ b/nx/test/nx/lin_alg_test.exs
@@ -31,26 +31,6 @@ defmodule Nx.LinAlgTest do
         Nx.LinAlg.norm(t, ord: -3)
       end)
     end
-
-    test "returns 0 for a zero vector" do
-      t = Nx.broadcast(0.0, {2})
-      ords = [nil, :inf, :neg_inf, 0, 1, 2, 3]
-
-      Enum.each(ords, fn ord ->
-        float_norm = t |> Nx.LinAlg.norm(ord: ord) |> Nx.as_type({:f, 32})
-        assert float_norm == Nx.tensor(0.0)
-      end)
-    end
-
-    test "returns 0 for a zero matrix" do
-      t = Nx.broadcast(0.0, {2, 2})
-      ords = [nil, :nuclear, :frobenius, :inf, :neg_inf, 1, -1, 2, -2]
-
-      Enum.each(ords, fn ord ->
-        float_norm = t |> Nx.LinAlg.norm(ord: ord) |> Nx.as_type({:f, 32})
-        assert float_norm == Nx.tensor(0.0)
-      end)
-    end
   end
 
   describe "qr" do


### PR DESCRIPTION
I found a small thing when fooling around with Nx:

## Issue

Trying to compute the p-norm of a zero vector raises an ArithmeticError.
```elixir
t = Nx.tensor([0,0,0])
Nx.LinAlg.norm(t, ord: 2)

** (ArithmeticError) bad argument in arithmetic expression
    (nx 0.1.0-dev) lib/nx/binary_backend.ex:681: Nx.BinaryBackend.element_divide/3
    (nx 0.1.0-dev) lib/nx/binary_backend.ex:639: Nx.BinaryBackend."-element_wise_bin_op/4-lbc$^17/2-9-"/7
    (nx 0.1.0-dev) lib/nx/binary_backend.ex:638: Nx.BinaryBackend.element_wise_bin_op/4
    (nx 0.1.0-dev) lib/nx/lin_alg.ex:264: Nx.LinAlg.norm_integer/3
```
EDIT: Actually it fails for tensors like `Nx.tensor([0, -2, -3, -1])` as well (0 is the maximum) because abs is not used when computing the stability coefficient.
## Cause

There is this stabilization coefficient that is equal to the maximum absolute value in the tensor (it was non-absolute in the code, I fixed this as well). So for zero vectors the coefficient is zero, which causes a divide-by-zero error in the next step.

Since this is kind of an edge case, I added a regular test for this. It fails on main, works on this branch.

I have some doubts about my code though. I'm not sure whether branching like this and testing for equality with `Nx.tensor(0)` is the way to go. Also typecasting to f32 in the test seems hackish - maybe every norm should return a float? I think that's how numpy handles this, even for 0-norm. Their p-norm is also numerically unstable, so:
```python
a = np.array([1e200])
np.linalg.norm(a)
# inf
```
 Any suggestions/thoughts on this? :smile_cat: 