### PR TITLE
Make argsort expr compatible with both BinaryBackend and EXLA

### DIFF
--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -722,16 +722,14 @@ defmodule EXLA.Defn do
     EXLA.Op.select(EXLA.Op.equal(cholesky, tensor), zeros, cholesky)
   end
 
-  defp to_operator(:sort, [tensor, opts], _ans, state) do
+  defp to_operator(:sort, [tensor, opts, comparator], _ans, state) do
     dimension = opts[:axis]
-    comparator = opts[:comparator_fun]
     comp = to_computation(comparator, {:pred, 8}, state)
     EXLA.Op.sort(tensor, comp, dimension)
   end
 
-  defp to_operator(:argsort, [tensor, opts], ans, state) do
+  defp to_operator(:argsort, [tensor, opts, comparator], ans, state) do
     dimension = opts[:axis]
-    comparator = opts[:comparator_fun]
 
     # Grow the comparator to arity 4 because argsort uses
     # variadic_sort underneath

--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -728,8 +728,9 @@ defmodule EXLA.Defn do
     EXLA.Op.sort(tensor, comp, dimension)
   end
 
-  defp to_operator(:argsort, [tensor, opts, comparator], ans, state) do
+  defp to_operator(:argsort, [tensor, opts], ans, state) do
     dimension = opts[:axis]
+    comparator = opts[:comparator_fun]
 
     # Grow the comparator to arity 4 because argsort uses
     # variadic_sort underneath

--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -722,8 +722,9 @@ defmodule EXLA.Defn do
     EXLA.Op.select(EXLA.Op.equal(cholesky, tensor), zeros, cholesky)
   end
 
-  defp to_operator(:sort, [tensor, opts, comparator], _ans, state) do
+  defp to_operator(:sort, [tensor, opts], _ans, state) do
     dimension = opts[:axis]
+    comparator = opts[:comparator_fun]
     comp = to_computation(comparator, {:pred, 8}, state)
     EXLA.Op.sort(tensor, comp, dimension)
   end

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -7630,9 +7630,11 @@ defmodule Nx do
     %T{shape: shape, names: names} = tensor = to_tensor(tensor)
     axis = Nx.Shape.normalize_axis(shape, opts[:axis], names)
 
