### PR TITLE
Initial implementation of vmap

### DIFF
--- a/nx/lib/nx/defn/kernel.ex
+++ b/nx/lib/nx/defn/kernel.ex
@@ -234,6 +234,13 @@ defmodule Nx.Defn.Kernel do
   end
 
   @doc """
+  Vectorizes `fun` over given `args`.
+  """
+  def vmap(fun, args, in_axes \\ nil) when is_function(fun) do
+    Nx.Defn.Vectorize.transform(fun, args, in_axes)
+  end
+
+  @doc """
   Computes the value and gradient of the given `var` on `fun`.
 
   It returns a tuple with the value and the gradient.

--- a/nx/lib/nx/defn/kernel.ex
+++ b/nx/lib/nx/defn/kernel.ex
@@ -234,7 +234,32 @@ defmodule Nx.Defn.Kernel do
   end
 
   @doc """
-  Vectorizes `fun` over given `args`.
+  Vectorizes `fun` over `args` with `in_axes`.
+
+  `vmap` acts similar to `apply`; however, the given `fun` is
+  "vectorized" over `in_axes` of the given `args`. `in_axes` are
+  treated as "batch dimensions" in the input function. For example,
+  consider a dot product between 2 rank 3 tensors:
+
+      a = Nx.iota({2, 3, 2})
+      b = Nx.iota({2, 2, 3})
+      Nx.dot(a, b)
+
+  The result would have shape `{2, 2, 2, 2}` as the dot product contracts
+  `a` along axis 1 and `b` along axis 2. With `vmap`, we can compute the
+  dot product such that `Nx.dot(a, b)` is treated as 2 distinct matrix
+  multiplications between matrices with shapes `{3, 2}` and `{2, 3}`:
+
+      a = Nx.iota({2, 3, 2})
+      b = Nx.iota({2, 2, 3})
+      vmap(&Nx.dot(&1, &2), [a, b])
+
+  `a` and `b` are "vectorized" along the leading axis such that the expression
+  is treated as 2 stacked matrix multiplications and the output shape is
+  `{2, 3, 3}`.
+
+  `in_axes` tells which axes to vectorize over. By default, it vectorizes over
+  all leading axes.
   """
   def vmap(fun, args, in_axes \\ nil) when is_function(fun) do
     Nx.Defn.Vectorize.transform(fun, args, in_axes)

--- a/nx/lib/nx/defn/vectorize.ex
+++ b/nx/lib/nx/defn/vectorize.ex
@@ -1,0 +1,86 @@
+defmodule Nx.Defn.Vectorize do
+  @moduledoc false
+
+  alias Nx.Defn.{Expr, Tree}
+  alias Nx.Tensor, as: T
+
+  def transform(fun, args, in_axes) do
+    in_axes =
+      case in_axes do
+        nil ->
+          List.duplicate(0, length(args))
+
+        in_axes when is_list(in_axes) ->
+          in_axes
+      end
+
+    validate_in_axes!(args, in_axes, args, in_axes, 0, [])
+
+    expr = apply(fun, args)
+
+    {vectorized, _} = to_vectorized(expr, in_axes, %{})
+
+    vectorized
+  end
+
+  defp validate_in_axes!(all_args, all_axes, [_ | args], [nil | in_axes], i, batch_sizes) do
+    validate_in_axes!(all_args, all_axes, args, in_axes, i + 1, batch_sizes)
+  end
+
+  defp validate_in_axes!(all_args, all_axes, [t | args], [axis | in_axes], i, batch_sizes) do
+    unless axis < Nx.rank(t) do
+      raise ArgumentError, "vmap input axes cannot exceed rank of input tensor"
+                           <> " arg #{inspect(i)} has rank #{inspect(Nx.rank(t))}"
+                           <> " and axis #{inspect(axis)}"
+    end
+
+    validate_in_axes!(all_args, all_axes, args, in_axes, i + 1, [elem(Nx.shape(t), axis) | batch_sizes])
+  end
+
+  defp validate_in_axes!(_, axes, [], [], _, batch_sizes) do
+    case Enum.uniq(batch_sizes) do
+      [_] ->
+        :ok
+
+      [] ->
+        raise ArgumentError, "at least 1 input axis passed to vmap must be non-nil"
+
+      _ ->
+        raise ArgumentError, "input batch sizes must match, got sizes #{inspect(Enum.reverse(batch_sizes))}"
+                             <> " for axes #{inspect(axes)}"
+    end
+  end
+
+  defp validate_in_axes!(args, in_axes, _, _, _, _) do
+    raise ArgumentError, "length of vmap input axes must match length of function"
+                         " arguments, got #{inspect(args)} and #{inspect(in_axes)}"
+  end
+
+  defp to_vectorized(expr, in_axes, cache) do
+    Tree.composite(expr, cache, fn
+      %T{data: %Expr{id: id, op: op, args: args}} = expr, cache ->
+        case cache do
+          %{^id => res} ->
+            {res, cache}
+
+          %{} ->
+            {res, cache} = vectorize(op, args, in_axes, expr, cache)
+            {res, Map.put(cache, id, res)}
+        end
+    end)
+  end
+
+  ## Defvectorized
+
+  ## These functions have no need for a batching rule.
+
+  @defvectorized [:parameter, :negate, :sign, :floor, :ceil, :round, :exp, :log] ++
+                 [:expm1, :log1p, :tanh, :sin, :cos, :tan, :asin, :acos, :atan, :abs] ++
+                 [:atan2, :sinh, :cosh, :asinh, :acosh, :atanh, :erf, :erfc, :erf_inv] ++
+                 [:sqrt, :rsqrt, :power, :bitwise_not, :population_count, :count_leading_zeros] ++
+                 [:scalar, :tensor, :parameter, :eye, :iota, :random_uniform, :random_normal]
+
+  defp vectorize(op, _, _, expr, cache) when op in @defvectorized do
+    {expr, cache}
+  end
+end

--- a/nx/lib/nx/defn/vectorize.ex
+++ b/nx/lib/nx/defn/vectorize.ex
@@ -64,6 +64,7 @@ defmodule Nx.Defn.Vectorize do
             {res, cache}
 
           %{} ->
+            {args, cache} = Tree.traverse_args(expr, cache, &to_vectorized(&1, in_axes, &2))
             {res, cache} = vectorize(op, args, in_axes, expr, cache)
             {res, Map.put(cache, id, res)}
         end
@@ -74,13 +75,60 @@ defmodule Nx.Defn.Vectorize do
 
   ## These functions have no need for a batching rule.
 
-  @defvectorized [:parameter, :negate, :sign, :floor, :ceil, :round, :exp, :log] ++
+  @defvectorized [:negate, :sign, :floor, :ceil, :round, :exp, :log] ++
                  [:expm1, :log1p, :tanh, :sin, :cos, :tan, :asin, :acos, :atan, :abs] ++
                  [:atan2, :sinh, :cosh, :asinh, :acosh, :atanh, :erf, :erfc, :erf_inv] ++
-                 [:sqrt, :rsqrt, :power, :bitwise_not, :population_count, :count_leading_zeros] ++
-                 [:scalar, :tensor, :parameter, :eye, :iota, :random_uniform, :random_normal]
+                 [:sqrt, :rsqrt, :power, :bitwise_not, :population_count, :count_leading_zeros]
 
-  defp vectorize(op, _, _, expr, cache) when op in @defvectorized do
+  defp vectorize(op, [arg], _, _expr, cache) when op in @defvectorized do
+    {apply(Nx, op, [arg]), cache}
+  end
+
+  @constants [:scalar, :tensor, :parameter]
+
+  defp vectorize(op, _, _, expr, cache) when op in @constants do
     {expr, cache}
   end
+
+  ## Special
+
+  defp vectorize(:dot, [lhs, lhs_c_dims, lhs_b_dims, rhs, rhs_c_dims, rhs_b_dims], [lhs_in_axis, rhs_in_axis], expr, cache) do
+    {lhs_contract, lhs_batch, rhs_contract, rhs_batch} =
+      case {lhs_in_axis, rhs_in_axis} do
+        {lbd, nil} ->
+          lhs_batch = bump_dims(lhs_b_dims, lbd)
+          lhs_contract = bump_dims(lhs_c_dims, lbd)
+          {lhs_contract, lhs_batch, rhs_c_dims, rhs_b_dims}
+
+        {nil, rbd} ->
+          rhs_batch = bump_dims(rhs_b_dims, rbd)
+          rhs_contract = bump_dims(rhs_c_dims, rbd)
+          {lhs_c_dims, lhs_b_dims, rhs_contract, rhs_batch}
+
+        {lbd, rbd} ->
+          lhs_batch = [lbd] ++ bump_dims(lhs_b_dims, lbd)
+          rhs_batch = [rbd] ++ bump_dims(rhs_b_dims, rbd)
+          lhs_contract = bump_dims(lhs_c_dims, lbd)
+          rhs_contract = bump_dims(rhs_c_dims, rbd)
+          {lhs_contract, lhs_batch, rhs_contract, rhs_batch}
+      end
+
+    IO.inspect lhs_batch
+    IO.inspect lhs_contract
+    IO.inspect rhs_batch
+    IO.inspect rhs_contract
+
+    {Nx.dot(lhs, lhs_contract, lhs_batch, rhs, rhs_contract, rhs_batch), cache}
+  end
+
+  defp bump_dims(dims, b) do
+    Enum.map(dims, fn d -> if d >= b, do: d + 1, else: d end)
+  end
+
+  ## Not implemented
+
+  defp vectorize(op, _, _, _, _) do
+    raise ArgumentError, "vmap not implemented for #{inspect(op)}"
+  end
+
 end

--- a/nx/test/nx/defn/vmap_test.exs
+++ b/nx/test/nx/defn/vmap_test.exs
@@ -1,0 +1,67 @@
+defmodule Nx.Defn.VmapTest do
+  use ExUnit.Case, async: true
+
+  import Nx.Defn
+
+  describe "simple" do
+    defn vmap_itself(t), do: vmap(fn t -> t end, [t])
+    defn vmap_tensor(t), do: vmap(fn _t -> Nx.tensor(1.0) end, [t])
+    defn vmap_tuple(t1, t2), do: vmap(fn t1, t2 -> {t1, t2} end, [t1, t2])
+
+    test "vectorizes in simple cases" do
+      assert vmap_itself(Nx.tensor([1])) == Nx.tensor([1])
+      assert vmap_tensor(Nx.tensor([1])) == Nx.tensor(1.0)
+      assert vmap_tuple(Nx.tensor([1]), Nx.tensor([1])) == {Nx.tensor([1]), Nx.tensor([1])}
+    end
+  end
+
+  describe "error cases" do
+    defn vmap_invalid_in_axis(t1, t2), do: vmap(fn t1, t2 -> Nx.add(t1, t2) end, [t1, t2], [0, 2])
+
+    test "invalid in axis" do
+      assert_raise ArgumentError, ~r/vmap input axes cannot exceed rank/, fn ->
+        vmap_invalid_in_axis(Nx.tensor(1), Nx.tensor(1))
+      end
+    end
+
+    defn vmap_too_many_axes(t), do: vmap(fn t -> t end, [t], [0, 0])
+
+    test "too many axes" do
+      assert_raise ArgumentError, ~r/length of vmap input axes/, fn ->
+        vmap_too_many_axes(Nx.tensor([1]))
+      end
+    end
+
+    defn vmap_too_few_axes(t1, t2), do: vmap(fn t1, _ -> t1 end, [t1, t2], [0])
+
+    test "too few axes" do
+      assert_raise ArgumentError, ~r/length of vmap input axes/, fn ->
+        vmap_too_few_axes(Nx.tensor([1]), Nx.tensor([1]))
+      end
+    end
+
+    defn vmap_batch_sizes_not_matching(t1, t2), do: vmap(fn t1, t2 -> {t1, t2} end, [t1, t2], [0, 0])
+
+    test "batch sizes do not match" do
+      assert_raise ArgumentError, ~r/batch sizes must match/, fn ->
+        vmap_batch_sizes_not_matching(Nx.iota({2, 3, 2}), Nx.iota({1, 2, 3}))
+      end
+    end
+
+    defn vmap_no_non_nil(t1), do: vmap(fn t1 -> t1 end, [t1], [nil])
+
+    test "at least one non-nil axis" do
+      assert_raise ArgumentError, ~r/at least 1 input axis passed to vmap must be non-nil/, fn ->
+        vmap_no_non_nil(Nx.iota({2, 3, 2}))
+      end
+    end
+  end
+
+  describe "element-wise unary ops" do
+    defn vmap_cos(t), do: vmap(fn t -> Nx.cos(t) end, [t])
+
+    test "vectorizes over cos" do
+      assert vmap_cos(Nx.iota({4, 4, 4})) == Nx.cos(Nx.iota({4, 4, 4}))
+    end
+  end
+end


### PR DESCRIPTION
WIP

This is an attempt to resolve #174. I've implemented `vmap` in basically the same style as `grad` except it supports multiple vectorized arguments. We don't include `out_axes` like Jax, but that's easy to add either with an additional `transpose` or to propagate during the expression transformation.

There are still a lot of checks and validations that need to be done:

- Normalize in axes
- Do we support multiple in axes?
- What constraints should be placed on in axes?

I wanted to open this to collect feedback on the foundation before moving forward with implementing some additional batch rules. Based on this PR, we'd then have to revisit some Nx implementations to support batching. Off the top of my head I believe most of the LinAlg operators will need to support batched matrix operations.

I think we can also discuss the possibility of implementing automatic vectorization based on input names (e.g. `:batch` name is always treated as a batch dimension). 
