### PR TITLE
Add note on CUDA stack size and lower default memory allocation

### DIFF
--- a/exla/README.md
+++ b/exla/README.md
@@ -103,12 +103,14 @@ docker run -it \
 
 With CUDA enabled:
 
+*Note: XLA_TARGET should match your CUDA version. See: https://github.com/elixir-nx/xla#xla_target*
+ 
 ```shell
 docker run -it \
   -v $PWD:$PWD \
   -e TEST_TMPDIR=$PWD/tmp/bazel_cache \
   -e BUILD_CACHE=$PWD/tmp/xla_extension_cache \
-  -e XLA_TARGET=cuda \
+  -e XLA_TARGET=cuda102 \
   -e EXLA_TARGET=cuda \
   -w $PWD \
   --gpus=all \

--- a/exla/config/runtime.exs
+++ b/exla/config/runtime.exs
@@ -2,7 +2,7 @@ import Config
 
 target = System.get_env("EXLA_TARGET", "host")
 
-config :exla, :clients, default: [platform: String.to_atom(target)]
+config :exla, :clients, default: [platform: String.to_atom(target), memory_fraction: 0.8]
 
 config :logger, :console,
   format: "\n$time [$level] $metadata $levelpad$message\n",

--- a/exla/lib/exla.ex
+++ b/exla/lib/exla.ex
@@ -92,17 +92,15 @@ defmodule EXLA do
 
   ### GPU Runtime Issues
 
-  Some versions of CUDA and cuDNN may interact poorly with the Erlang
-  VM leading to strange Segmentation Faults. GPU Executions run in dirty
-  IO threads, which have a considerable smaller stack size than regular
-  scheduler threads. This may lead to problems with certain CUDA or cuDNN
-  programs. In a development environment, it is suggested to set:
+  GPU Executions run in dirty IO threads, which have a considerable smaller
+  stack size than regular scheduler threads. This may lead to problems with
+  certain CUDA or cuDNN versions, leading to segmentation fails. In a development
+  environment, it is suggested to set:
 
-  `ELIXIR_ERL_OPTIONS=+sssdio 128`
+      ELIXIR_ERL_OPTIONS="+sssdio 128"
 
   To increase the stack size of dirty IO threads from 40 kilowords to
-  128 kilowords in order to avoid poor interactions between CUDA, cuDNN,
-  and the dirty IO scheduler. In a release, you can set this flag in `vm.args`.
+  128 kilowords. In a release, you can set this flag in your `vm.args`.
 
   ## Device allocation
 

--- a/exla/lib/exla.ex
+++ b/exla/lib/exla.ex
@@ -90,6 +90,20 @@ defmodule EXLA do
     * `:memory_fraction` - how much memory of a GPU device to
       allocate. Defaults to `0.9.`
 
+  ### GPU Runtime Issues
+
+  Some versions of CUDA and cuDNN may interact poorly with the Erlang
+  VM leading to strange Segmentation Faults. GPU Executions run in dirty
+  IO threads, which have a considerable smaller stack size than regular
+  scheduler threads. This may lead to problems with certain CUDA or cuDNN
+  programs. In a development environment, it is suggested to set:
+
+  `ELIXIR_ERL_OPTIONS=+sssdio 128`
+
+  To increase the stack size of dirty IO threads from 40 kilowords to
+  128 kilowords in order to avoid poor interactions between CUDA, cuDNN,
+  and the dirty IO scheduler. In a release, you can set this flag in `vm.args`.
+
   ## Device allocation
 
   EXLA also ships with a `EXLA.DeviceBackend` that allows data


### PR DESCRIPTION
Closes #197 

Also sets a lower `:memory_allocation` in runtime configuration so all tests can pass. The old default may cause issues with certain GPUs and CUDA versions which leads to CUDA OOM. The recommended default of 0.9 is still what JAX uses, but 0.8 is what I needed to set to get my GPU to pass all of our tests.