### PR TITLE
Fix exla and libtorch for Mac OS

### DIFF
--- a/exla/Makefile
+++ b/exla/Makefile
@@ -18,21 +18,25 @@ CFLAGS = -fPIC -I$(ERTS_INCLUDE_DIR) -isystem $(XLA_INCLUDE_PATH) -O3 -Wall -Wex
 				 -Wno-unused-parameter -Wno-missing-field-initializers -Wno-comment \
 				 -shared -std=c++14
 
-# Use a relative RPATH, so at runtime libexla.so looks for libxla_extension.so
-# in ./lib regardless of the absolute location. This way priv can be safely
-# packed into an Elixir release. Also, we use $$ to escape Makefile variable
-# and single quotes to escape shell variable
-LDFLAGS = -L$(EXLA_LIB_DIR) -Wl,-rpath,'$$ORIGIN/lib' -lxla_extension
+LDFLAGS = -L$(EXLA_LIB_DIR) -lxla_extension
 
 ifeq ($(shell uname -s), Darwin)
-	# LDFLAGS += -undefined dynamic_lookup -dynamiclib
 	LDFLAGS += -flat_namespace -undefined suppress
+	POST_INSTALL = install_name_tool -change bazel-out/darwin-opt/bin/tensorflow/compiler/xla/extension/libxla_extension.so @loader_path/lib/libxla_extension.so $(EXLA_SO)
+else
+	# Use a relative RPATH, so at runtime libexla.so looks for libxla_extension.so
+	# in ./lib regardless of the absolute location. This way priv can be safely
+	# packed into an Elixir release. Also, we use $$ to escape Makefile variable
+	# and single quotes to escape shell variable
+	LDFLAGS += -Wl,-rpath,'$$ORIGIN/lib'
+	POST_INSTALL = $(NOOP)
 endif
 
 $(EXLA_SO): $(XLA_EXTENSION_DIR) $(EXLA_DIR)/exla.cc $(EXLA_DIR)/exla_client.cc $(EXLA_DIR)/exla_client.h $(EXLA_DIR)/exla_nif_util.cc $(EXLA_DIR)/exla_nif_util.h $(EXLA_DIR)/exla_log_sink.h
 	mkdir -p $(PRIV_DIR)
 	ln -sf $(abspath $(XLA_EXTENSION_LIB)) $(EXLA_LIB_DIR)
 	$(CXX) $(CFLAGS) $(EXLA_DIR)/exla.cc $(EXLA_DIR)/exla_nif_util.cc $(EXLA_DIR)/exla_client.cc -o $(EXLA_SO) $(LDFLAGS)
+	$(POST_INSTALL)
 
 clean:
 	rm -rf $(EXLA_SO)

--- a/exla/Makefile
+++ b/exla/Makefile
@@ -1,5 +1,6 @@
 # Environment variables passed via elixir_make
 # ERTS_INCLUDE_DIR
+# MIX_APP_PATH
 
 # XLA Extension Installation Location
 XLA_EXTENSION_DIR ?= cache/xla_extension
@@ -8,7 +9,7 @@ XLA_INCLUDE_PATH = $(XLA_EXTENSION_DIR)/include
 
 # Private configuration
 EXLA_DIR = c_src/exla
-PRIV_DIR = priv
+PRIV_DIR = $(MIX_APP_PATH)/priv
 EXLA_SO = $(PRIV_DIR)/libexla.so
 EXLA_LIB_DIR = $(PRIV_DIR)/lib
 
@@ -25,7 +26,7 @@ LDFLAGS = -L$(EXLA_LIB_DIR) -Wl,-rpath,'$$ORIGIN/lib' -lxla_extension
 
 ifeq ($(shell uname -s), Darwin)
 	# LDFLAGS += -undefined dynamic_lookup -dynamiclib
-	# LDFLAGS += -flat_namespace -undefined suppress
+	LDFLAGS += -flat_namespace -undefined suppress
 endif
 
 $(EXLA_SO): $(XLA_EXTENSION_DIR) $(EXLA_DIR)/exla.cc $(EXLA_DIR)/exla_client.cc $(EXLA_DIR)/exla_client.h $(EXLA_DIR)/exla_nif_util.cc $(EXLA_DIR)/exla_nif_util.h $(EXLA_DIR)/exla_log_sink.h

--- a/exla/Makefile
+++ b/exla/Makefile
@@ -3,7 +3,6 @@
 
 # XLA Extension Installation Location
 XLA_EXTENSION_DIR ?= cache/xla_extension
