### PR TITLE
fix: handle tall/wide b matrix on tri solve

### DIFF
--- a/nx/lib/nx/binary_backend.ex
+++ b/nx/lib/nx/binary_backend.ex
@@ -1200,14 +1200,14 @@ defmodule Nx.BinaryBackend do
   @impl true
   def triangular_solve(
         %{type: output_type} = out,
-        %{type: a_type, shape: {rows, rows}} = a,
+        %{type: a_type, shape: {rows, rows} = a_shape} = a,
         %{type: b_type, shape: b_shape} = b,
         opts
       )
-      when b_shape == {rows, rows} or b_shape == {rows} do
+      when tuple_size(b_shape) == 2 or b_shape == {rows} do
     a_data = to_binary(a)
     b_data = to_binary(b)
-    out_bin = B.Matrix.ts(a_data, a_type, b_data, b_type, b_shape, output_type, opts)
+    out_bin = B.Matrix.ts(a_data, a_type, a_shape, b_data, b_type, b_shape, output_type, opts)
     from_binary(out, out_bin)
   end
 

--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -358,6 +358,29 @@ defmodule Nx.LinAlg do
         [1.0, 1.0, -1.0]
       >
 
+      iex> a = Nx.tensor([[1, 0, 0], [1, 1, 0], [1, 2, 1]])
+      iex> b = Nx.tensor([[0, 1, 3], [2, 1, 3]])
+      iex> Nx.LinAlg.triangular_solve(a, b, left_side: false)
+      #Nx.Tensor<
+        f32[2][3]
+        [
+          [2.0, -5.0, 3.0],
+          [4.0, -5.0, 3.0]
+        ]
+      >
+
+      iex> a = Nx.tensor([[1, 0, 0], [1, 1, 0], [1, 2, 1]])
+      iex> b = Nx.tensor([[0, 2], [3, 0], [0, 0]])
+      iex> Nx.LinAlg.triangular_solve(a, b, left_side: true)
+      #Nx.Tensor<
+        f32[3][2]
+        [
+          [0.0, 2.0],
+          [3.0, -2.0],
+          [-6.0, 2.0]
+        ]
+      >
+
   ### Error cases
 
       iex> Nx.LinAlg.triangular_solve(Nx.tensor([[3, 0, 0, 0], [2, 1, 0, 0]]), Nx.tensor([4, 2, 4, 2]))
@@ -405,8 +428,13 @@ defmodule Nx.LinAlg do
         raise ArgumentError, "expected a square matrix, got matrix with shape: #{inspect(other)}"
     end
 
+    left_side = opts[:left_side]
+
     case b_shape do
-      {^m, ^m} ->
+      {^m, _} when left_side ->
+        nil
+
+      {_, ^m} when not left_side ->
         nil
 
       {^m} ->


### PR DESCRIPTION
This is an attempt to fix the `Nx.LinAlg.triangular_solve` BinaryBackend implementation, as reported on #473

closes #473