### PR TITLE
fix: support wide matrices for backends other than the binary backend

### DIFF
--- a/exla/test/exla/defn_expr_test.exs
+++ b/exla/test/exla/defn_expr_test.exs
@@ -380,20 +380,30 @@ defmodule EXLA.DefnExprTest do
     defn exp(t), do: Nx.exp(t)
 
     test "computes the exp across types" do
-      assert compare_tensors!(Nx.tensor([1, 2, 3]) |> exp(),
-               Nx.tensor([2.718281828459045, 7.38905609893065, 20.085536923187668]))
+      assert compare_tensors!(
+               Nx.tensor([1, 2, 3]) |> exp(),
+               Nx.tensor([2.718281828459045, 7.38905609893065, 20.085536923187668])
+             )
 
-      assert compare_tensors!(Nx.tensor([1, 2, 3], type: {:s, 8}) |> exp(),
-               Nx.tensor([2.718281828459045, 7.38905609893065, 20.085536923187668], type: {:f, 32}))
+      assert compare_tensors!(
+               Nx.tensor([1, 2, 3], type: {:s, 8}) |> exp(),
+               Nx.tensor([2.718281828459045, 7.38905609893065, 20.085536923187668], type: {:f, 32})
+             )
 
-      assert compare_tensors!(Nx.tensor([1, 2, 3], type: {:u, 8}) |> exp(),
-               Nx.tensor([2.718281828459045, 7.38905609893065, 20.085536923187668], type: {:f, 32}))
+      assert compare_tensors!(
+               Nx.tensor([1, 2, 3], type: {:u, 8}) |> exp(),
+               Nx.tensor([2.718281828459045, 7.38905609893065, 20.085536923187668], type: {:f, 32})
+             )
 
-      assert compare_tensors!(Nx.tensor([1.0, 2.0, 3.0]) |> exp(),
-               Nx.tensor([2.718281828459045, 7.38905609893065, 20.085536923187668]))
+      assert compare_tensors!(
+               Nx.tensor([1.0, 2.0, 3.0]) |> exp(),
+               Nx.tensor([2.718281828459045, 7.38905609893065, 20.085536923187668])
+             )
 
-      assert compare_tensors!(Nx.tensor([1.0, 2.0, 3.0], type: {:f, 32}) |> exp(),
-               Nx.tensor([2.718281828459045, 7.38905609893065, 20.085536923187668], type: {:f, 32}))
+      assert compare_tensors!(
+               Nx.tensor([1.0, 2.0, 3.0], type: {:f, 32}) |> exp(),
+               Nx.tensor([2.718281828459045, 7.38905609893065, 20.085536923187668], type: {:f, 32})
+             )
     end
   end
 
@@ -2825,6 +2835,38 @@ defmodule EXLA.DefnExprTest do
       assert s.shape == {3}
       assert vt.shape == {3, 3}
       s_full = Nx.multiply(s, Nx.tensor([[1, 0, 0], [0, 1, 0], [0, 0, 1]]))
