### PR TITLE
Implement gather

### DIFF
--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -719,6 +719,27 @@ defmodule EXLA.Defn do
     )
   end
 
+  defp to_operator(:gather, [tensor, indices], _ans, _state) do
+    tensor_rank = tensor |> op_shape() |> tuple_size()
+    indices_rank = indices |> op_shape() |> tuple_size()
+
+    index_vector_dim = indices_rank - 1
+    slice_sizes = List.duplicate(1, tensor_rank)
+    offset_dims = []
+    collapsed_slice_dims = axes_for_rank(tensor_rank)
+    start_index_map = axes_for_rank(tensor_rank)
+
+    EXLA.Op.gather(
+      tensor,
+      indices,
+      index_vector_dim,
+      slice_sizes,
+      offset_dims,
+      collapsed_slice_dims,
+      start_index_map
+    )
+  end
+
   defp to_operator(:reverse, [tensor, axes], _ans, _state) do
     EXLA.Op.reverse(tensor, axes)
   end

--- a/exla/test/exla/defn_expr_test.exs
+++ b/exla/test/exla/defn_expr_test.exs
@@ -2569,7 +2569,7 @@ defmodule EXLA.DefnExprTest do
   end
 
   describe "gather" do
-    defn(gather(t, idx), do: Nx.gather(t, idx))
+    defn gather(t, idx), do: Nx.gather(t, idx)
 
     test "1d result" do
       assert gather(Nx.tensor([[1, 2], [3, 4]]), Nx.tensor([[1, 1], [0, 1], [1, 0]])) ==

--- a/exla/test/exla/defn_expr_test.exs
+++ b/exla/test/exla/defn_expr_test.exs
@@ -2568,6 +2568,26 @@ defmodule EXLA.DefnExprTest do
     end
   end
 
