### PR TITLE
feat: apply eps to factorization results

### DIFF
--- a/nx/lib/nx/binary_backend/matrix.ex
+++ b/nx/lib/nx/binary_backend/matrix.ex
@@ -1,6 +1,5 @@
 defmodule Nx.BinaryBackend.Matrix do
   @moduledoc false
-  @default_eps 1.0e-10
   import Nx.Shared
 
   def ts(a_data, a_type, b_data, b_type, shape, output_type, input_opts) do
@@ -184,7 +183,7 @@ defmodule Nx.BinaryBackend.Matrix do
     {_, input_num_bits} = input_type
 
     mode = opts[:mode]
-    eps = opts[:eps] || @default_eps
+    eps = opts[:eps]
 
     r_matrix =
       if mode == :reduced do
@@ -226,7 +225,7 @@ defmodule Nx.BinaryBackend.Matrix do
 
   def lu(input_data, input_type, {n, n} = input_shape, p_type, l_type, u_type, opts) do
     a = binary_to_matrix(input_data, input_type, input_shape)
-    eps = opts[:eps] || @default_eps
+    eps = opts[:eps]
 
     {p, a_prime} = lu_validate_and_pivot(a, n)
 
@@ -328,7 +327,7 @@ defmodule Nx.BinaryBackend.Matrix do
     # [5] - http://www.mymathlib.com/c_source/matrices/linearsystems/singular_value_decomposition.c
     a = binary_to_matrix(input_data, input_type, input_shape)
 
-    eps = opts[:eps] || @default_eps
+    eps = opts[:eps]
     max_iter = opts[:max_iter] || 1000
     {u, d, v} = householder_bidiagonalization(a, input_shape, eps)
 

--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -8,6 +8,8 @@ defmodule Nx.LinAlg do
 
   alias Nx.Tensor, as: T
 
+  @default_eps 1.0e-10
+
   @doc """
   Performs a Cholesky decomposition of a square matrix.
 
@@ -650,7 +652,7 @@ defmodule Nx.LinAlg do
       ** (ArgumentError) tensor must have at least as many rows as columns, got shape: {3, 4}
   """
   def qr(tensor, opts \\ []) do
-    opts = keyword!(opts, mode: :reduced)
+    opts = keyword!(opts, mode: :reduced, eps: @default_eps)
     %T{type: type, shape: shape} = tensor = Nx.to_tensor(tensor)
 
     mode = opts[:mode]
@@ -744,7 +746,7 @@ defmodule Nx.LinAlg do
 
   """
   def svd(tensor, opts \\ []) do
-    opts = keyword!(opts, [:eps, :max_iter])
+    opts = keyword!(opts, [:max_iter, eps: @default_eps])
     %T{type: type, shape: shape} = tensor = Nx.to_tensor(tensor)
 
     output_type = Nx.Type.to_floating(type)
@@ -850,7 +852,7 @@ defmodule Nx.LinAlg do
       ** (ArgumentError) tensor must have as many rows as columns, got shape: {3, 4}
   """
   def lu(tensor, opts \\ []) do
-    opts = keyword!(opts, [:eps])
+    opts = keyword!(opts, eps: @default_eps)
     %T{type: type, shape: shape} = tensor = Nx.to_tensor(tensor)
 
     output_type = Nx.Type.to_floating(type)

--- a/nx/test/nx/defn/expr_test.exs
+++ b/nx/test/nx/defn/expr_test.exs
@@ -269,7 +269,7 @@ defmodule Nx.Defn.ExprTest do
              \s\s
                Nx.Defn.Expr
                parameter a                   s64[2][2]
-               b = qr [ a, mode: :reduced ]  tuple2
+               b = qr [ a, mode: :reduced, eps: 1.0e-10 ]  tuple2
                c = elem [ b, 0, 2 ]          f32[2][2]
              >\
              """


### PR DESCRIPTION
This PR aims to improve factorization results by applying
rounding over the `eps` parameter for each resulting component

Example:
```elixir
iex(1)> t = Nx.tensor([[10000, 2000, 3], [1, 2, 4], [1, 2, 5]])
#Nx.Tensor<
  s64[3][3]
  [
    [10000, 2000, 3],
    [1, 2, 4],
    [1, 2, 5]
  ]
>
# With rounding
iex(2)> Nx.LinAlg.qr(t, eps: 1.0e-3)                           
{#Nx.Tensor<
   f32[3][3]
   [
     [1.0, 0.0, 0.0],
     [0.0, 0.7071067690849304, -0.7071067690849304],
     [0.0, 0.7071067690849304, 0.7071067690849304]
   ]
>, #Nx.Tensor<
   f32[3][3]
   [
     [1.0e4, 2000.0003662109375, 3.0009000301361084],
     [0.0, 2.5455844402313232, 6.363536834716797],
     [0.0, 0.0, 0.7071067690849304]
   ]
>}
# Without rounding
iex(3)> Nx.LinAlg.qr(t)             
{#Nx.Tensor<
   f32[3][3]
   [
     [1.0, -1.4142136205919087e-4, 0.0],
     [9.999999747378752e-5, 0.7071067690849304, -0.7071067690849304],
     [9.999999747378752e-5, 0.7071067690849304, 0.7071067690849304]
   ]
>, #Nx.Tensor<
   f32[3][3]
   [
     [1.0e4, 2000.0003662109375, 3.0009000301361084],
     [0.0, 2.5455844402313232, 6.363536834716797],
     [0.0, 0.0, 0.7071067690849304]
   ]
>}
```