### PR TITLE
feat: add take_along_axis (with binary backend impl)

### DIFF
--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -7666,6 +7666,19 @@ defmodule Nx do
     impl!(tensor).take(%{tensor | shape: shape, names: names}, tensor, indices, axis)
   end
 
+  @doc """
+
+  ## Examples
+
+      iex> Nx.take_along_axis(Nx.tensor([[1, 2, 3], [4, 5, 6]]), Nx.tensor([[0, 0, 2, 2, 1, 1], [2, 2, 1, 1, 0, 0]]), axis: 1)
+      #Nx.Tensor<
+        s64[2][6]
+        [
+          [1, 1, 3, 3, 2, 2],
+          [6, 6, 5, 5, 4, 4]
+        ]
+      >
+  """
   def take_along_axis(tensor, indices, opts \\ []) when is_list(opts) do
     tensor = to_tensor(tensor)
     indices = to_tensor(indices)

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -7702,8 +7702,8 @@ defmodule Nx do
         ]
       >
 
-    The indices returned from `Nx.argsort/2` can be used with `Nx.take_along_axis/3` to
-    produce the sorted tensor (or to sort more tensors according to the same criteria).
+  The indices returned from `Nx.argsort/2` can be used with `Nx.take_along_axis/3` to
+  produce the sorted tensor (or to sort more tensors according to the same criteria).
 
       iex> tensor = Nx.tensor([[[1, 2], [3, 4], [5, 6]]])
       #Nx.Tensor<
@@ -7761,7 +7761,7 @@ defmodule Nx do
         ]
       >
 
-    ### Error cases
+  ### Error cases
 
       iex> tensor = Nx.iota({3, 3})
       iex> idx = Nx.tensor([[2.0], [1.0], [2.0]], type: {:f, 32})

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -7678,6 +7678,54 @@ defmodule Nx do
           [6, 6, 5, 5, 4, 4]
         ]
       >
+
+      iex> Nx.take_along_axis(Nx.tensor([[1, 2, 3], [4, 5, 6]]), Nx.tensor([[0, 1, 1], [1, 0, 0], [0, 1, 0]]), axis: 0)
+      #Nx.Tensor<
+        s64[3][3]
+        [
+          [1, 5, 6],
+          [4, 2, 3],
+          [1, 5, 3]
+        ]
+      >
+
+    The indices returned from `Nx.argsort/2` can be used with `Nx.take_along_axis/3` to
+    produce the sorted tensor (or to sort more tensors according to the same criteria).
+
+      iex> tensor = Nx.tensor([[[1, 2], [3, 4], [5, 6]]])
+      #Nx.Tensor<
+        s64[1][3][2]
+        [
+          [
+            [1, 2],
+            [3, 4],
+            [5, 6]
+          ]
+        ]
+      >
+      iex> idx = Nx.argsort(tensor, axis: 2, direction: :desc)
+      #Nx.Tensor<
+        s64[1][3][2]
+        [
+          [
+            [1, 0],
+            [1, 0],
+            [1, 0]
+          ]
+        ]
+      >
+      iex> Nx.take_along_axis(tensor, idx, axis: 2)
+      #Nx.Tensor<
+        s64[1][3][2]
+        [
+          [
+            [2, 1],
+            [4, 3],
+            [6, 5]
+          ]
+        ]
+      >
+
   """
   def take_along_axis(tensor, indices, opts \\ []) when is_list(opts) do
     tensor = to_tensor(tensor)

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -7667,6 +7667,19 @@ defmodule Nx do
   end
 
   @doc """