+  describe "gather" do
+    defn(gather(t, idx), do: Nx.gather(t, idx))
+
+    test "1d result" do
+      assert gather(Nx.tensor([[1, 2], [3, 4]]), Nx.tensor([[1, 1], [0, 1], [1, 0]])) ==
+               Nx.tensor([4, 2, 3])
+
+      assert gather(
+               Nx.tensor([[[1, 2], [11, 12]], [[101, 102], [111, 112]]]),
+               Nx.tensor([[0, 0, 0], [0, 1, 1], [1, 1, 1]])
+             ) ==
+               Nx.tensor([1, 12, 112])
+    end
+
+    test "2d indices" do
+      assert gather(Nx.tensor([[1, 2], [3, 4]]), Nx.tensor([[[1, 1], [0, 0]], [[1, 0], [0, 1]]])) ==
+               Nx.tensor([[4, 1], [3, 2]])
+    end
+  end
+
   describe "reverse" do
     defn reverse(t), do: Nx.reverse(t)
     defn reverse1(t), do: Nx.reverse(t, axes: [1])

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -7785,6 +7785,54 @@ defmodule Nx do
   end
 
   @doc """
+  Builds a new tensor by taking individual values from the original
+  tensor at the given indices.
+
+  The last dimension in indices must have the same size as the tensor
+  rank, think of it as one value per axis.
+
+  ## Examples
+
+      iex> Nx.gather(Nx.tensor([[1, 2], [3, 4]]), Nx.tensor([[1, 1], [0, 1], [1, 0]]))
+      #Nx.Tensor<
+        s64[3]
+        [4, 2, 3]
+      >
+
+      iex> Nx.gather(Nx.tensor([[1, 2], [3, 4]]), Nx.tensor([[[1, 1], [0, 0]], [[1, 0], [0, 1]]]))
+      #Nx.Tensor<
+        s64[2][2]
+        [
+          [4, 1],
+          [3, 2]
+        ]
+      >
+
+      iex> Nx.gather(Nx.tensor([[[1, 2], [11, 12]], [[101, 102], [111, 112]]]), Nx.tensor([[0, 0, 0], [0, 1, 1], [1, 1, 1]]))
+      #Nx.Tensor<
+        s64[3]
+        [1, 12, 112]
+      >
+
+  ### Error cases
+
+      iex> Nx.gather(Nx.tensor([[1, 2], [3, 4]]), Nx.tensor([[0, 0]], type: {:f, 32}))
+      ** (ArgumentError) indices must be an integer tensor, got {:f, 32}
+  """
+  def gather(tensor, indices) do
+    tensor = to_tensor(tensor)
+    indices = to_tensor(indices)
+
+    unless Nx.Type.integer?(indices.type) do
+      raise ArgumentError, "indices must be an integer tensor, got #{inspect(indices.type)}"
+    end
+
+    {shape, names} = Nx.Shape.gather(tensor.shape, indices.shape)
+
+    impl!(tensor).gather(%{tensor | shape: shape, names: names}, tensor, indices)
+  end
+
+  @doc """
   Concatenates tensors along the given axis.
 
   If no axis is provided, defaults to 0.

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -150,9 +150,9 @@ defmodule Nx do
   a scalar between 0 and the dimension size. Out of bound dynamic indexes
   are always clamped to the tensor dimensions:
 
-      iex> one = Nx.tensor(1)
+      iex> two = Nx.tensor(2)
       iex> t = Nx.tensor([[1, 2], [3, 4]])
-      iex> t[one][one]
+      iex> t[two][two]
       #Nx.Tensor<
         s64
         4

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -7536,7 +7536,7 @@ defmodule Nx do
   Passing a multi-dimensional indices tensor only affects the
   resulting shape. Specifically, the given axis in the input shape
   gets replaced with the indices shape.
-  
+
   See `gather/2`, `slice/3`, `slice_axis/3`, and `take_along_axis/3`
   for other ways to retrieve values from a tensor.
 

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -147,7 +147,7 @@ defmodule Nx do
       ** (ArgumentError) index -3 is out of bounds for axis 0 in shape {2}
 
   The index can also be another tensor but in such cases it must be
-  a number between 0 and the dimension size. Out of bound dynamic indexes
+  a scalar between 0 and the dimension size. Out of bound dynamic indexes
   are always clamped to the tensor dimensions:
 
       iex> one = Nx.tensor(1)
@@ -200,7 +200,7 @@ defmodule Nx do
   axes with ranges, it is often desired to use a list:
 
       iex> t = Nx.tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]])
-      iex> t[[1..-2//1, 1..2]]
+      iex> t[[1..2, 1..2]]
       #Nx.Tensor<
         s64[2][2]
         [
@@ -212,7 +212,7 @@ defmodule Nx do
   You can mix both ranges and integers in the list too:
 
       iex> t = Nx.tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]])
-      iex> t[[1..-2//1, 2]]
+      iex> t[[1..2, 2]]
       #Nx.Tensor<
         s64[2]
         [6, 9]
@@ -7287,7 +7287,9 @@ defmodule Nx do
   The resulting tensor will have the shape of `length` unless
   `:strides` are given.
 
-  It is not possible to slice in reverse.
+  It is not possible to slice in reverse. See `gather/2`,
+  `slice_axis/3`, `take/3`, and `take_along_axis/3` for other ways
+  to retrieve values from a tensor.
 
   ### Examples
 
@@ -7412,7 +7414,9 @@ defmodule Nx do
 
   If the `:strides` is given, it must be strictly greater than zero.
 
-  It is not possible to slice in reverse.
+  It is not possible to slice in reverse. See `gather/2`, `slice/3`,
+  `take/3`, and `take_along_axis/3` for other ways to retrieve values
+  from a tensor.
 
   ## Examples
 
@@ -7532,6 +7536,9 @@ defmodule Nx do
   Passing a multi-dimensional indices tensor only affects the
   resulting shape. Specifically, the given axis in the input shape
   gets replaced with the indices shape.
+  
+  See `gather/2`, `slice/3`, `slice_axis/3`, and `take_along_axis/3`
+  for other ways to retrieve values from a tensor.
 
   ## Options
 
@@ -7670,12 +7677,11 @@ defmodule Nx do
   Takes the values from a tensor given an `indices` tensor, along the specified axis.
 
   The `indices` shape must be the same as the `tensor`'s shape, with the exception for
-  the `axis` dimension, which can have arbitrary size.
+  the `axis` dimension, which can have arbitrary size. The returned tensor will have the
+  same shape as the `indices` tensor.
 
-  Arbitrary tensors according to the shape rules are accepted. `Nx.argsort/2` also
-  produces suitable indices for this function, as shown in the examples below.
-
-  See also: `Nx.take/3`, `Nx.sort/2`, `Nx.argsort/2`
+  See `gather/2`, `slice/3`, `slice_axis/3`, and `take/3` for other ways to retrieve
+  values from a tensor.
 
   ## Options
 
@@ -7768,6 +7774,7 @@ defmodule Nx do
       iex> Nx.take_along_axis(tensor, idx, axis: 1)
       ** (ArgumentError) indices must be an integer tensor, got {:f, 32}
   """
