### PR TITLE
Add dynamic slicing

### DIFF
--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -688,14 +688,11 @@ defmodule EXLA.Defn do
     EXLA.Op.clamp(operand, min, max)
   end
 
-  defp to_operator(:slice, [tensor, start_indices, lengths, strides], _ans, _state) do
-    # TODO: Use Enum.zip_with on Elixir v1.12
-    limit_indices =
-      start_indices
-      |> Enum.zip(lengths)
-      |> Enum.map(fn {i, len} -> i + len end)
+  defp to_operator(:slice, [tensor, start_indices, lengths, strides], ans, _state) do
+    zeros = List.duplicate(0, tuple_size(ans.shape))
+    slice = EXLA.Op.dynamic_slice(tensor, start_indices, lengths)
 
-    EXLA.Op.slice(tensor, start_indices, limit_indices, strides)
+    EXLA.Op.slice(slice, zeros, lengths, strides)
   end
 
   defp to_operator(:reverse, [tensor, axes], _ans, _state) do

--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -695,6 +695,12 @@ defmodule EXLA.Defn do
     EXLA.Op.slice(slice, zeros, lengths, strides)
   end
 
+  defp to_operator(:put_slice, [tensor, slice, start_indices], ans, _state) do
+    tensor = to_type(tensor, ans.type)
+    slice = to_type(slice, ans.type)
+    EXLA.Op.dynamic_update_slice(tensor, slice, start_indices)
+  end
+
   defp to_operator(:reverse, [tensor, axes], _ans, _state) do
     EXLA.Op.reverse(tensor, axes)
   end

--- a/exla/test/exla/defn_expr_test.exs
+++ b/exla/test/exla/defn_expr_test.exs
@@ -2368,6 +2368,31 @@ defmodule EXLA.DefnExprTest do
     end
   end
 
+  describe "put slice" do
+    defn put_slice1(t1, t2), do: Nx.put_slice(t1, t2, [2])
+    defn put_slice2(t1, t2), do: Nx.put_slice(t1, t2, [1, 2])
+    defn put_slice3(t1, t2), do: Nx.put_slice(t1, t2, [2, 2])
+    defn put_slice4(t1, t2), do: Nx.put_slice(t1, t2, [Nx.tensor(0), Nx.tensor(2)])
+
+    test "works with one dimension" do
+      assert put_slice1(Nx.tensor([0, 1, 2, 3, 4]), Nx.tensor([5, 6])) == Nx.tensor([0, 1, 5, 6, 4])
+    end
+
+    test "works with two dimensions" do
+      assert put_slice2(Nx.tensor([[1, 2, 3], [4, 5, 6]]), Nx.tensor([[7, 8], [9, 10]])) == Nx.tensor([[1, 7, 8], [4, 9, 10]])
+    end
+
+    test "works with float types" do
+      assert put_slice3(Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]), Nx.tensor([[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]])) ==
+        Nx.tensor([[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]])
+    end
+
+    test "works with mixed types" do
+      assert put_slice4(Nx.tensor([[1, 2, 3], [4, 5, 6]]), Nx.tensor([[10.0, 11.0]])) ==
+        Nx.tensor([[1.0, 10.0, 11.0], [4.0, 5.0, 6.0]])
+    end
+  end
+
   describe "reverse" do
     defn reverse(t), do: Nx.reverse(t)
     defn reverse1(t), do: Nx.reverse(t, axes: [1])

--- a/exla/test/exla/defn_expr_test.exs
+++ b/exla/test/exla/defn_expr_test.exs
@@ -2342,7 +2342,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "slicing" do
-    defn slice1(t), do: Nx.slice(t, [0, 6, 2], [2, 1, 3])
+    defn slice1(t), do: Nx.slice(t, [Nx.tensor(0), Nx.tensor(6), Nx.tensor(2)], [2, 1, 3])
     defn slice2(t), do: Nx.slice(t, [1, 4, 10], [1, 1, 10], strides: [1, 2, 3])
     defn slice3(t), do: Nx.slice(t, [0, 4, 11], [2, 3, 9], strides: [2, 1, 3])
 
