### PR TITLE
LibTorch Makefile version check

### DIFF
--- a/torchx/Makefile
+++ b/torchx/Makefile
@@ -1,5 +1,5 @@
 LIBTORCH_VERSION := $(shell head -c 3 $(LIBTORCH_DIR)/build-version)
-REQUIRED_LIBTORCH_VERSION := 1.8
+MINIMUM_LIBTORCH_VERSION := 1.8
 
 LIBTORCH_INCLUDE_PATH = $(LIBTORCH_DIR)/include/
 LIBTORCH_API_INCLUDE_PATH = $(LIBTORCH_DIR)/include/torch/csrc/api/include
@@ -26,8 +26,8 @@ check_version:
 		exit 1; \
 	fi
 
-	@ if [ $(LIBTORCH_VERSION) != $(REQUIRED_LIBTORCH_VERSION) ]; then \
-		echo "LibTorch version should be at least $(REQUIRED_LIBTORCH_VERSION). Got: $(LIBTORCH_VERSION)."; \
+	@ if [ $(LIBTORCH_VERSION) >= $(MINIMUM_LIBTORCH_VERSION) ]; then \
+		echo "LibTorch version should be at least $(MINIMUM_LIBTORCH_VERSION). Got: $(LIBTORCH_VERSION)."; \
 		echo "You can download LibTorch here: https://pytorch.org/get-started/locally/"; \
 		exit 1; \
 	fi


### PR DESCRIPTION
Closes #368.

Suggestion/Proposal: Maybe we should also check whether the version installed is beyond the version supported by us (eg: we may not support a nightly version at some point of time). That's why I renamed `REQUIRED_*` to `MINIMUM_*`