### PR TITLE
Include EXLA in the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,41 +1,41 @@
 name: Test
-
 on:
   push:
     branches:
       - main
   pull_request:
 jobs:
-  build_and_test:
+  main:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        elixir: ["1.12.0"]
+        otp: ["24.0"]
+        working_directory: ["nx", "exla"]
     defaults:
       run:
-        working-directory: "nx"
-    strategy:
-      matrix:
-        elixir: ["1.12.0-rc.1"]
-        otp: ["24.0"]
+        working-directory: ${{ matrix.working_directory }}
+    env:
+      MIX_ENV: test
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ matrix.otp }}
           elixir-version: ${{ matrix.elixir }}
-      - name: Retrieve Mix Dependencies Cache
+      - name: Retrieve dependencies cache
         uses: actions/cache@v1
         id: mix-cache # id to use in retrieve action
         with:
           path: deps
           key: ${{ matrix.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
-      - name: Install Mix Dependencies
-        if: steps.mix-cache.outputs.cache-hit != 'true'
-        run: |
-          mix local.rebar --force
-          mix local.hex --force
-          mix deps.get
-      - name: Compile for Tests
-        run: MIX_ENV=test mix compile --warnings-as-errors
-      - name: Run Tests
-        run: mix test
-      - name: Ensure code is Formatted
+      - name: Install dependencies
+        if: ${{ steps.mix-cache.outputs.cache-hit != 'true' }}
+        run: mix deps.get
+      - name: Check warnings
+        run: mix compile --warnings-as-errors
+      - name: Check formatting
         run: mix format --check-formatted
+      - name: Run tests
+        run: mix test

--- a/exla/lib/exla.ex
+++ b/exla/lib/exla.ex
@@ -186,4 +186,7 @@ defmodule EXLA do
 
   @impl true
   defdelegate __jit__(key, vars, fun, opts), to: EXLA.Defn
+
+  @impl true
+  def __stream__(_, _, _, _, _, _), do: raise("not implemented")
 end

--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -685,7 +685,7 @@ defmodule EXLA.Defn do
     indices_shape = op_shape(indices)
     indices_rank = tuple_size(indices_shape)
 
-    axes_range = 0..(indices_rank-1)//1
+    axes_range = 0..(indices_rank - 1)//1
 
     index_vector_dim = indices_rank
     slice_sizes = List.duplicate(1, indices_rank)


### PR DESCRIPTION
Having the precompiled XLA avilable we can run EXLA tests on the CI just fine. However, we need to resolve the failing tests first :) [Here](https://github.com/jonatanklosko/nx/runs/3626433592?check_suite_focus=true) is an example build.