### PR TITLE
Change default sort comparators to use strict inequality

### DIFF
--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -7496,8 +7496,10 @@ defmodule Nx do
 
   ### Options
 
-  * `:axis`: The name or number of the corresponding axis on which the sort should be applied.
-  * `:comparator`: Can be `:asc`, `:desc` or a arity-2 function for comparison between two tensor elements. Defaults to `:asc`
+    * `:axis` - The name or number of the corresponding axis on which the sort
+      should be applied
+    * `:comparator` - Can be `:asc`, `:desc` or an arity-2 function for comparison
+      between two tensor elements (strict inequality). Defaults to `:asc`
 
   ### Examples
 
@@ -7649,8 +7651,8 @@ defmodule Nx do
 
     * `:axis` - The name or number of the corresponding axis on which the sort
       should be applied
-    * `:comparator` - Can be `:asc`, `:desc` or a arity-2 function for comparison
-      between two tensor elements. Defaults to `:asc`
+    * `:comparator` - Can be `:asc`, `:desc` or an arity-2 function for comparison
+      between two tensor elements (strict inequality). Defaults to `:asc`
 
   ## Examples
 
@@ -7765,8 +7767,8 @@ defmodule Nx do
 
   ## Helpers
 
-  defp to_nx_comparator(:asc), do: &Nx.less_equal/2
-  defp to_nx_comparator(:desc), do: &Nx.greater_equal/2
+  defp to_nx_comparator(:asc), do: &Nx.less/2
+  defp to_nx_comparator(:desc), do: &Nx.greater/2
   defp to_nx_comparator(comp) when is_function(comp, 2), do: comp
 
   defp to_nx_comparator(_) do


### PR DESCRIPTION
Closes #393.

Experimenting with @seanmor5 we found out that even with XLS stable sort, the results don't look stable at all (the order of same elements is reversed). Turns out the comparators need to be strict inequality, and in turn this fixes the segfault problem.