-    impl!(tensor).sort(tensor, tensor,
-      axis: axis,
-      comparator: comparator
+    impl!(tensor).sort(
+      tensor,
+      tensor,
+      [axis: axis, comparator: comparator],
+      to_nx_comparator(comparator)
     )
   end
 
@@ -7753,13 +7755,23 @@ defmodule Nx do
     %T{shape: shape, names: names} = tensor = to_tensor(tensor)
     axis = Nx.Shape.normalize_axis(shape, opts[:axis], names)
 
-    impl!(tensor).argsort(%{tensor | type: {:s, 64}}, tensor,
-      axis: axis,
-      comparator: comparator
+    impl!(tensor).argsort(
+      %{tensor | type: {:s, 64}},
+      tensor,
+      [axis: axis, comparator: comparator],
+      to_nx_comparator(comparator)
     )
   end
 
   ## Helpers
+
+  defp to_nx_comparator(:asc), do: &Nx.less_equal/2
+  defp to_nx_comparator(:desc), do: &Nx.greater_equal/2
+  defp to_nx_comparator(comp) when is_function(comp, 2), do: comp
+
+  defp to_nx_comparator(_) do
+    raise ArgumentError, "comparator must be either :desc or :asc or a function with arity 2"
+  end
 
   defp backend!(backend) when is_atom(backend),
     do: {backend, []}

--- a/nx/lib/nx/backend.ex
+++ b/nx/lib/nx/backend.ex
@@ -83,8 +83,8 @@ defmodule Nx.Backend do
   @callback window_max(out :: tensor, tensor, shape, keyword) :: tensor
   @callback window_min(out :: tensor, tensor, shape, keyword) :: tensor
   @callback map(out :: tensor, tensor, fun) :: tensor
-  @callback sort(out :: tensor, tensor, keyword) :: tensor
-  @callback argsort(out :: tensor, tensor, keyword) :: tensor
+  @callback sort(out :: tensor, tensor, keyword, fun) :: tensor
+  @callback argsort(out :: tensor, tensor, keyword, fun) :: tensor
   @callback scatter_window_max(out :: tensor, tensor, tensor, shape, keyword, tensor) :: tensor
   @callback scatter_window_min(out :: tensor, tensor, tensor, shape, keyword, tensor) :: tensor
 

--- a/nx/lib/nx/binary_backend.ex
+++ b/nx/lib/nx/binary_backend.ex
@@ -1694,12 +1694,12 @@ defmodule Nx.BinaryBackend do
   def bitcast(out, tensor), do: from_binary(out, to_binary(tensor))
 
   @impl true
-  def sort(output, t, opts), do: do_sort(output, t, opts, false)
+  def sort(output, t, opts, comparator), do: do_sort(output, t, opts, comparator, false)
 
   @impl true
-  def argsort(output, t, opts), do: do_sort(output, t, opts, true)
+  def argsort(output, t, opts, comparator), do: do_sort(output, t, opts, comparator, true)
 
-  defp do_sort(output, t, opts, return_indices) do
+  defp do_sort(output, t, opts, comparator, return_indices) do
     %T{shape: shape, type: type} = t
     last_axis = Nx.rank(t) - 1
 
@@ -1721,11 +1721,11 @@ defmodule Nx.BinaryBackend do
             a <= b
           end
 
-        fun ->
+        _ ->
           fn a, b ->
             a = binary_to_number(a, type)
             b = binary_to_number(b, type)
-            to_scalar(fun.(a, b)) != 0
+            to_scalar(comparator.(a, b)) != 0
           end
       end
 

--- a/nx/lib/nx/defn/expr.ex
+++ b/nx/lib/nx/defn/expr.ex
@@ -728,7 +728,9 @@ defmodule Nx.Defn.Expr do
       raise "argsort comparator must return a predicate type, got: #{inspect(fun.type)}"
     end
 
-    expr(out, context, :argsort, [tensor, opts, fun])
+    opts = put_in(opts[:comparator_fun], fun)
+
+    expr(out, context, :argsort, [tensor, opts])
   end
 
   defp to_nx_comparator(:asc), do: &Nx.less_equal/2

--- a/nx/lib/nx/defn/expr.ex
+++ b/nx/lib/nx/defn/expr.ex
@@ -690,14 +690,11 @@ defmodule Nx.Defn.Expr do
   end
 
   @impl true
-  def sort(out, tensor, opts) do
-    comparator = opts[:comparator]
-
+  def sort(out, tensor, opts, comparator) do
     %{type: type} = out
     %{data: %{context: context}} = tensor = to_expr(tensor)
 
     args = [parameter(:sort, type, {}, 0), parameter(:sort, type, {}, 1)]
-    comparator = to_nx_comparator(comparator)
     fun = fun(args, context, comparator)
 
     if fun.shape != {} do
@@ -708,18 +705,14 @@ defmodule Nx.Defn.Expr do
       raise "sort comparator must return a predicate type, got: #{inspect(fun.type)}"
     end
 
-    opts = put_in(opts[:comparator_fun], fun)
-
-    expr(out, context, :sort, [tensor, opts])
+    expr(out, context, :sort, [tensor, opts, fun])
   end
 
   @impl true
-  def argsort(out, %{type: input_type} = tensor, opts) do
-    comparator = opts[:comparator]
+  def argsort(out, %{type: input_type} = tensor, opts, comparator) do
     %{data: %{context: context}} = tensor = to_expr(tensor)
 
     args = [parameter(:argsort, input_type, {}, 0), parameter(:argsort, input_type, {}, 1)]
-    comparator = to_nx_comparator(comparator)
     fun = fun(args, context, comparator)
 
     if fun.shape != {} do
@@ -730,17 +723,8 @@ defmodule Nx.Defn.Expr do
       raise "argsort comparator must return a predicate type, got: #{inspect(fun.type)}"
     end
 
-    opts = put_in(opts[:comparator_fun], fun)
-
-    expr(out, context, :argsort, [tensor, opts])
+    expr(out, context, :argsort, [tensor, opts, fun])
   end
-
-  defp to_nx_comparator(:asc), do: &Nx.less_equal/2
-  defp to_nx_comparator(:desc), do: &Nx.greater_equal/2
-  defp to_nx_comparator(comp) when is_function(comp, 2), do: comp
-
-  defp to_nx_comparator(_),
-    do: "comparator must be either :desc or :asc or a function with arity 2"
 
   ## Undefined
 

--- a/nx/lib/nx/defn/expr.ex
+++ b/nx/lib/nx/defn/expr.ex
@@ -708,7 +708,9 @@ defmodule Nx.Defn.Expr do
       raise "sort comparator must return a predicate type, got: #{inspect(fun.type)}"
     end
 
-    expr(out, context, :sort, [tensor, opts, fun])
+    opts = put_in(opts[:comparator_fun], fun)
+
+    expr(out, context, :sort, [tensor, opts])
   end
 
   @impl true

--- a/nx/test/nx/defn/evaluator_test.exs
+++ b/nx/test/nx/defn/evaluator_test.exs
@@ -177,6 +177,15 @@ defmodule Nx.Defn.EvaluatorTest do
     end
   end
 
+  describe "sort/2" do
+    defn sort(x), do: Nx.sort(x)
+
+    test "simple" do
+      t = Nx.tensor([3, 1, 2])
+      assert sort(t) == Nx.tensor([1, 2, 3])
+    end
+  end
+
   describe "anonymous functions args" do
     defn calls_binary_fun(fun, a, b), do: fun.(a, b)
 

--- a/nx/test/nx/defn/evaluator_test.exs
+++ b/nx/test/nx/defn/evaluator_test.exs
@@ -168,6 +168,15 @@ defmodule Nx.Defn.EvaluatorTest do
     end
   end
 
+  describe "argsort/2" do
+    defn argsort(x), do: Nx.argsort(x)
+
+    test "simple" do
+      t = Nx.tensor([3, 1, 2])
+      assert argsort(t) == Nx.tensor([1, 2, 0])
+    end
+  end
+
   describe "anonymous functions args" do
     defn calls_binary_fun(fun, a, b), do: fun.(a, b)
 

--- a/nx/test/nx_test.exs
+++ b/nx/test/nx_test.exs
@@ -1357,6 +1357,18 @@ defmodule NxTest do
         end
       )
     end
+
+    test "raises for invalid comparator" do
+      t = Nx.tensor([3, 2, 1, 0])
+
+      assert_raise(
+        ArgumentError,
+        "comparator must be either :desc or :asc or a function with arity 2",
+        fn ->
+          Nx.sort(t, comparator: :invalid)
+        end
+      )
+    end
   end
 
   describe "argsort/2" do
@@ -1398,6 +1410,18 @@ defmodule NxTest do
                  ],
                  names: [:x, :y, :z]
                )
+    end
+
+    test "raises for invalid comparator" do
+      t = Nx.tensor([3, 2, 1, 0])
+
+      assert_raise(
+        ArgumentError,
+        "comparator must be either :desc or :asc or a function with arity 2",
+        fn ->
+          Nx.argsort(t, comparator: :invalid)
+        end
+      )
     end
   end
 


### PR DESCRIPTION
Currently `argsort/2` doesn't work inside defn unless compiled with EXLA, because the expression is not compatible with BinaryBackend. This unifies the expression for both EXLA and BinaryBackend as @seanmor5 suggested.