### PR TITLE
Make Nx.stack/2 support stacking along any axis

### DIFF
--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -7489,10 +7489,11 @@ defmodule Nx do
   end
 
   @doc """
-  Stacks a list of `n` scalar tensors into an `{n}`-shaped tensor
+  Joins a list of tensors with the same shape along a new axis.
 
   ### Options
 
+    * `:axis` - optional index of the axis along which the tensors are stacked. Defaults to 0.
     * `:name` - optional name for the added dimension. Defaults to an unnamed axis.
 
   ### Examples
@@ -7503,6 +7504,73 @@ defmodule Nx do
         [1, 2, 3]
       >
 
+      iex> Nx.stack([Nx.tensor([1, 2, 3]), Nx.tensor([4, 5, 6])])
+      #Nx.Tensor<
+        s64[2][3]
+        [
+          [1, 2, 3],
+          [4, 5, 6]
+        ]
+      >
+
+      iex> t1 = Nx.iota({2, 1, 4})
+      iex> t2 = Nx.iota({2, 1, 4})
+      iex> t3 = Nx.iota({2, 1, 4})
+      iex> Nx.stack([t1, t2, t3], axis: -1)
+      #Nx.Tensor<
+        s64[2][1][4][3]
+        [
+          [
+            [
+              [0, 0, 0],
+              [1, 1, 1],
+              [2, 2, 2],
+              [3, 3, 3]
+            ]
+          ],
+          [
+            [
+              [4, 4, 4],
+              [5, 5, 5],
+              [6, 6, 6],
+              [7, 7, 7]
+            ]
+          ]
+        ]
+      >
+
+      iex> t1 = Nx.iota({2, 1, 4})
+      iex> t2 = Nx.iota({2, 1, 4})
+      iex> t3 = Nx.iota({2, 1, 4})
+      iex> Nx.stack([t1, t2, t3], axis: 1)
+      #Nx.Tensor<
+        s64[2][3][1][4]
+        [
+          [
+            [
+              [0, 1, 2, 3]
+            ],
+            [
+              [0, 1, 2, 3]
+            ],
+            [
+              [0, 1, 2, 3]
+            ]
+          ],
+          [
+            [
+              [4, 5, 6, 7]
+            ],
+            [
+              [4, 5, 6, 7]
+            ],
+            [
+              [4, 5, 6, 7]
+            ]
+          ]
+        ]
+      >
+
       iex> Nx.stack([Nx.tensor(1), Nx.tensor(2)], name: :x)
       #Nx.Tensor<
         s64[x: 2]
@@ -7510,12 +7578,13 @@ defmodule Nx do
       >
   """
   def stack(tensors, opts \\ []) when is_list(tensors) do
-    opts = keyword!(opts, name: nil)
+    opts = keyword!(opts, axis: 0, name: nil)
+    axis = opts[:axis]
     name = opts[:name]
 
     tensors
-    |> Enum.map(&Nx.new_axis(&1, 0, name))
-    |> Nx.concatenate()
+    |> Enum.map(&Nx.new_axis(&1, axis, name))
+    |> Nx.concatenate(axis: axis)
   end
 
   @doc """


### PR DESCRIPTION
This is something I needed for personal use, so I figured I ought to make a PR since I have the implementation ready anyway.

I presume the `Nx.stack` function is supposed to deliver similar functionality as `np.stack` which supports stacking along any given axis - [numpy docs](https://numpy.org/doc/stable/reference/generated/numpy.stack.html#numpy-stack).  The current implementation from `main` works only along the first axis (the docs say it only works for scalar tensors, but in reality the implementation supports any rank).

I think this function is a bit lackluster if it doesn't support this. What do you think?