@@ -2456,6 +2456,7 @@ defmodule EXLA.DefnExprTest do
     defn concatenate1(t1, t2, t3), do: Nx.concatenate([t1, t2, t3], axis: 1)
     defn concatenate2(t1, t2, t3), do: Nx.concatenate([t1, t2, t3], axis: 2)
     defn concatenate1_inp(t1), do: Nx.concatenate([t1], axis: 2)
+    defn concat_constants(), do: Nx.concatenate([Nx.tensor([1]), Nx.tensor([2])], axis: 0)
 
     test "works 0th axis" do
       t1 = Nx.iota({2, 2, 2})
@@ -2580,6 +2581,10 @@ defmodule EXLA.DefnExprTest do
                  ],
                  type: {:f, 32}
                )
+    end
+
+    test "works with constants" do
+      assert concat_constants() == Nx.tensor([1, 2])
     end
   end
 

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -7239,6 +7239,22 @@ defmodule Nx do
           [1.0, 1.0, 1.0]
         ]
       >
+
+      iex> Nx.slice(Nx.tensor([[1, 2, 3], [4, 5, 6]]), [Nx.tensor(1), Nx.tensor(2)], [1, 1])
+      #Nx.Tensor<
+        s64[1][1]
+        [
+          [6]
+        ]
+      >
+
+  ### Error cases
+
+      iex> Nx.slice(Nx.tensor([[1, 2, 3], [4, 5, 6]]), [Nx.tensor([1, 2]), Nx.tensor(1)], [1, 1])
+      ** (ArgumentError) index must be scalar, got shape {2} for axis 0
+
+      iex> Nx.slice(Nx.tensor([[1, 2, 3], [4, 5, 6]]), [Nx.tensor(1.0), Nx.tensor(0)], [1, 1])
+      ** (ArgumentError) index must be integer type, got {:f, 32} for axis 0
   """
   @doc type: :shape
   def slice(tensor, start_indices, lengths, opts \\ [])
@@ -7246,6 +7262,28 @@ defmodule Nx do
     opts = keyword!(opts, strides: 1)
     %T{shape: shape} = tensor = to_tensor(tensor)
     strides = opts[:strides]
+
+    start_indices =
+      start_indices
+      |> Enum.with_index()
+      |> Enum.map(fn {index, i} ->
+          %T{shape: idx_shape, type: idx_type} = t = to_tensor(index)
+          unless idx_shape == {} do
+            raise ArgumentError, "index must be scalar, got shape #{inspect(idx_shape)}"
+                                 <> " for axis #{i}"
+          end
+
+          case idx_type do
+            {:s, _} ->
+              t
+
+            {:u, _} ->
+              t
+
+            type ->
+              raise ArgumentError, "index must be integer type, got #{inspect(type)} for axis #{i}"
+          end
+      end)
 
     strides =
       if is_integer(strides),
@@ -7311,6 +7349,79 @@ defmodule Nx do
     start_indices = List.duplicate(0, rank(tensor)) |> List.replace_at(axis, start_index)
     lengths = shape |> put_elem(axis, len) |> Tuple.to_list()
     slice(tensor, start_indices, lengths, opts)
+  end
+
+  @doc """
+  Puts the given slice into the given tensor at the given
+  start indices.
+
+  The given slice shape must be less than or equal to the
+  shape of the given tensor. All start indices must be less
+  than their respective dimensions.
+
+  ## Examples
+
+      iex> Nx.put_slice(Nx.tensor([0, 1, 2, 3, 4]), Nx.tensor([5, 6]), [2])
+      #Nx.Tensor<
+        s64[5]
+        [0, 1, 5, 6, 4]
+      >
+
+      iex> Nx.put_slice(Nx.tensor([[1, 2, 3], [4, 5, 6]]), Nx.tensor([[7, 8], [9, 10]]), [1, 2])
+      #Nx.Tensor<
+        s64[2][3]
+        [
+          [1, 7, 8],
+          [4, 9, 10]
+        ]
+      >
+
+      iex> Nx.put_slice(Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]), Nx.tensor([[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]]), [2, 2])
+      #Nx.Tensor<
+        f32[2][3]
+        [
+          [7.0, 8.0, 9.0],
+          [10.0, 11.0, 12.0]
+        ]
+      >
+
+      iex> Nx.put_slice(Nx.tensor([[1, 2, 3], [4, 5, 6]]), Nx.tensor([[10.0, 11.0]]), [Nx.tensor(0), Nx.tensor(2)])
+      #Nx.Tensor<
+        f32[2][3]
+        [
+          [1.0, 10.0, 11.0],
+          [4.0, 5.0, 6.0]
+        ]
+      >
+  """
+  def put_slice(tensor, slice, start_indices) when is_list(start_indices) do
+    %T{shape: shape, names: names} = tensor = to_tensor(tensor)
+    %T{shape: slice_shape, names: slice_names} = slice = to_tensor(slice)
+
+    start_indices =
+      start_indices
+      |> Enum.with_index()
+      |> Enum.map(fn {index, i} ->
+          %T{shape: idx_shape, type: idx_type} = t = to_tensor(index)
+          unless idx_shape == {} do
+            raise ArgumentError, "index must be scalar, got shape #{inspect(idx_shape)}"
+                                 <> " for axis #{i}"
+          end
+
+          case idx_type do
+            {:s, _} ->
+              t
+
+            {:u, _} ->
+              t
+
+            type ->
+              raise ArgumentError, "index must be integer type, got #{inspect(type)} for axis #{i}"
+          end
+      end)
+
+    {shape, names} = Nx.Shape.put_slice(shape, names, slice_shape, slice_names, start_indices)
+    impl!(tensor).put_slice(%{tensor | shape: shape, names: names}, tensor, slice, start_indices)
   end
 
   @doc """

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -7267,22 +7267,24 @@ defmodule Nx do
       start_indices
       |> Enum.with_index()
       |> Enum.map(fn {index, i} ->
-          %T{shape: idx_shape, type: idx_type} = t = to_tensor(index)
-          unless idx_shape == {} do
-            raise ArgumentError, "index must be scalar, got shape #{inspect(idx_shape)}"
-                                 <> " for axis #{i}"
-          end
+        %T{shape: idx_shape, type: idx_type} = t = to_tensor(index)
 
-          case idx_type do
-            {:s, _} ->
-              t
+        unless idx_shape == {} do
+          raise ArgumentError,
+                "index must be scalar, got shape #{inspect(idx_shape)}" <>
+                  " for axis #{i}"
+        end
 
-            {:u, _} ->
-              t
+        case idx_type do
+          {:s, _} ->
+            t
 
-            type ->
-              raise ArgumentError, "index must be integer type, got #{inspect(type)} for axis #{i}"
-          end
+          {:u, _} ->
+            t
+
+          type ->
+            raise ArgumentError, "index must be integer type, got #{inspect(type)} for axis #{i}"
+        end
       end)
 
     strides =