+  Takes the values from a tensor given an `indices` tensor, along the specified axis.
+
+  The `indices` shape must be the same as the `tensor`'s shape, with the exception for
+  the `axis` dimension, which can have arbitrary size.
+
+  Arbitrary tensors according to the shape rules are accept, but `Nx.argsort/2` also
+  produces suitable indices for this function, as shown in the examples below.
+
+  See also: `Nx.take/3`, `Nx.sort/2`, `Nx.argsort/2`
+
+  ## Options
+
+    * `:axis` - The axis along which to take the values from. Defaults to `0`.
 
   ## Examples
 

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -7666,6 +7666,22 @@ defmodule Nx do
     impl!(tensor).take(%{tensor | shape: shape, names: names}, tensor, indices, axis)
   end
 
+  def take_along_axis(tensor, indices, opts \\ []) when is_list(opts) do
+    tensor = to_tensor(tensor)
+    indices = to_tensor(indices)
+
+    unless Nx.Type.integer?(indices.type) do
+      raise ArgumentError, "indices must be an integer tensor, got #{inspect(indices.type)}"
+    end
+
+    opts = keyword!(opts, axis: 0)
+    axis = Nx.Shape.normalize_axis(tensor.shape, opts[:axis], tensor.names)
+
+    shape = Nx.Shape.take_along_axis(tensor.shape, indices.shape, axis)
+
+    impl!(tensor).take_along_axis(%{tensor | shape: shape}, tensor, indices, axis)
+  end
+
   @doc """
   Concatenates tensors along the given axis.
 

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -7716,7 +7716,29 @@ defmodule Nx do
           ]
         ]
       >
-      iex> idx = Nx.argsort(tensor, axis: 2, direction: :desc)
+      iex> idx1 = Nx.argsort(tensor, axis: 1, direction: :desc)
+      #Nx.Tensor<
+        s64[1][3][2]
+        [
+          [
+            [2, 2],
+            [1, 1],
+            [0, 0]
+          ]
+        ]
+      >
+      iex> Nx.take_along_axis(tensor, idx1, axis: 1)
+      #Nx.Tensor<
+        s64[1][3][2]
+        [
+          [
+            [5, 6],
+            [3, 4],
+            [1, 2]
+          ]
+        ]
+      >
+      iex> idx2 = Nx.argsort(tensor, axis: 2, direction: :desc)
       #Nx.Tensor<
         s64[1][3][2]
         [
@@ -7727,7 +7749,7 @@ defmodule Nx do
           ]
         ]
       >
-      iex> Nx.take_along_axis(tensor, idx, axis: 2)
+      iex> Nx.take_along_axis(tensor, idx2, axis: 2)
       #Nx.Tensor<
         s64[1][3][2]
         [
@@ -7739,6 +7761,12 @@ defmodule Nx do
         ]
       >
 
+    ### Error cases
+
+      iex> tensor = Nx.iota({3, 3})
+      iex> idx = Nx.tensor([[2.0], [1.0], [2.0]], type: {:f, 32})
+      iex> Nx.take_along_axis(tensor, idx, axis: 1)
+      ** (ArgumentError) indices must be an integer tensor, got {:f, 32}
   """
   def take_along_axis(tensor, indices, opts \\ []) when is_list(opts) do
     tensor = to_tensor(tensor)

--- a/nx/lib/nx/backend.ex
+++ b/nx/lib/nx/backend.ex
@@ -65,7 +65,8 @@ defmodule Nx.Backend do
   @callback clip(out :: tensor, tensor, min :: tensor, max :: tensor) :: tensor
   @callback slice(out :: tensor, tensor, list, list, list) :: tensor
   @callback put_slice(out :: tensor, tensor, tensor, list) :: tensor
-  @callback take(out :: tensor, tensor, tensor, axis) :: tensor
+  @callback take(out :: tensor, input :: tensor, indices :: tensor, axis) :: tensor
+  @callback take_along_axis(out :: tensor, input :: tensor, indices :: tensor, axis) :: tensor
   @callback concatenate(out :: tensor, tensor, axis) :: tensor
   @callback select(out :: tensor, tensor, tensor, tensor) :: tensor
 

