### PR TITLE
Implement Nx.take/3 backed by xla::Gather

### DIFF
--- a/exla/lib/exla/nif.ex
+++ b/exla/lib/exla/nif.ex
@@ -89,6 +89,17 @@ defmodule EXLA.NIF do
   def dynamic_update_slice(_op, _update, _start_indices),
     do: :erlang.nif_error(:undef)
 
+  def gather(
+        _op,
+        _start_indices,
+        _index_vector_dim,
+        _slice_sizes,
+        _offset_dims,
+        _collapsed_slice_dims,
+        _start_index_map
+      ),
+      do: :erlang.nif_error(:undef)
+
   def rng_normal(_mu, _sigma, _shape),
     do: :erlang.nif_error(:undef)
 

--- a/exla/lib/exla/op.ex
+++ b/exla/lib/exla/op.ex
@@ -236,6 +236,187 @@ defmodule EXLA.Op do
     %Op{builder: builder, ref: ref}
   end
 
+  @doc """
+  The XLA gather operation stitches together several slices
+  of an input array.
+
+  Note that this operation is extremely generic and far from
+  intuitive for regular usage. However, it can be used to implement
+  many specific operations that have to do with combining multiple
+  tensor slices.
+
+  ## Parameteres
+
+  The XLA docs are rather cryptic unless already understood,
+  so here's an attempt of a more intuitive description.
+
+  ### `index_vector_dim`
+
+  Determines which dimension contains index vectors. In most cases
+  we want to set this to the last dimension.
+
+      given
+        start_indices = [[0, 1], [1, 1]]
+      and given
+        index_vector_dim = 1
+      then
+        index vectors are [0, 1] and [1, 1]
+
+  Note that we can set this to `last_dimension + 1`, in which case
+  `start_indices` are implicitly reshaped to have a trailing dimension
+  of 1.
+
+      given
+        start_indices = [[0, 1], [1, 1]]
+      and given
+        index_vector_dim = 2
+      then
+        start_indices <- [[[0], [1]], [[1], [1]]]
+        index vectors are [0], [1], [1], [1]
+
+  ### `start_index_map`
+
+  Note: though given as a list, it can be treated as a map of `list_idx -> value`.
+
+  An index vector may have less elements than the operand tensor shape.
+  For example:
+
+      given
+        operand = [[1, 2], [3, 4]]
+        start_indices = [[1], [0]]
+        index_vector_dim = 1
+
+  As described above, in this case index vectors are `[1]`, `[0]` and they have
+  length 1. However, the operand has rank 2, so we need vectors of the form `[_, _]`
+  to point to a specific element in the operand. The `start_index_map` determines
+  where indices go into this template:
+
+      and given
+        start_index_map = [0] # effectively %{0 => 0}
+      then
+        actual index vectors are [1, _] and [0, _]
+
+      and given
+        start_index_map = [1] # effectively %{0 => 1}
+      then
+        actual index vectors are [_, 1] and [_, 0]
+
+  Finally, the missing elements (`_`) are assumed to be 0.
+
+  Complete examples:
+
+      given
+        operand = [[1, 2], [3, 4]]
+        start_indices = [[0], [1]]
+        index_vector_dim = 1
+      and given
+        start_index_map = [1] # effectively %{0 => 0, 1 => 1}
+      then
+        actual index vectors are [0, 0], [0, 1] (leading 0 is inserted)
+
+      given
+        operand = [[1, 2], [3, 4]]
+        start_indices = [[0, 1], [1, 1]]
+        index_vector_dim = 1
+      and given
+        start_index_map = [0, 1] # effectively %{0 => 0, 1 => 1}
+      then
+        actual index vectors are [0, 1], [1, 1] (as expected)
+
+      given
+        operand = [[1, 2], [3, 4]]
+        start_indices = [[0, 1], [1, 1]]
+        index_vector_dim = 1
+      and given
+        start_index_map = [1, 0] # effectively %{0 => 1, 1 => 0}
+      then
+        actual index vectors are [1, 0], [1, 1] (see how the first vector is reversed)
+
+  ### `slice_sizes`
+
+  For every starting point (as described above) we take a slice given
+  by `slice_sizes`. Naturally, `slice_sizes` must have the same length
+  as operand rank, so that we have one size per dimension.
+
+      given
+        operand = [[1, 2], [3, 4]]
+        actual index vector [1, 0]
+      and given
+        slice_sizes = [1, 2]
+      then
+        slice for actual index vector is [[3, 4]]
+
+  ### `collapsed_slice_dims`
+
+  A list of dimensions that are collapsed (effectively removed) in
+  the slice shape. Only dimensions of size 1 can be collapsed.
+
+      given
+        slice is [[3, 4]] # shape: [1][2]
+      and given
+        collapsed_slice_dims = [0]
+      then
+        actual slice is [3, 4] # shape [2]
+
+  ### `offset_dims`
+
+  A list of dimensions in the output tensor corresponding to the
+  non-collapsed dimensions in slice tensors. In other words, these
+  dimensions are used for indexing elements of the slice tensors.
+
+      given
+        operand = [[1, 2], [3, 4]]
+        start_indices = [[1, 0], [0, 0], [1, 0]]
+        index_vector_dim = 1
+        start_index_map = [1, 2] # effectively %{0 => 0, 1 => 1}
+        collapsed_slice_dims = [0]
+      and given
+        offset_dims = [1]
+      then
+        result is [[3, 4], [1, 2], [3, 4]]
+
+  In the above example the collapsed slices are `[3, 4]`, `[1, 2]`, `[3, 4]`
+  and have rank 1. Using `offset_dims` we specify that the first
+  dimension in each slice corresponds to the second dimension in
+  the output tensor.
+
+  If we use the first output dimension instead, we get:
+
+      and given
+        offset_dims = [0]
+      then
+        result is [[3, 1, 3], [4, 2, 4]]
+
+  ## Docs
+
+  More formal specification can be found in [the XLA Gather docs](https://www.tensorflow.org/xla/operation_semantics#gather).
+  """
+  def gather(
+        %Op{builder: builder, ref: op},
+        %Op{builder: builder, ref: start_indices},
+        index_vector_dim,
+        slice_sizes,
+        offset_dims,
+        collapsed_slice_dims,
+        start_index_map
+      )
+      when is_integer(index_vector_dim) and is_list(slice_sizes) and is_list(offset_dims) and
+             is_list(collapsed_slice_dims) and is_list(start_index_map) do
+    ref =
+      EXLA.NIF.gather(
+        op,
+        start_indices,
+        index_vector_dim,
+        slice_sizes,
+        offset_dims,
+        collapsed_slice_dims,
+        start_index_map
+      )
+      |> unwrap!()
+
+    %Op{builder: builder, ref: ref}
+  end
+
   def dot(
         %Op{builder: builder, ref: left},
         %Op{builder: builder, ref: right},

--- a/exla/lib/exla/op.ex
+++ b/exla/lib/exla/op.ex
@@ -310,7 +310,7 @@ defmodule EXLA.Op do
         start_indices = [[0], [1]]
         index_vector_dim = 1
       and given
-        start_index_map = [1] # effectively %{0 => 0, 1 => 1}
+        start_index_map = [1] # effectively %{0 => 1}
       then
         actual index vectors are [0, 0], [0, 1] (leading 0 is inserted)
 

--- a/exla/test/exla/defn_expr_test.exs
+++ b/exla/test/exla/defn_expr_test.exs
@@ -2502,6 +2502,62 @@ defmodule EXLA.DefnExprTest do
     end
   end
 
+  describe "take" do
+    defn take_axis_0(t, idx), do: Nx.take(t, idx)
+    defn take_axis_1(t, idx), do: Nx.take(t, idx, axis: 1)
+
+    test "1d indices" do
+      assert take_axis_0(Nx.tensor([[1, 2], [3, 4]]), Nx.tensor([1, 0, 1])) ==
+               Nx.tensor([[3, 4], [1, 2], [3, 4]])
+
+      assert take_axis_1(Nx.tensor([[1, 2], [3, 4]]), Nx.tensor([1, 0, 1])) ==
+               Nx.tensor([[2, 1, 2], [4, 3, 4]])
+    end
+
+    test "2d indices" do
+      assert take_axis_1(
+               Nx.tensor([[[1, 2], [11, 12]], [[101, 102], [111, 112]]]),
+               Nx.tensor([[0, 0, 0], [1, 1, 1], [0, 0, 0]])
+             ) ==
+               Nx.tensor([
+                 [
+                   [
+                     [1, 2],
+                     [1, 2],
+                     [1, 2]
+                   ],
+                   [
+                     [11, 12],
+                     [11, 12],
+                     [11, 12]
+                   ],
+                   [
+                     [1, 2],
+                     [1, 2],
+                     [1, 2]
+                   ]
+                 ],
+                 [
+                   [
+                     [101, 102],
+                     [101, 102],
+                     [101, 102]
+                   ],
+                   [
+                     [111, 112],
+                     [111, 112],
+                     [111, 112]
+                   ],
+                   [
+                     [101, 102],
+                     [101, 102],
+                     [101, 102]
+                   ]
+                 ]
+               ])
+    end
+  end
+
   describe "reverse" do
     defn reverse(t), do: Nx.reverse(t)
     defn reverse1(t), do: Nx.reverse(t, axes: [1])

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -7519,6 +7519,150 @@ defmodule Nx do
   end
 
   @doc """
+  Takes and concatenates slices along an axis.
+
+  Intuitively speaking, `take/3` reorders tensor slices along
+  the given axis based on the given indices, possibly duplicating
+  and removing slices.
+
+  Passing a multi-dimensional indices tensor only affects the
+  resulting shape. Specifically, the given axis in the input shape
+  gets replaced with the indices shape.
+
+  ## Options
+
+    * `:axis` - an axis to take tensor slices over. Defaults to 0.
+
+  ## Examples
+
+      iex> Nx.take(Nx.tensor([[1, 2], [3, 4]]), Nx.tensor([1, 0, 1]))
+      #Nx.Tensor<
+        s64[3][2]
+        [
+          [3, 4],
+          [1, 2],
+          [3, 4]
+        ]
+      >
+
+      iex> Nx.take(Nx.tensor([[1, 2], [3, 4]]), Nx.tensor([1, 0, 1]), axis: 1)
+      #Nx.Tensor<
+        s64[2][3]
+        [
+          [2, 1, 2],
+          [4, 3, 4]
+        ]
+      >
+
+      iex> Nx.take(Nx.tensor([[1, 2], [3, 4]], names: [:x, :y]), Nx.tensor([1, 0, 1]), axis: :y)
+      #Nx.Tensor<
+        s64[x: 2][y: 3]
+        [
+          [2, 1, 2],
+          [4, 3, 4]
+        ]
+      >
+
+      iex> Nx.take(Nx.tensor([[[1, 2], [11, 12]], [[101, 102], [111, 112]]]), Nx.tensor([1, 0, 1]), axis: 1)
+      #Nx.Tensor<
+        s64[2][3][2]
+        [
+          [
+            [11, 12],
+            [1, 2],
+            [11, 12]
+          ],
+          [
+            [111, 112],
+            [101, 102],
+            [111, 112]
+          ]
+        ]
+      >
+
+  Multi-dimensional indices tensor:
+
+      iex> Nx.take(Nx.tensor([[1, 2], [11, 12]]), Nx.tensor([[0, 0], [1, 1], [0, 0]]), axis: 1)
+      #Nx.Tensor<
+        s64[2][3][2]
+        [
+          [
+            [1, 1],
+            [2, 2],
+            [1, 1]
+          ],
+          [
+            [11, 11],
+            [12, 12],
+            [11, 11]
+          ]
+        ]
+      >
+
+      iex> Nx.take(Nx.tensor([[[1, 2], [11, 12]], [[101, 102], [111, 112]]]), Nx.tensor([[0, 0, 0], [1, 1, 1], [0, 0, 0]]), axis: 1)
+      #Nx.Tensor<
+        s64[2][3][3][2]
+        [
+          [
+            [
+              [1, 2],
+              [1, 2],
+              [1, 2]
+            ],
+            [
+              [11, 12],
+              [11, 12],
+              [11, 12]
+            ],
+            [
+              [1, 2],
+              [1, 2],
+              [1, 2]
+            ]
+          ],
+          [
+            [
+              [101, 102],
+              [101, 102],
+              [101, 102]
+            ],
+            [
+              [111, 112],
+              [111, 112],
+              [111, 112]
+            ],
+            [
+              [101, 102],
+              [101, 102],
+              [101, 102]
+            ]
+          ]
+        ]
+      >
+
+  ### Error cases
+
+      iex> Nx.take(Nx.tensor([[1, 2], [3, 4]]), Nx.tensor([1, 0, 1], type: {:f, 32}))
+      ** (ArgumentError) indices must be an integer tensor, got {:f, 32}
+  """
+  @doc type: :shape
+  def take(tensor, indices, opts \\ []) when is_list(opts) do
+    tensor = to_tensor(tensor)
+    indices = to_tensor(indices)
+
+    unless Nx.Type.integer?(indices.type) do
+      raise ArgumentError, "indices must be an integer tensor, got #{inspect(indices.type)}"
+    end
+
+    opts = keyword!(opts, axis: 0)
+    axis = Nx.Shape.normalize_axis(tensor.shape, opts[:axis], tensor.names)
+
+    {shape, names} = Nx.Shape.take(tensor.shape, tensor.names, indices.shape, indices.names, axis)
+
+    impl!(tensor).take(%{tensor | shape: shape, names: names}, tensor, indices, axis)
+  end
+
+  @doc """
   Concatenates tensors along the given axis.
 
   If no axis is provided, defaults to 0.

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -7279,6 +7279,10 @@ defmodule Nx do
   zero. `start_index + length` must not exceed the respective
   tensor dimension.
 
+  It is possible for `start_indices` to be a list of tensors.
+  However, `lengths` must always be a list of integers. If you
+  want to specify a tensor as the list of indices, see `take/3`.
+
   If the `:strides` is given, it must be strictly greater than zero.
   The resulting tensor will have the shape of `length` unless
   `:strides` are given.

--- a/nx/lib/nx/backend.ex
+++ b/nx/lib/nx/backend.ex
@@ -65,6 +65,7 @@ defmodule Nx.Backend do
   @callback clip(out :: tensor, tensor, min :: tensor, max :: tensor) :: tensor
   @callback slice(out :: tensor, tensor, list, list, list) :: tensor
   @callback put_slice(out :: tensor, tensor, tensor, list) :: tensor
+  @callback take(out :: tensor, tensor, tensor, axis) :: tensor
   @callback concatenate(out :: tensor, tensor, axis) :: tensor
   @callback select(out :: tensor, tensor, tensor, tensor) :: tensor
 

--- a/nx/lib/nx/binary_backend.ex
+++ b/nx/lib/nx/binary_backend.ex
@@ -1702,6 +1702,12 @@ defmodule Nx.BinaryBackend do
     slices =
       for <<bin::size(idx_size)-bitstring <- to_binary(indices)>> do
         idx = binary_to_number(bin, indices.type)
+
+        if idx < 0 or idx >= elem(shape, axis) do
+          raise ArgumentError,
+                "index #{idx} is out of bounds for axis #{axis} in shape #{inspect(shape)}"
+        end
+
         slice_start = List.replace_at(slice_start, axis, idx)
 
         slice_data =

--- a/nx/lib/nx/binary_backend.ex
+++ b/nx/lib/nx/binary_backend.ex
@@ -1598,12 +1598,19 @@ defmodule Nx.BinaryBackend do
     %T{type: {_, size}, shape: shape} = tensor
     %{shape: output_shape} = out
 
+    tensor
+    |> to_binary()
+    |> do_slice(shape, size, start_indices, lengths, strides, output_shape)
+    |> then(&from_binary(out, &1))
+  end
+
+  defp do_slice(data, shape, size, start_indices, lengths, strides, output_shape) do
     start_indices = clamp_indices(start_indices, shape, lengths)
 
     if top_dimension_slice?(tuple_size(shape), shape, output_shape) do
       length = Nx.size(output_shape) * div(size, 8)
       offset = div(length, elem(output_shape, 0)) * hd(start_indices)
-      from_binary(out, binary_part(to_binary(tensor), offset, length))
+      binary_part(data, offset, length)
     else
       # Anchored around the start indices
       weighted_shape = weighted_shape(shape, size, output_shape)
@@ -1616,12 +1623,7 @@ defmodule Nx.BinaryBackend do
           {d, dim_size + (s - 1) * dim_size}
         end)
 
-      input_data = to_binary(tensor)
-
-      output_data =
-        IO.iodata_to_binary(weighted_traverse(weighted_shape, input_data, size, offset))
-
-      from_binary(out, output_data)
+      IO.iodata_to_binary(weighted_traverse(weighted_shape, data, size, offset))
     end
   end
 
@@ -1681,51 +1683,62 @@ defmodule Nx.BinaryBackend do
 
   @impl true
   def take(out, tensor, indices, axis) do
-    %T{type: {_, idx_size}} = indices
-
     # We iterate over the indices in a flat manner,
     # and take a unit tensor slice along axis given
     # by each index. Then we concatenate the tensors
     # along the axis, which gives us the result with
     # index dimensions flattened and we just reshape.
 
-    tensor_rank = tuple_size(tensor.shape)
+    %T{type: {_, size}, shape: shape} = tensor
+    %T{type: {_, idx_size}} = indices
+
+    data = to_binary(tensor)
+    tensor_rank = tuple_size(shape)
     slice_start = List.duplicate(0, tensor_rank)
-    slice_lengths = tensor.shape |> Tuple.to_list() |> List.replace_at(axis, 1)
+    slice_lengths = shape |> Tuple.to_list() |> List.replace_at(axis, 1)
+    slice_shape = List.to_tuple(slice_lengths)
+    strides = List.duplicate(1, tensor_rank)
 
     slices =
       for <<bin::size(idx_size)-bitstring <- to_binary(indices)>> do
         idx = binary_to_number(bin, indices.type)
         slice_start = List.replace_at(slice_start, axis, idx)
-        Nx.slice(tensor, slice_start, slice_lengths)
+        slice_data = do_slice(data, shape, size, slice_start, slice_lengths, strides, slice_shape)
+        {slice_data, slice_shape}
       end
 
-    slices
-    |> Nx.concatenate(axis: axis)
-    |> Nx.reshape(out.shape, names: out.names)
+    concat_shape = put_elem(tensor.shape, axis, length(slices))
+    result_data = do_concatenate(slices, size, concat_shape, axis)
+    from_binary(out, result_data)
   end
 
   @impl true
   def concatenate(out, tensors, axis) do
     %{shape: output_shape, type: {_, size} = output_type} = out
+
+    tensors
+    |> Enum.map(fn %{shape: shape} = t ->
+      t = as_type(%{t | type: output_type}, t)
+      {to_binary(t), shape}
+    end)
+    |> do_concatenate(size, output_shape, axis)
+    |> then(&from_binary(out, &1))
+  end
+
+  defp do_concatenate(binaries_with_shape, size, output_shape, axis) do
     rank = tuple_size(output_shape)
     steps = product_part(output_shape, 0, axis)
 
-    tensors =
-      Enum.map(tensors, fn %{shape: shape} = t ->
-        t = as_type(%{t | type: output_type}, t)
-        {to_binary(t), product_part(shape, axis, rank) * size}
-      end)
-
     data =
       for step <- 1..steps,
-          {binary, product} <- tensors do
+          {binary, shape} <- binaries_with_shape do
+        product = product_part(shape, axis, rank) * size
         before = (step - 1) * product
         <<_::bitstring-size(before), part::bitstring-size(product), _::bitstring>> = binary
         part
       end
 
-    from_binary(out, data)
+    IO.iodata_to_binary(data)
   end
 
   defp product_part(_tuple, n, n), do: 1

--- a/nx/lib/nx/binary_backend.ex
+++ b/nx/lib/nx/binary_backend.ex
@@ -1708,7 +1708,7 @@ defmodule Nx.BinaryBackend do
       end
 
     concat_shape = put_elem(tensor.shape, axis, length(slices))
-    result_data = do_concatenate(slices, size, concat_shape, axis)
+    result_data = do_concatenate(slices, size, axis, concat_shape)
     from_binary(out, result_data)
   end
 
@@ -1721,11 +1721,11 @@ defmodule Nx.BinaryBackend do
       t = as_type(%{t | type: output_type}, t)
       {to_binary(t), shape}
     end)
-    |> do_concatenate(size, output_shape, axis)
+    |> do_concatenate(size, axis, output_shape)
     |> then(&from_binary(out, &1))
   end
 
-  defp do_concatenate(binaries_with_shape, size, output_shape, axis) do
+  defp do_concatenate(binaries_with_shape, size, axis, output_shape) do
     rank = tuple_size(output_shape)
     steps = product_part(output_shape, 0, axis)
 

--- a/nx/lib/nx/defn/expr.ex
+++ b/nx/lib/nx/defn/expr.ex
@@ -653,6 +653,12 @@ defmodule Nx.Defn.Expr do
   end
 
   @impl true
+  def take(out, tensor, indices, axis) do
+    {[tensor, indices], context} = to_exprs([tensor, indices])
+    expr(out, context, :take, [tensor, indices, axis])
+  end
+
+  @impl true
   def reverse(out, tensor, axes) do
     tensor = to_expr(tensor)
     expr(out, tensor.data.context, :reverse, [tensor, axes])


### PR DESCRIPTION
This PR introduces two bits:

* bindings to [`xla::Gather`](https://www.tensorflow.org/xla/operation_semantics#gather) - a very generic operation that may be used to implement many specific operations
* `Nx.take/3` - one specific operation backed by `xla::Gather`, it corresponds to [np.take](https://numpy.org/doc/stable/reference/generated/numpy.take.html) (Group 1 below). I went with the same naming because gather is too broad, but alternatives are welcome

## Gather overview

Gather is a really broad term and its meaning varies across packages, some variants I found could be grouped like so:

**Group 1: "reorder" tensor along specific axis**

```
tensor: [
  [1, 2],
  [3, 4]
]
indices: [1, 0, 1]

result along axis 0: [
  [3, 4]
  [1, 2],
  [3, 4]
]
```

* [tf.gather](https://www.tensorflow.org/api_docs/python/tf/gather) without batching
* [np.take](https://numpy.org/doc/stable/reference/generated/numpy.take.html)
* [torch.index_select](https://pytorch.org/docs/stable/generated/torch.index_select.html)

**Group 2: zip tensor slices with indices slices and "reorder" accordingly**

```
tensor: [
  [1, 2],
  [3, 4]
]
indices: [
  [1, 0],
  [1, 1]
]

result along axis 1: [
  [2, 1],
  [4, 4]
]
```

* [tf.gather](https://www.tensorflow.org/api_docs/python/tf/gather) with batching (though I think it only works if batching along leading axis)
* [np.take_along_axis](https://numpy.org/doc/stable/reference/generated/numpy.take_along_axis.html)
* [torch.gather](https://pytorch.org/docs/stable/generated/torch.gather.html#torch.gather)

**Group 3: pick elements at specific indices**

```
tensor: [
  [1, 2],
  [3, 4]
]
indices: [[1, 0], [0, 1]]

result: [3, 2]
```

* [tf.gather_nd](https://www.tensorflow.org/api_docs/python/tf/gather_nd)
* `np` and `torch` support this via fancy indexing as far as I understand