### PR TITLE
feat: add more options to triangular_solve

### DIFF
--- a/nx/lib/nx/binary_backend/matrix.ex
+++ b/nx/lib/nx/binary_backend/matrix.ex
@@ -10,7 +10,11 @@ defmodule Nx.BinaryBackend.Matrix do
         shape -> shape
       end
 
-    a_matrix = a_data |> binary_to_matrix(a_type, a_shape) |> ts_handle_lower_opt(opts, :a)
+    a_matrix =
+      a_data
+      |> binary_to_matrix(a_type, a_shape)
+      |> ts_handle_lower_opt(opts, :a)
+      |> ts_handle_transform_a_opt(opts)
 
     b_matrix_or_vec =
       case shape do
@@ -124,6 +128,13 @@ defmodule Nx.BinaryBackend.Matrix do
       matrix
     else
       Enum.reverse(matrix)
+    end
+  end
+
+  defp ts_handle_transform_a_opt(matrix, opts) do
+    case opts[:transform_a] do
+      :transpose -> transpose_matrix(matrix)
+      _ -> matrix
     end
   end
 

--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -317,6 +317,18 @@ defmodule Nx.LinAlg do
         [-1.3333333730697632, 2.6666667461395264, -0.6666666865348816, 1.3333333730697632]
       >
 
+      iex> a = Nx.tensor([[1, 0, 0], [1, 1, 0], [1, 2, 1]])
+      iex> b = Nx.tensor([[0, 2, 1], [1, 1, 0], [3, 3, 1]])
+      iex> Nx.LinAlg.triangular_solve(a, b, left_side: false)
+      #Nx.Tensor<
+        f32[3][3]
+        [
+          [-1.0, 0.0, 1.0],
+          [0.0, 1.0, 0.0],
+          [1.0, 1.0, 1.0]
+        ]
+      >
+
   ### Error cases
 
       iex> Nx.LinAlg.triangular_solve(Nx.tensor([[3, 0, 0, 0], [2, 1, 0, 0]]), Nx.tensor([4, 2, 4, 2]))
@@ -330,7 +342,7 @@ defmodule Nx.LinAlg do
 
   """
   def triangular_solve(a, b, opts \\ []) do
-    opts = keyword!(opts, lower: true)
+    opts = keyword!(opts, lower: true, left_side: true)
     output_type = binary_type(a, b) |> Nx.Type.to_floating()
     %T{shape: a_shape = {m, _}} = a = Nx.to_tensor(a)
     %T{shape: b_shape} = b = Nx.to_tensor(b)
@@ -339,7 +351,7 @@ defmodule Nx.LinAlg do
     # left_side: true/false ->
     #   if true, solves op(A).X = B
     #   if false solves X.op(A) = B
-    # lower: true/false
+    # OK lower: true/false
     #   if true, solves as if A is lower triangular
     #   if false, solves as if A is upper triangular
     # unit_diagonal: true/false

--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -392,9 +392,8 @@ defmodule Nx.LinAlg do
 
       t ->
         raise ArgumentError,
-              "invalid value for :transform_a option, expected one of [:none, :transpose, :conjugate], got #{
-                inspect(t)
-              }"
+              "invalid value for :transform_a option, expected one of [:none, :transpose], " <>
+                "got: #{inspect(t)}"
     end
 
     case a_shape do

--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -294,7 +294,6 @@ defmodule Nx.LinAlg do
   * `:lower` - When `true`, defines the `a` matrix as lower triangular. If false, a is upper triangular.
                Defaults to `true`
   * `:left_side` - When `true`, solves the system as `op(A).X = B`. Otherwise, solves `X.op(A) = B`. Defaults to `true`.
-  * `:unit_diagonal` - When `true`, the diagonal elements aren't accessed. Defaults to `false`
 
   ## Examples
 
@@ -378,7 +377,7 @@ defmodule Nx.LinAlg do
 
   """
   def triangular_solve(a, b, opts \\ []) do
-    opts = keyword!(opts, lower: true, left_side: true, unit_diagonal: false, transform_a: :none)
+    opts = keyword!(opts, lower: true, left_side: true, transform_a: :none)
     output_type = binary_type(a, b) |> Nx.Type.to_floating()
     %T{shape: a_shape = {m, _}} = a = Nx.to_tensor(a)
     %T{shape: b_shape} = b = Nx.to_tensor(b)


### PR DESCRIPTION
Adds missing opts from [XLA](https://www.tensorflow.org/xla/operation_semantics#triangularsolve) to `Nx.LinAlg.triangular_solve`