+  @doc type: :shape
   def take_along_axis(tensor, indices, opts \\ []) when is_list(opts) do
     tensor = to_tensor(tensor)
     indices = to_tensor(indices)
@@ -7819,6 +7826,7 @@ defmodule Nx do
       iex> Nx.gather(Nx.tensor([[1, 2], [3, 4]]), Nx.tensor([[0, 0]], type: {:f, 32}))
       ** (ArgumentError) indices must be an integer tensor, got {:f, 32}
   """
+  @doc type: :shape
   def gather(tensor, indices) do
     tensor = to_tensor(tensor)
     indices = to_tensor(indices)

--- a/nx/lib/nx/backend.ex
+++ b/nx/lib/nx/backend.ex
@@ -67,6 +67,7 @@ defmodule Nx.Backend do
   @callback put_slice(out :: tensor, tensor, tensor, list) :: tensor
   @callback take(out :: tensor, input :: tensor, indices :: tensor, axis) :: tensor
   @callback take_along_axis(out :: tensor, input :: tensor, indices :: tensor, axis) :: tensor
+  @callback gather(out :: tensor, input :: tensor, indices :: tensor) :: tensor
   @callback concatenate(out :: tensor, tensor, axis) :: tensor
   @callback select(out :: tensor, tensor, tensor, tensor) :: tensor
 

--- a/nx/lib/nx/defn/expr.ex
+++ b/nx/lib/nx/defn/expr.ex
@@ -665,6 +665,12 @@ defmodule Nx.Defn.Expr do
   end
 
   @impl true
+  def gather(out, tensor, indices) do
+    {[tensor, indices], context} = to_exprs([tensor, indices])
+    expr(out, context, :gather, [tensor, indices])
+  end
+
+  @impl true
   def reverse(out, tensor, axes) do
     tensor = to_expr(tensor)
     expr(out, tensor.data.context, :reverse, [tensor, axes])

--- a/nx/lib/nx/shape.ex
+++ b/nx/lib/nx/shape.ex
@@ -1260,6 +1260,55 @@ defmodule Nx.Shape do
   end
 
   @doc """
+  Returns the shape after a gather.
+
+  ## Examples
+
+      iex> Nx.Shape.gather({2, 3}, {10, 2})
+      {{10}, [nil]}
+
+      iex> Nx.Shape.gather({2, 3}, {4, 5, 2})
+      {{4, 5}, [nil, nil]}
+
+      iex> Nx.Shape.gather({2}, {4, 5, 1})
+      {{4, 5}, [nil, nil]}
+
+      iex> Nx.Shape.gather({2, 2, 2, 2, 2}, {3, 3, 5})
+      {{3, 3}, [nil, nil]}
+
+      iex> Nx.Shape.gather({2, 2, 2}, {3})
+      {{}, []}
+
+  ### Error cases
+
+      iex> Nx.Shape.gather({2, 3}, {})
+      ** (ArgumentError) expected indices rank to be at least 1, got: 0
+
+      iex> Nx.Shape.gather({2, 3}, {1})
+      ** (ArgumentError) expected the last indices dimension size (1) to match the tensor rank (2)
+  """
+  def gather(shape, indices_shape) do
+    shape = Tuple.to_list(shape)
+    rank = length(shape)
+    indices_shape = Tuple.to_list(indices_shape)
+
+    if indices_shape == [] do
+      raise ArgumentError, "expected indices rank to be at least 1, got: 0"
+    end
+
+    {outer_shape, [last_size]} = Enum.split(indices_shape, -1)
+
+    if last_size != rank do
+      raise ArgumentError,
+            "expected the last indices dimension size (#{last_size}) to match the tensor rank (#{rank})"
+    end
+
+    shape = List.to_tuple(outer_shape)
+    names = List.duplicate(nil, tuple_size(shape))
+    {shape, names}
+  end
+
+  @doc """
   Returns the shape and names after a concat.
 
   ## Examples


### PR DESCRIPTION
Implements "Group 3" outlined in #433. Essentially this allows for building a new tensor from arbitrary individual elements from the original tensor.

As pointed out in #433, *gather* is not exactly an unambiguous term, but seems like the most appropriate name for this operation, especially that this should pair with how scatter works.