@@ -7395,33 +7397,43 @@ defmodule Nx do
       >
   """
   def put_slice(tensor, slice, start_indices) when is_list(start_indices) do
-    %T{shape: shape, names: names} = tensor = to_tensor(tensor)
-    %T{shape: slice_shape, names: slice_names} = slice = to_tensor(slice)
+    %T{shape: shape, names: names, type: type} = tensor = to_tensor(tensor)
+    %T{shape: slice_shape, names: slice_names, type: slice_type} = slice = to_tensor(slice)
+
+    output_type = binary_type(type, slice_type)
 
     start_indices =
       start_indices
       |> Enum.with_index()
       |> Enum.map(fn {index, i} ->
-          %T{shape: idx_shape, type: idx_type} = t = to_tensor(index)
-          unless idx_shape == {} do
-            raise ArgumentError, "index must be scalar, got shape #{inspect(idx_shape)}"
-                                 <> " for axis #{i}"
-          end
+        %T{shape: idx_shape, type: idx_type} = t = to_tensor(index)
 
-          case idx_type do
-            {:s, _} ->
-              t
+        unless idx_shape == {} do
+          raise ArgumentError,
+                "index must be scalar, got shape #{inspect(idx_shape)}" <>
+                  " for axis #{i}"
+        end
 
-            {:u, _} ->
-              t
+        case idx_type do
+          {:s, _} ->
+            t
 
-            type ->
-              raise ArgumentError, "index must be integer type, got #{inspect(type)} for axis #{i}"
-          end
+          {:u, _} ->
+            t
+
+          type ->
+            raise ArgumentError, "index must be integer type, got #{inspect(type)} for axis #{i}"
+        end
       end)
 
     {shape, names} = Nx.Shape.put_slice(shape, names, slice_shape, slice_names, start_indices)
-    impl!(tensor).put_slice(%{tensor | shape: shape, names: names}, tensor, slice, start_indices)
+
+    impl!(tensor).put_slice(
+      %{tensor | shape: shape, names: names, type: output_type},
+      tensor,
+      slice,
+      start_indices
+    )
   end
 
   @doc """

