### PR TITLE
Remove support for user-defined comparator for sort and argsort

### DIFF
--- a/exla/test/exla/defn_expr_test.exs
+++ b/exla/test/exla/defn_expr_test.exs
@@ -2636,7 +2636,7 @@ defmodule EXLA.DefnExprTest do
   describe "sort" do
     defn sort0(t), do: Nx.sort(t, axis: 0)
     defn sort1(t), do: Nx.sort(t, axis: 1)
-    defn sort1_asc(t), do: Nx.sort(t, axis: 1, comparator: :asc)
+    defn sort1_asc(t), do: Nx.sort(t, axis: 1, direction: :asc)
     defn sort2(t), do: Nx.sort(t, axis: 2)
 
     test "sorts a 1d tensor" do
@@ -2677,7 +2677,7 @@ defmodule EXLA.DefnExprTest do
   describe "argsort" do
     defn argsort0(t), do: Nx.argsort(t, axis: 0)
     defn argsort1(t), do: Nx.argsort(t, axis: 1)
-    defn argsort1_asc(t), do: Nx.argsort(t, axis: 1, comparator: :asc)
+    defn argsort1_asc(t), do: Nx.argsort(t, axis: 1, direction: :asc)
     defn argsort2(t), do: Nx.argsort(t, axis: 2)
 
     test "sorts a 1d tensor and returns its indices" do

--- a/nx/lib/nx/backend.ex
+++ b/nx/lib/nx/backend.ex
@@ -83,8 +83,8 @@ defmodule Nx.Backend do
   @callback window_max(out :: tensor, tensor, shape, keyword) :: tensor
   @callback window_min(out :: tensor, tensor, shape, keyword) :: tensor
   @callback map(out :: tensor, tensor, fun) :: tensor
-  @callback sort(out :: tensor, tensor, keyword, fun) :: tensor
-  @callback argsort(out :: tensor, tensor, keyword, fun) :: tensor
+  @callback sort(out :: tensor, tensor, keyword) :: tensor
+  @callback argsort(out :: tensor, tensor, keyword) :: tensor
   @callback scatter_window_max(out :: tensor, tensor, tensor, shape, keyword, tensor) :: tensor
   @callback scatter_window_min(out :: tensor, tensor, tensor, shape, keyword, tensor) :: tensor
 

--- a/nx/lib/nx/binary_backend.ex
+++ b/nx/lib/nx/binary_backend.ex
@@ -1694,19 +1694,19 @@ defmodule Nx.BinaryBackend do
   def bitcast(out, tensor), do: from_binary(out, to_binary(tensor))
 
   @impl true
-  def sort(output, t, opts, comparator), do: do_sort(output, t, opts, comparator, false)
+  def sort(output, t, opts), do: do_sort(output, t, opts, false)
 
   @impl true
-  def argsort(output, t, opts, comparator), do: do_sort(output, t, opts, comparator, true)
+  def argsort(output, t, opts), do: do_sort(output, t, opts, true)
 
-  defp do_sort(output, t, opts, comparator, return_indices) do
+  defp do_sort(output, t, opts, return_indices) do
     %T{shape: shape, type: type} = t
     last_axis = Nx.rank(t) - 1
 
     axis = opts[:axis]
 
     comparator =
-      case opts[:comparator] do
+      case opts[:direction] do
         :desc ->
           fn a, b ->
             a = binary_to_number(a, type)
@@ -1719,13 +1719,6 @@ defmodule Nx.BinaryBackend do
             a = binary_to_number(a, type)
             b = binary_to_number(b, type)
             a <= b
-          end
-
-        _ ->
-          fn a, b ->
-            a = binary_to_number(a, type)
-            b = binary_to_number(b, type)
-            to_scalar(comparator.(a, b)) != 0
           end
       end
 

--- a/nx/lib/nx/defn/expr.ex
+++ b/nx/lib/nx/defn/expr.ex
@@ -690,40 +690,15 @@ defmodule Nx.Defn.Expr do
   end
 
   @impl true
-  def sort(out, tensor, opts, comparator) do
-    %{type: type} = out
+  def sort(out, tensor, opts) do
     %{data: %{context: context}} = tensor = to_expr(tensor)
-
-    args = [parameter(:sort, type, {}, 0), parameter(:sort, type, {}, 1)]
-    fun = fun(args, context, comparator)
-
-    if fun.shape != {} do
-      raise "sort comparator must return a scalar tensor, got: #{inspect(fun.shape)}"
-    end
-
-    if fun.type != {:u, 8} do
-      raise "sort comparator must return a predicate type, got: #{inspect(fun.type)}"
-    end
-
-    expr(out, context, :sort, [tensor, opts, fun])
+    expr(out, context, :sort, [tensor, opts])
   end
 
   @impl true
-  def argsort(out, %{type: input_type} = tensor, opts, comparator) do
+  def argsort(out, tensor, opts) do
     %{data: %{context: context}} = tensor = to_expr(tensor)
-
-    args = [parameter(:argsort, input_type, {}, 0), parameter(:argsort, input_type, {}, 1)]
-    fun = fun(args, context, comparator)
-
-    if fun.shape != {} do
-      raise "argsort comparator must return a scalar tensor, got: #{inspect(fun.shape)}"
-    end
-
-    if fun.type != {:u, 8} do
-      raise "argsort comparator must return a predicate type, got: #{inspect(fun.type)}"
-    end
-
-    expr(out, context, :argsort, [tensor, opts, fun])
+    expr(out, context, :argsort, [tensor, opts])
   end
 
   ## Undefined

--- a/nx/test/nx_test.exs
+++ b/nx/test/nx_test.exs
@@ -1339,7 +1339,7 @@ defmodule NxTest do
 
       assert_raise(
         ArgumentError,
-        "unknown key :blep in [blep: :all_day], expected one of [:axis, :comparator]",
+        "unknown key :blep in [blep: :all_day], expected one of [:axis, :direction]",
         fn ->
           Nx.sort(t, blep: :all_day)
         end
@@ -1351,21 +1351,21 @@ defmodule NxTest do
 
       assert_raise(
         ArgumentError,
-        "expected a keyword list with keys [:axis, :comparator], got: [:blep]",
+        "expected a keyword list with keys [:axis, :direction], got: [:blep]",
         fn ->
           Nx.sort(t, [:blep])
         end
       )
     end
 
-    test "raises for invalid comparator" do
+    test "raises for invalid direction" do
       t = Nx.tensor([3, 2, 1, 0])
 
       assert_raise(
         ArgumentError,
-        "comparator must be either :desc or :asc or a function with arity 2",
+        "unknown value for :direction, expected :asc or :desc, got: :invalid",
         fn ->
-          Nx.sort(t, comparator: :invalid)
+          Nx.sort(t, direction: :invalid)
         end
       )
     end
@@ -1412,14 +1412,14 @@ defmodule NxTest do
                )
     end
 
-    test "raises for invalid comparator" do
+    test "raises for invalid direction" do
       t = Nx.tensor([3, 2, 1, 0])
 
       assert_raise(
         ArgumentError,
-        "comparator must be either :desc or :asc or a function with arity 2",
+        "unknown value for :direction, expected :asc or :desc, got: :invalid",
         fn ->
-          Nx.argsort(t, comparator: :invalid)
+          Nx.argsort(t, direction: :invalid)
         end
       )
     end


### PR DESCRIPTION
Replaces the `:comparator` option of `sort` and `argsort` with `:direction` that is either `:asc` or `:desc`. We decided not to allow arbitrary comparator functions, as some backends may not support it (Torchx) and Jax doesn't support that either.