### PR TITLE
Ignore expected error log in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        working_directory: ["nx", "exla"]
         elixir: ["1.12.0"]
         otp: ["24.0"]
-        working_directory: ["nx", "exla"]
     defaults:
       run:
         working-directory: ${{ matrix.working_directory }}

--- a/exla/test/exla/defn_api_test.exs
+++ b/exla/test/exla/defn_api_test.exs
@@ -7,6 +7,8 @@ defmodule EXLA.DefnAPITest do
     @defn_compiler {EXLA, run_options: [keep_on_device: true]}
     defn add_two_keep_on_device(a, b), do: a + b
 
+    # Ignored logged errors, since they are expected
+    @tag capture_log: true
     test "keeps data on device" do
       tensor = add_two_keep_on_device(1, 2)
       assert %EXLA.DeviceBackend{state: {ref, :default}} = tensor.data


### PR DESCRIPTION
See https://github.com/elixir-nx/nx/runs/3654704783#step:8:16, the error gets logged out, but the test already catches that error.