--- a/nx/lib/nx/binary_backend.ex
+++ b/nx/lib/nx/binary_backend.ex
@@ -1772,9 +1772,6 @@ defmodule Nx.BinaryBackend do
       match_types [t_type, idx_type, output_type] do
         data = for <<match!(x, 0) <- data_bin>>, do: x
 
-        IO.inspect(data, label: "data")
-        IO.inspect(idx_bin, label: "idx_bin")
-
         for <<match!(x, 1) <- idx_bin>>, into: <<>> do
           index = read!(x, 1)
 

--- a/nx/lib/nx/binary_backend.ex
+++ b/nx/lib/nx/binary_backend.ex
@@ -1727,6 +1727,11 @@ defmodule Nx.BinaryBackend do
   end
 
   @impl true
+  def take_along_axis(out, tensor, indices, axis) do
+    raise "not implmented"
+  end
+
+  @impl true
   def concatenate(out, tensors, axis) do
     %{shape: output_shape, type: {_, size} = output_type} = out
 

--- a/nx/lib/nx/binary_backend.ex
+++ b/nx/lib/nx/binary_backend.ex
@@ -1729,6 +1729,11 @@ defmodule Nx.BinaryBackend do
   @impl true
   def take_along_axis(out, tensor, indices, axis) do
     raise "not implmented"
+
+    # plan:
+    # 1. transpose `axis` into the last dimension for both `tensors` and `indices` (like sort/argsort)
+    # 2. iterate through `zip(tensor, indices)`, using Enum.take(tensor_last_dim, indices_row)
+    # 3. undo the permutation (like sort/argsort)
   end
 
   @impl true

--- a/nx/lib/nx/binary_backend.ex
+++ b/nx/lib/nx/binary_backend.ex
@@ -1733,26 +1733,20 @@ defmodule Nx.BinaryBackend do
         %T{shape: idx_shape, type: {_, idx_size} = idx_type} = indices,
         axis
       ) do
-    permute = fn t ->
-      permutation =
-        t
-        |> Nx.axes()
-        |> List.delete(axis)
-        |> List.insert_at(Nx.rank(t) - 1, axis)
+    permutation =
+      tensor
+      |> Nx.axes()
+      |> List.delete(axis)
+      |> List.insert_at(Nx.rank(tensor) - 1, axis)
 
-      inverse_permutation =
-        permutation
-        |> Enum.with_index()
-        |> Enum.sort_by(fn {x, _} -> x end)
-        |> Enum.map(fn {_, i} -> i end)
+    inverse_permutation =
+      permutation
+      |> Enum.with_index()
+      |> Enum.sort_by(fn {x, _} -> x end)
+      |> Enum.map(fn {_, i} -> i end)
 
-      shape_list = Tuple.to_list(output.shape)
-      permuted_shape = permutation |> Enum.map(&Enum.at(shape_list, &1)) |> List.to_tuple()
-
-      {permuted_shape, inverse_permutation}
-    end
-
-    {permuted_shape, inverse_permutation} = permute.(tensor)
+    shape_list = Tuple.to_list(output.shape)
+    permuted_shape = permutation |> Enum.map(&Enum.at(shape_list, &1)) |> List.to_tuple()
 
     t_view = tensor |> to_binary() |> aggregate_axes([axis], t_shape, t_size)
 

--- a/nx/lib/nx/binary_backend.ex
+++ b/nx/lib/nx/binary_backend.ex
@@ -1728,11 +1728,6 @@ defmodule Nx.BinaryBackend do
 
   @impl true
   def take_along_axis(out, tensor, indices, axis) do
-    # plan:
-    # 1. transpose `axis` into the last dimension for both `tensors` and `indices` (like sort/argsort)
-    # 2. iterate through `zip(tensor, indices)`, using Enum.take(tensor_last_dim, indices_row)
-    # 3. undo the permutation (like sort/argsort)
-
     permute = fn t ->
       permutation =
         t