--- a/nx/lib/nx/backend.ex
+++ b/nx/lib/nx/backend.ex
@@ -64,6 +64,7 @@ defmodule Nx.Backend do
   @callback dot(out :: tensor, tensor, axes, axes, tensor, axes, axes) :: tensor
   @callback clip(out :: tensor, tensor, min :: tensor, max :: tensor) :: tensor
   @callback slice(out :: tensor, tensor, list, list, list) :: tensor
+  @callback put_slice(out :: tensor, tensor, tensor, list) :: tensor
   @callback concatenate(out :: tensor, tensor, axis) :: tensor
   @callback select(out :: tensor, tensor, tensor, tensor) :: tensor
 

--- a/nx/lib/nx/defn/expr.ex
+++ b/nx/lib/nx/defn/expr.ex
@@ -636,10 +636,21 @@ defmodule Nx.Defn.Expr do
     if axis in axes do
       [{is, il} | merge_slice(axis + 1, axes, inner_start, start, inner_lengths, lengths)]
     else
-      [s | start] = start
+      [_ | start] = start
       [l | lengths] = lengths
-      [{Nx.add(is, 1), l} | merge_slice(axis + 1, axes, inner_start, start, inner_lengths, lengths)]
+
+      [
+        {Nx.add(is, 1), l}
+        | merge_slice(axis + 1, axes, inner_start, start, inner_lengths, lengths)
+      ]
     end
+  end
+
+  @impl true
+  def put_slice(out, tensor, slice, start) do
+    {[tensor, slice | start], context} = to_exprs([tensor, slice | start])
+
+    expr(out, context, :put_slice, [tensor, slice, start])
   end
 
   @impl true

--- a/nx/lib/nx/defn/expr.ex
+++ b/nx/lib/nx/defn/expr.ex
@@ -601,7 +601,7 @@ defmodule Nx.Defn.Expr do
 
   @impl true
   def slice(out, tensor, start, lengths, strides) do
-    tensor = to_expr(tensor)
+    {[tensor | start], context} = to_exprs([tensor | start])
 
     # If we are in a sequence of slices, it is the access syntax,
     # so we compact them into a single slice.
@@ -619,7 +619,8 @@ defmodule Nx.Defn.Expr do
       |> Nx.slice(start, lengths)
       |> Nx.squeeze(axes: axes)
     else
-      _ -> expr(out, tensor.data.context, :slice, [tensor, start, lengths, strides])
+      _ ->
+        expr(out, context, :slice, [tensor, start, lengths, strides])
     end
   end
 
@@ -637,7 +638,7 @@ defmodule Nx.Defn.Expr do
     else
       [s | start] = start
       [l | lengths] = lengths
-      [{is + s, l} | merge_slice(axis + 1, axes, inner_start, start, inner_lengths, lengths)]
+      [{Nx.add(is, 1), l} | merge_slice(axis + 1, axes, inner_start, start, inner_lengths, lengths)]
     end
   end
 

--- a/nx/lib/nx/defn/tree.ex
+++ b/nx/lib/nx/defn/tree.ex
@@ -53,13 +53,37 @@ defmodule Nx.Defn.Tree do
 
   def traverse_args(%T{data: %Expr{op: :slice, args: [tensor, start_indices | args]}}, acc, fun) do
     {tensor, acc} = fun.(tensor, acc)