+
+      assert compare_tensors!(u |> Nx.dot(s_full) |> Nx.dot(Nx.transpose(vt)), output,
+               atol: 1.0e-5,
+               rtol: 1.0e-2
+             )
+    end
+
+    test "svd (tall matrix)" do
+      input = Nx.tensor([[2, 0], [0, 1], [0, 0]])
+      output = Nx.as_type(input, {:f, 32})
+
+      assert {u, s, vt} = svd(input)
+      assert u.shape == {3, 3}
+      assert s.shape == {2}
+      assert vt.shape == {2, 2}
+      s_full = Nx.multiply(s, Nx.tensor([[1, 0], [0, 1], [0, 0]]))
+
+      assert compare_tensors!(u |> Nx.dot(s_full) |> Nx.dot(Nx.transpose(vt)), output,
+               atol: 1.0e-5,
+               rtol: 1.0e-2
+             )
+    end
+
+     test "svd (wide matrix)" do
+      input = Nx.tensor([[2, 0, 0], [0, 1, 0]])
+      output = Nx.as_type(input, {:f, 32})
+
+      assert {u, s, vt} = svd(input)
+      assert u.shape == {2, 2}
+      assert s.shape == {2}
+      assert vt.shape == {3, 3}
+      s_full = Nx.multiply(Nx.reshape(s, {2, 1}), Nx.tensor([[1, 0, 0], [0, 1, 0]]))
 
       assert compare_tensors!(u |> Nx.dot(s_full) |> Nx.dot(Nx.transpose(vt)), output,
                atol: 1.0e-5,

--- a/nx/lib/nx/binary_backend.ex
+++ b/nx/lib/nx/binary_backend.ex
@@ -1172,12 +1172,16 @@ defmodule Nx.BinaryBackend do
 
   @impl true
   def svd(
-        {u_holder, %{type: output_type} = s_holder, v_holder},
+        {%{shape: {m, _}} = u_holder, s_holder, %{shape: {_, n}} = v_holder} = outputs,
         %{type: input_type, shape: input_shape} = tensor,
         opts
       ) do
+    if m < n do
+      raise ArgumentError, "SVD not implemented for wide matrices (m x n 2-D tensors where m < n)"
+    end
+
     bin = to_binary(tensor)
-    {u, s, v} = B.Matrix.svd(bin, input_type, input_shape, output_type, opts)
+    {u, s, v} = B.Matrix.svd(bin, input_type, input_shape, outputs, opts)
     {from_binary(u_holder, u), from_binary(s_holder, s), from_binary(v_holder, v)}
   end
 

--- a/nx/lib/nx/binary_backend.ex
+++ b/nx/lib/nx/binary_backend.ex
@@ -1177,7 +1177,7 @@ defmodule Nx.BinaryBackend do
         opts
       ) do
     if m < n do
-      raise ArgumentError, "SVD not implemented for wide matrices (m x n 2-D tensors where m < n)"
+      raise ArgumentError, "SVD not implemented for wide matrices (tensors with shape {m, n} where m < n)"
     end
 
     bin = to_binary(tensor)

--- a/nx/lib/nx/binary_backend.ex
+++ b/nx/lib/nx/binary_backend.ex
@@ -1177,7 +1177,8 @@ defmodule Nx.BinaryBackend do
         opts
       ) do
     if m < n do
-      raise ArgumentError, "SVD not implemented for wide matrices (tensors with shape {m, n} where m < n)"
+      raise ArgumentError,
+            "SVD not implemented for wide matrices (tensors with shape {m, n} where m < n)"
     end
 
     bin = to_binary(tensor)

--- a/nx/lib/nx/binary_backend/matrix.ex
+++ b/nx/lib/nx/binary_backend/matrix.ex
@@ -366,7 +366,7 @@ defmodule Nx.BinaryBackend.Matrix do
 
     {s, [vt_row | _] = vt} = apply_singular_value_corrections(s, vt)
 
-    # TO-DO: complete the vtt matrix with linearly independent rows
+    # TO-DO: complete the vt matrix with linearly independent rows
     # requires solvting a homogeneous equation system for non-homogenous
     # solutions
     if length(vt) != vt_rows or length(vt_row) != vt_cols do

--- a/nx/lib/nx/binary_backend/matrix.ex
+++ b/nx/lib/nx/binary_backend/matrix.ex
@@ -367,7 +367,7 @@ defmodule Nx.BinaryBackend.Matrix do
     {s, [vt_row | _] = vt} = apply_singular_value_corrections(s, vt)
 
     # TO-DO: complete the vt matrix with linearly independent rows
-    # requires solvting a homogeneous equation system for non-homogenous
+    # requires solving a homogeneous equation system for non-homogenous
     # solutions
     if length(vt) != vt_rows or length(vt_row) != vt_cols do
       raise "vt matrix completion for wide-matrices not implemented"

--- a/nx/lib/nx/binary_backend/matrix.ex
+++ b/nx/lib/nx/binary_backend/matrix.ex
@@ -314,7 +314,13 @@ defmodule Nx.BinaryBackend.Matrix do
     end)
   end
 
-  def svd(input_data, input_type, input_shape, output_type, opts) do
+  def svd(
+        input_data,
+        input_type,
+        input_shape,
+        {_u_holder, %{type: output_type}, %{shape: {vt_rows, vt_cols}}},
+        opts
+      ) do
     # This implementation is a mixture of concepts described in [1] and the
     # algorithmic descriptions found in [2], [3] and [4]
     #