-
 XLA_EXTENSION_LIB = $(XLA_EXTENSION_DIR)/lib
 XLA_INCLUDE_PATH = $(XLA_EXTENSION_DIR)/include
 
@@ -24,13 +23,15 @@ CFLAGS = -fPIC -I$(ERTS_INCLUDE_DIR) -isystem $(XLA_INCLUDE_PATH) -O3 -Wall -Wex
 # and single quotes to escape shell variable
 LDFLAGS = -L$(EXLA_LIB_DIR) -Wl,-rpath,'$$ORIGIN/lib' -lxla_extension
 
+ifeq ($(shell uname -s), Darwin)
+	# LDFLAGS += -undefined dynamic_lookup -dynamiclib
+	# LDFLAGS += -flat_namespace -undefined suppress
+endif
+
 $(EXLA_SO): $(XLA_EXTENSION_DIR) $(EXLA_DIR)/exla.cc $(EXLA_DIR)/exla_client.cc $(EXLA_DIR)/exla_client.h $(EXLA_DIR)/exla_nif_util.cc $(EXLA_DIR)/exla_nif_util.h $(EXLA_DIR)/exla_log_sink.h
-	mkdir -p $(PRIV_DIR) && \
-		ln -sf $(abspath $(XLA_EXTENSION_LIB)) $(EXLA_LIB_DIR) && \
-		$(CXX) $(CFLAGS) $(EXLA_DIR)/exla.cc $(EXLA_DIR)/exla_nif_util.h \
-											$(EXLA_DIR)/exla_nif_util.cc $(EXLA_DIR)/exla_client.h \
-											$(EXLA_DIR)/exla_client.cc $(EXLA_DIR)/exla_log_sink.h \
-											-o $(EXLA_SO) $(LDFLAGS)
+	mkdir -p $(PRIV_DIR)
+	ln -sf $(abspath $(XLA_EXTENSION_LIB)) $(EXLA_LIB_DIR)
+	$(CXX) $(CFLAGS) $(EXLA_DIR)/exla.cc $(EXLA_DIR)/exla_nif_util.cc $(EXLA_DIR)/exla_client.cc -o $(EXLA_SO) $(LDFLAGS)
 
 clean:
 	rm -rf $(EXLA_SO)

--- a/torchx/Makefile
+++ b/torchx/Makefile
@@ -1,5 +1,5 @@
 LIBTORCH_VERSION := $(shell head -c 3 $(LIBTORCH_DIR)/build-version)
-MINIMUM_LIBTORCH_VERSION := 1.8
+EXPECTED_LIBTORCH_VERSION := 1.8
 
 LIBTORCH_INCLUDE_PATH = $(LIBTORCH_DIR)/include/
 LIBTORCH_API_INCLUDE_PATH = $(LIBTORCH_DIR)/include/torch/csrc/api/include
@@ -26,8 +26,8 @@ check_version:
 		exit 1; \
 	fi
 
-	@ if [ $(LIBTORCH_VERSION) >= $(MINIMUM_LIBTORCH_VERSION) ]; then \
-		echo "LibTorch version should be at least $(MINIMUM_LIBTORCH_VERSION). Got: $(LIBTORCH_VERSION)."; \
+	@ if [ $(LIBTORCH_VERSION) != $(EXPECTED_LIBTORCH_VERSION) ]; then \
+		echo "LibTorch version should be $(EXPECTED_LIBTORCH_VERSION). Got: $(LIBTORCH_VERSION)."; \
 		echo "You can download LibTorch here: https://pytorch.org/get-started/locally/"; \
 		exit 1; \
 	fi


### PR DESCRIPTION
Currently, EXLA does not link on Mac OS. It cannot find the NIF symbols. There are [two known answers to this](https://stackoverflow.com/questions/8288358/erlang-nif-test-os-x-lion) which I tried. But both fail next with the following reason:

```
10:20:23.468 [warn]   The on_load function for module Elixir.EXLA.NIF returned:
{:error,
 {:load_failed,
  'Failed to load NIF library: \'dlopen(/Users/jose/OSS/nx/exla/_build/test/lib/exla/priv/libexla.so, 2): Library not loaded: bazel-out/darwin-opt/bin/tensorflow/compiler/xla/extension/libxla_extension.so\n  Referenced from: /Users/jose/OSS/nx/exla/priv/libexla.so\n  Reason: image not found\''}}
```

I am wondering, instead of linking to libxla_extension.so, could we instead build a fat binary with libxla_extension and simplify stuff like rpath handling and so on?