-    {start_indices, acc} = Enum.map_reduce(start_indices, acc, fn
-      x, acc when is_integer(x) ->
-        {x, acc}
-      x, acc ->
-        fun.(x, acc)
+
+    {start_indices, acc} =
+      Enum.map_reduce(start_indices, acc, fn
+        x, acc when is_integer(x) ->
+          {x, acc}
+
+        x, acc ->
+          fun.(x, acc)
       end)
+
     {[tensor, start_indices | args], acc}
+  end
+
+  def traverse_args(
+        %T{data: %Expr{op: :put_slice, args: [tensor, slice, start_indices]}},
+        acc,
+        fun
+      ) do
+    {tensor, acc} = fun.(tensor, acc)
+    {slice, acc} = fun.(slice, acc)
+
+    {start_indices, acc} =
+      Enum.map_reduce(start_indices, acc, fn
+        x, acc when is_integer(x) ->
+          {x, acc}
+
+        x, acc ->
+          fun.(x, acc)
+      end)
+
+    {[tensor, slice, start_indices], acc}
   end
 
   def traverse_args(%T{data: %Expr{args: args}}, acc, fun) do

--- a/nx/lib/nx/defn/tree.ex
+++ b/nx/lib/nx/defn/tree.ex
@@ -51,6 +51,17 @@ defmodule Nx.Defn.Tree do
     {[list | args], acc}
   end
 
+  def traverse_args(%T{data: %Expr{op: :slice, args: [tensor, start_indices | args]}}, acc, fun) do
+    {tensor, acc} = fun.(tensor, acc)
+    {start_indices, acc} = Enum.map_reduce(start_indices, acc, fn
+      x, acc when is_integer(x) ->
+        {x, acc}
+      x, acc ->
+        fun.(x, acc)
+      end)
+    {[tensor, start_indices | args], acc}
+  end
+
   def traverse_args(%T{data: %Expr{args: args}}, acc, fun) do
     Enum.map_reduce(args, acc, fn
       %T{data: %Expr{}} = arg, acc -> fun.(arg, acc)

--- a/nx/test/nx/defn_test.exs
+++ b/nx/test/nx/defn_test.exs
@@ -583,7 +583,7 @@ defmodule Nx.DefnTest do
                range_access(Nx.iota({3, 4, 5}))
 
       assert %T{
-               data: %Expr{op: :slice, args: [_, [1, 1, 0], [1, 2, 5], [1, 1, 1]]},
+               data: %Expr{op: :slice, args: [_, [%T{}, %T{}, %T{}], [1, 2, 5], [1, 1, 1]]},
                shape: {1, 2, 5}
              } = slice
     end
@@ -592,7 +592,7 @@ defmodule Nx.DefnTest do
 
     test "multi dimensional multi-access with keywords is collapsed" do
       assert %T{
-               data: %Expr{op: :slice, args: [_, [0, 1, 1], [3, 2, 3], [1, 1, 1]]},
+               data: %Expr{op: :slice, args: [_, [%T{}, %T{}, %T{}], [3, 2, 3], [1, 1, 1]]},
                shape: {3, 2, 3}
              } = keyword_access(Nx.iota({3, 4, 5}, names: [:x, :y, :z]))
     end

--- a/nx/test/nx/defn_test.exs
+++ b/nx/test/nx/defn_test.exs
@@ -541,10 +541,10 @@ defmodule Nx.DefnTest do
     test "single dimensional single access" do
       {zero, minus_one} = single_access(Nx.tensor([1, 2, 3, 4, 5]))
       assert %T{data: %Expr{op: :squeeze, args: [slice, [0]]}, shape: {}} = zero
-      assert %T{data: %Expr{op: :slice, args: [_, [0], [1], [1]]}, shape: {1}} = slice
+      assert %T{data: %Expr{op: :slice, args: [_, [%T{}], [1], [1]]}, shape: {1}} = slice
 
       assert %T{data: %Expr{op: :squeeze, args: [slice, [0]]}, shape: {}} = minus_one
-      assert %T{data: %Expr{op: :slice, args: [_, [4], [1], [1]]}, shape: {1}} = slice
+      assert %T{data: %Expr{op: :slice, args: [_, [%T{}], [1], [1]]}, shape: {1}} = slice
     end
 
     test "multi dimensional single access" do
@@ -552,14 +552,14 @@ defmodule Nx.DefnTest do
       assert %T{data: %Expr{op: :squeeze, args: [slice, [0]]}, shape: {4, 5}} = zero
 
       assert %T{
-               data: %Expr{op: :slice, args: [_, [0, 0, 0], [1, 4, 5], [1, 1, 1]]},
+               data: %Expr{op: :slice, args: [_, [%T{}, %T{}, %T{}], [1, 4, 5], [1, 1, 1]]},
                shape: {1, 4, 5}
              } = slice
 
       assert %T{data: %Expr{op: :squeeze, args: [slice, [0]]}, shape: {4, 5}} = minus_one
 
       assert %T{
-               data: %Expr{op: :slice, args: [_, [2, 0, 0], [1, 4, 5], [1, 1, 1]]},
+               data: %Expr{op: :slice, args: [_, [%T{}, %T{}, %T{}], [1, 4, 5], [1, 1, 1]]},
                shape: {1, 4, 5}
              } = slice
     end
@@ -571,7 +571,7 @@ defmodule Nx.DefnTest do
                multi_access(Nx.iota({3, 4, 5}))
 
       assert %T{
-               data: %Expr{op: :slice, args: [_, [1, 2, 3], [1, 1, 1], [1, 1, 1]]},
+               data: %Expr{op: :slice, args: [_, [%T{}, %T{}, %T{}], [1, 1, 1], [1, 1, 1]]},
                shape: {1, 1, 1}
              } = slice
     end


### PR DESCRIPTION
This would partially resolve #223 although I think we'd still be missing some richer dynamic indexing capabilities. As of now, gradients are failing with:

```
    ** (FunctionClauseError) no function clause matching in Nx.BinaryBackend.to_binary/1

     The following arguments were given to Nx.BinaryBackend.to_binary/1:
     
         # 1
         #Nx.Tensor<
           s64
           
           Nx.Defn.Expr
         >
     
     Attempted function clauses (showing 1 out of 1):
     
         defp to_binary(%Nx.Tensor{data: %{state: data}})
     
     code: lhs = grad_reduce_product_min(x)
     stacktrace:
       (nx 0.1.0-dev) lib/nx/binary_backend.ex:133: Nx.BinaryBackend.to_binary/1
       (nx 0.1.0-dev) lib/nx/binary_backend.ex:192: Nx.BinaryBackend.to_scalar/1
       (nx 0.1.0-dev) lib/nx/binary_backend.ex:1662: anonymous fn/1 in Nx.BinaryBackend.put_slice/4
       (elixir 1.12.0-rc.0) lib/enum.ex:1553: Enum."-map/2-lists^map/1-0-"/2
       (nx 0.1.0-dev) lib/nx/binary_backend.ex:1661: Nx.BinaryBackend.put_slice/4
       (nx 0.1.0-dev) lib/nx/defn/grad.ex:329: Nx.Defn.Grad.grad/5
       (nx 0.1.0-dev) lib/nx/defn/grad.ex:161: anonymous fn/3 in Nx.Defn.Grad.to_grad/3
       (elixir 1.12.0-rc.0) lib/enum.ex:1675: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
       (nx 0.1.0-dev) lib/nx/defn/grad.ex:183: Nx.Defn.Grad.grad_jvps/4
       (nx 0.1.0-dev) lib/nx/defn/grad.ex:172: anonymous fn/3 in Nx.Defn.Grad.to_grad/3
       (nx 0.1.0-dev) lib/nx/defn/grad.ex:161: anonymous fn/3 in Nx.Defn.Grad.to_grad/3
       (nx 0.1.0-dev) lib/nx/defn/grad.ex:24: Nx.Defn.Grad.transform/2
       (nx 0.1.0-dev) lib/nx/defn/kernel.ex:232: Nx.Defn.Kernel.grad/2
       test/nx/defn/grad_test.exs:2239: anonymous fn/3 in Nx.Defn.GradTest.grad_reduce_product_min/1
       (nx 0.1.0-dev) lib/nx/defn/evaluator.ex:21: Nx.Defn.Evaluator.__jit__/4
       test/nx/defn/grad_test.exs:2243: (test)
```

I think it's an issue with how I did the put_slice expr implementation