@@ -329,25 +335,25 @@ defmodule Nx.BinaryBackend.Matrix do
 
     eps = opts[:eps]
     max_iter = opts[:max_iter] || 1000
-    {u, d, v} = householder_bidiagonalization(a, input_shape, eps)
+    {u, d, vt} = householder_bidiagonalization(a, input_shape, eps)
 
     {fro_norm, off_diag_norm} = get_frobenius_norm(d)
 
-    {u, s_matrix, v, _, _} =
-      Enum.reduce_while(1..max_iter, {u, d, v, off_diag_norm, fro_norm}, fn
-        _, {u, d, v, off_diag_norm, fro_norm} ->
+    {u, s_matrix, vt, _, _} =
+      Enum.reduce_while(1..max_iter, {u, d, vt, off_diag_norm, fro_norm}, fn
+        _, {u, d, vt, off_diag_norm, fro_norm} ->
           eps = 1.0e-9 * fro_norm
 
           if off_diag_norm > eps do
-            # Execute a round of jacobi rotations on u, d and v
-            {u, d, v} = svd_jacobi_rotation_round(u, d, v, input_shape, eps)
+            # Execute a round of jacobi rotations on u, d and vt
+            {u, d, vt} = svd_jacobi_rotation_round(u, d, vt, input_shape, eps)
 
             # calculate a posteriori norms for d, so the next iteration of Enum.reduce_while can decide to halt
             {fro_norm, off_diag_norm} = get_frobenius_norm(d)
 
-            {:cont, {u, d, v, off_diag_norm, fro_norm}}
+            {:cont, {u, d, vt, off_diag_norm, fro_norm}}
           else
-            {:halt, {u, d, v, nil, nil}}
+            {:halt, {u, d, vt, nil, nil}}
           end
       end)
 
@@ -358,11 +364,18 @@ defmodule Nx.BinaryBackend.Matrix do
       |> Enum.map(fn {row, idx} -> Enum.at(row, idx) end)
       |> Enum.reject(&is_nil/1)
 
-    {s, v} = apply_singular_value_corrections(s, v)
+    {s, [vt_row | _] = vt} = apply_singular_value_corrections(s, vt)
+
+    # TO-DO: complete the vtt matrix with linearly independent rows
+    # requires solvting a homogeneous equation system for non-homogenous
+    # solutions
+    if length(vt) != vt_rows or length(vt_row) != vt_cols do
+      raise "vt matrix completion for wide-matrices not implemented"
+    end
 
     {u |> approximate_zeros(eps) |> matrix_to_binary(output_type),
      s |> approximate_zeros(eps) |> matrix_to_binary(output_type),
-     v |> approximate_zeros(eps) |> matrix_to_binary(output_type)}
+     vt |> approximate_zeros(eps) |> matrix_to_binary(output_type)}
   end
 
   defp svd_jacobi_rotation_round(u, d, v, {_, n}, eps) do

--- a/nx/lib/nx/shape.ex
+++ b/nx/lib/nx/shape.ex
@@ -1436,7 +1436,7 @@ defmodule Nx.Shape do
       )
 
   def svd({m, n}) do
-    {{m, m}, {n}, {n, n}}
+    {{m, m}, {min(m, n)}, {n, n}}
   end
 
   def svd(shape),

--- a/nx/lib/nx/shape.ex
+++ b/nx/lib/nx/shape.ex
@@ -1435,7 +1435,7 @@ defmodule Nx.Shape do
         "tensor must have rank 2, got rank #{tuple_size(shape)} with shape #{inspect(shape)}"
       )
 
-  def svd({m, n}) when m >= n do
+  def svd({m, n}) do
     {{m, m}, {min(m, n)}, {n, n}}
   end
 

--- a/nx/lib/nx/shape.ex
+++ b/nx/lib/nx/shape.ex
@@ -1435,7 +1435,7 @@ defmodule Nx.Shape do
         "tensor must have rank 2, got rank #{tuple_size(shape)} with shape #{inspect(shape)}"
       )
 
-  def svd({m, n}) do
+  def svd({m, n}) when m >= n do
     {{m, m}, {min(m, n)}, {n, n}}
   end
 


### PR DESCRIPTION
Fixes the Nx.Shape rule for SVD, allowing for all kinds of matrices.
Some backends, like BinaryBackend, may raise depending on the implementation
limitations.

closes #444