### PR TITLE
Point XLA to Hex

### DIFF
--- a/exla/mix.exs
+++ b/exla/mix.exs
@@ -33,7 +33,7 @@ defmodule EXLA.MixProject do
   defp deps do
     [
       {:nx, path: "../nx"},
-      {:xla, "0.1.0", runtime: false, github: "elixir-nx/xla"},
+      {:xla, "~> 0.1.0", runtime: false},
       {:elixir_make, "~> 0.6", runtime: false},
       {:benchee, "~> 1.0", only: :dev},
       {:ex_doc, "~> 0.23", only: :dev}

--- a/exla/mix.exs
+++ b/exla/mix.exs
@@ -33,7 +33,7 @@ defmodule EXLA.MixProject do
   defp deps do
     [
       {:nx, path: "../nx"},
-      {:xla, "~> 0.1.0", runtime: false, github: "elixir-nx/xla"},
+      {:xla, "0.1.0", runtime: false, github: "elixir-nx/xla"},
       {:elixir_make, "~> 0.6", runtime: false},
       {:benchee, "~> 1.0", only: :dev},
       {:ex_doc, "~> 0.23", only: :dev}

--- a/exla/mix.lock
+++ b/exla/mix.lock
@@ -7,5 +7,5 @@
   "makeup": {:hex, :makeup, "1.0.5", "d5a830bc42c9800ce07dd97fa94669dfb93d3bf5fcf6ea7a0c67b2e0e4a7f26c", [:mix], [{:nimble_parsec, "~> 0.5 or ~> 1.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "cfa158c02d3f5c0c665d0af11512fed3fba0144cf1aadee0f2ce17747fba2ca9"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.15.1", "b5888c880d17d1cc3e598f05cdb5b5a91b7b17ac4eaf5f297cb697663a1094dd", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.1", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "db68c173234b07ab2a07f645a5acdc117b9f99d69ebf521821d89690ae6c6ec8"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
-  "xla": {:git, "https://github.com/elixir-nx/xla.git", "24eab81f7752830d090c33981d6e63768e93461a", []},
+  "xla": {:hex, :xla, "0.1.0", "c8ca0b6fc8442bcb96196d20e214ba7c90780d88aa33299133f66fd0786938ec", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm", "fec0931516b1f16193546dac60a90930b8b2d700e8c90311a519aa341d324e3a"},
 }


### PR DESCRIPTION
As long as we point `:xla` to GitHub it needs to be a specific version, so that we can build a new XLA release before it gets "public".