### PR TITLE
Assert index in bounds in take_along_axis

### DIFF
--- a/nx/lib/nx/binary_backend.ex
+++ b/nx/lib/nx/binary_backend.ex
@@ -1849,9 +1849,14 @@ defmodule Nx.BinaryBackend do
         data = for <<match!(x, 0) <- data_bin>>, do: x
 
         for <<match!(x, 1) <- idx_bin>>, into: <<>> do
-          index = read!(x, 1)
+          idx = read!(x, 1)
 
-          val = Enum.at(data, index)
+          if idx < 0 or idx >= elem(tensor.shape, axis) do
+            raise ArgumentError,
+                  "index #{idx} is out of bounds for axis #{axis} in shape #{inspect(tensor.shape)}"
+          end
+
+          val = Enum.at(data, idx)
           <<write!(val, 2)>>
         end
       end


### PR DESCRIPTION
As mentioned in https://github.com/elixir-nx/nx/pull/456#issuecomment-921674991 this adjusts `take_along_axis` to also throw on invalid index.

Also, I extracted the index->offset into its own function, since it's the same for both gather and scatter add :)