--- a/nx/lib/nx/defn/expr.ex
+++ b/nx/lib/nx/defn/expr.ex
@@ -659,6 +659,12 @@ defmodule Nx.Defn.Expr do
   end
 
   @impl true
+  def take_along_axis(out, tensor, indices, axis) do
+    {[tensor, indices], context} = to_exprs([tensor, indices])
+    expr(out, context, :take_along_axis, [tensor, indices, axis])
+  end
+
+  @impl true
   def reverse(out, tensor, axes) do
     tensor = to_expr(tensor)
     expr(out, tensor.data.context, :reverse, [tensor, axes])

--- a/nx/lib/nx/shape.ex
+++ b/nx/lib/nx/shape.ex
@@ -1225,8 +1225,7 @@ defmodule Nx.Shape do
 
     shape_template =
       shape_list
-      |> Enum.with_index()
-      |> Enum.map(fn
+      |> Enum.with_index(fn
         {_, ^axis} -> "*"
         {l, _} -> "#{l}"
       end)
@@ -1243,8 +1242,7 @@ defmodule Nx.Shape do
 
     [shape_list, indices_shape_list]
     |> Enum.zip()
-    |> Enum.with_index()
-    |> Enum.each(fn
+    |> Enum.with_index(fn
       {{_input_length, _output_length}, ^axis} ->
         :ok
 

--- a/nx/lib/nx/shape.ex
+++ b/nx/lib/nx/shape.ex
@@ -1193,6 +1193,72 @@ defmodule Nx.Shape do
   end
 
   @doc """
+  Returns the shape and names after a `take_along_axis` operation is performed.
+
+  In practice, `axis` in `shape` gets replaced by `indices_shape`.
+
+  ## Examples
+
+      iex> Nx.Shape.take_along_axis({2, 3}, {10, 3}, 0)
+      {10, 3}
+
+      iex> Nx.Shape.take_along_axis({2, 3}, {2, 10}, 1)
+      {2, 10}
+
+      iex> Nx.Shape.take_along_axis({2, 3, 4}, {10, 3, 4}, 0)
+      {10, 3, 4}
+
+  ### Error cases
+
+      iex> Nx.Shape.take_along_axis({2, 3, 4}, {3, 10, 4}, 1)
+      ** (ArgumentError) non-indexing dimensions must match. Expected {2, *, 4}, got: {3, 10, 4}
+
+      iex> Nx.Shape.take_along_axis({2, 3}, {1, 2, 3}, 0)
+      ** (ArgumentError) shapes must have the same number of dimensions. Expected {*, 3}, got: {1, 2, 3}
+  """
+  def take_along_axis(shape, indices_shape, axis) do
+    if axis >= tuple_size(shape) or axis < 0 do
+      raise ArgumentError, "axis must be a non-negative less than #{tuple_size(shape)}"
+    end
+
+    shape_list = Tuple.to_list(shape)
+
+    shape_template =
+      shape_list
+      |> Enum.with_index()
+      |> Enum.map(fn
+        {_, ^axis} -> "*"
+        {l, _} -> "#{l}"
+      end)
+      |> Enum.join(", ")
+
+    shape_template = "{#{shape_template}}"
+
+    if tuple_size(shape) != tuple_size(indices_shape) do
+      raise ArgumentError,
+            "shapes must have the same number of dimensions. Expected #{shape_template}, got: #{inspect(indices_shape)}"
+    end
+
+    indices_shape_list = Tuple.to_list(indices_shape)
+
+    [shape_list, indices_shape_list]
+    |> Enum.zip()
+    |> Enum.with_index()
+    |> Enum.each(fn
+      {{_input_length, _output_length}, ^axis} ->
+        :ok
+
+      {{input_length, output_length}, _axis} ->
+        unless input_length == output_length do
+          raise ArgumentError,
+                "non-indexing dimensions must match. Expected #{shape_template}, got: #{inspect(indices_shape)}"
+        end
+    end)
+
+    indices_shape
+  end
+
+  @doc """
   Returns the shape and names after a concat.
 
   ## Examples

--- a/nx/lib/nx/shape.ex
+++ b/nx/lib/nx/shape.ex
@@ -1221,23 +1221,12 @@ defmodule Nx.Shape do
       raise ArgumentError, "axis must be a non-negative less than #{tuple_size(shape)}"
     end
 
-    shape_list = Tuple.to_list(shape)
-
-    shape_template =
-      shape_list
-      |> Enum.with_index(fn
-        _, ^axis -> "*"
-        l, _ -> "#{l}"
-      end)
-      |> Enum.join(", ")
-
-    shape_template = "{#{shape_template}}"
-
     if tuple_size(shape) != tuple_size(indices_shape) do
       raise ArgumentError,
-            "shapes must have the same number of dimensions. Expected #{shape_template}, got: #{inspect(indices_shape)}"
+            "shapes must have the same number of dimensions. Expected #{take_along_axis_shape_template(shape, axis)}, got: #{inspect(indices_shape)}"
     end
 
+    shape_list = Tuple.to_list(shape)
     indices_shape_list = Tuple.to_list(indices_shape)
 
     [shape_list, indices_shape_list]
@@ -1249,11 +1238,25 @@ defmodule Nx.Shape do
       {input_length, output_length}, _axis ->
         unless input_length == output_length do
           raise ArgumentError,
-                "non-indexing dimensions must match. Expected #{shape_template}, got: #{inspect(indices_shape)}"
+                "non-indexing dimensions must match. Expected #{take_along_axis_shape_template(shape, axis)}, got: #{inspect(indices_shape)}"
         end
     end)
 
     indices_shape
+  end
+
+  defp take_along_axis_shape_template(shape, axis) do
+    shape_list = Tuple.to_list(shape)
+
+    shape_template =
+      shape_list
+      |> Enum.with_index(fn
+        _, ^axis -> "*"
+        l, _ -> "#{l}"
+      end)
+      |> Enum.join(", ")
+
+    "{#{shape_template}}"
   end
 
   @doc """

--- a/nx/lib/nx/shape.ex
+++ b/nx/lib/nx/shape.ex
@@ -1226,8 +1226,8 @@ defmodule Nx.Shape do
     shape_template =
       shape_list
       |> Enum.with_index(fn
-        {_, ^axis} -> "*"
-        {l, _} -> "#{l}"
+        _, ^axis -> "*"
+        l, _ -> "#{l}"
       end)
       |> Enum.join(", ")
 
@@ -1243,10 +1243,10 @@ defmodule Nx.Shape do
     [shape_list, indices_shape_list]
     |> Enum.zip()
     |> Enum.with_index(fn
-      {{_input_length, _output_length}, ^axis} ->
+      {_input_length, _output_length}, ^axis ->
         :ok
 
-      {{input_length, output_length}, _axis} ->
+      {input_length, output_length}, _axis ->
         unless input_length == output_length do
           raise ArgumentError,
                 "non-indexing dimensions must match. Expected #{shape_template}, got: #{inspect(indices_shape)}"

--- a/nx/test/nx/defn/stream_test.exs
+++ b/nx/test/nx/defn/stream_test.exs
@@ -112,6 +112,6 @@ defmodule Nx.Defn.StreamTest do
     Nx.default_backend(UnknownBackend)
     assert %_{} = stream = Nx.Defn.stream(&stream_iota/2, args)
     assert Nx.Stream.send(stream, hd(args))
-    assert_receive {:EXIT, _, {:undef, _}}
+    assert_receive {:EXIT, _, {:undef, _}}, 500
   end
 end


### PR DESCRIPTION
This PR adds `Nx.take_along_axis/3`, which makes `Nx.argsort/3` more
useful, allows for more flexible indexing of tensors and
enables the grad implementation for `Nx.sort/2`