### PR TITLE
test: add tests for rounding error doctests

### DIFF
--- a/torchx/mix.exs
+++ b/torchx/mix.exs
@@ -12,7 +12,8 @@ defmodule Torchx.MixProject do
       elixir: "~> 1.12-dev",
       deps: deps(),
       docs: docs(),
-      compilers: [:elixir_make] ++ Mix.compilers()
+      compilers: [:elixir_make] ++ Mix.compilers(),
+      elixirc_paths: elixirc_paths(Mix.env())
     ]
   end
 
@@ -22,6 +23,9 @@ defmodule Torchx.MixProject do
       extra_applications: [:logger]
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   # Run "mix help deps" to learn about dependencies.
   defp deps do

--- a/torchx/test/support/torchx_case.ex
+++ b/torchx/test/support/torchx_case.ex
@@ -1,0 +1,20 @@
+defmodule Torchx.Case do
+  @moduledoc """
+  Test case for tensor assertions
+  """
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      import Torchx.Case
+    end
+  end
+
+  defmacro assert_tensor({:==, _, [left, right]}) do
+    quote do
+      assert Nx.backend_transfer(unquote(left), Nx.BinaryBackend) ==
+               Nx.backend_transfer(unquote(right), Nx.BinaryBackend)
+    end
+  end
+end

--- a/torchx/test/support/torchx_case.ex
+++ b/torchx/test/support/torchx_case.ex
@@ -11,10 +11,13 @@ defmodule Torchx.Case do
     end
   end
 
-  defmacro assert_tensor({:==, _, [left, right]}) do
-    quote do
-      assert Nx.backend_transfer(unquote(left), Nx.BinaryBackend) ==
-               Nx.backend_transfer(unquote(right), Nx.BinaryBackend)
-    end
+  def assert_all_close(left, right, opts \\ []) do
+    atol = opts[:atol] || 1.0e-4
+    rtol = opts[:rtol] || 1.0e-4
+
+    assert left
+           |> Nx.all_close?(right, atol: atol, rtol: rtol)
+           |> Nx.backend_transfer(Nx.BinaryBackend) ==
+             Nx.tensor(1, type: {:u, 8}, backend: Nx.BinaryBackend)
   end
 end

--- a/torchx/test/test_helper.exs
+++ b/torchx/test/test_helper.exs
@@ -1,4 +1,1 @@
-defmodule Torchx.TestHelper do
-end
-
 ExUnit.start()

--- a/torchx/test/torchx/backend_test.exs
+++ b/torchx/test/torchx/backend_test.exs
@@ -1,11 +1,12 @@
 defmodule Torchx.BackendTest do
-  use ExUnit.Case, async: true
+  use Torchx.Case, async: true
 
   alias Torchx.Backend, as: TB
 
   doctest TB
 
   # Torch Tensor creation shortcut
+  defp tt(data), do: Nx.tensor(data, backend: TB)
   defp tt(data, type), do: Nx.tensor(data, type: type, backend: TB)
 
   @types [{:s, 8}, {:u, 8}, {:s, 16}, {:s, 32}, {:s, 64}, {:bf, 16}, {:f, 32}, {:f, 64}]
@@ -204,6 +205,59 @@ defmodule Torchx.BackendTest do
       |> Nx.backend_transfer()
       |> Nx.to_flat_list()
       |> Enum.all?(&(&1 > 7.0 - 3.0 and &1 < 7.0 + 3.0))
+    end
+  end
+
+  describe "rounding error tests" do
+    test "atanh/1" do
+      assert_all_close(tt(0.5493), Nx.atanh(tt(0.5)))
+    end
+
+    test "ceil/1" do
+      assert_all_close(tt(-0.0), Nx.ceil(tt(-0.5)))
+      assert_all_close(tt(1.0), Nx.ceil(tt(0.5)))
+    end
+
+    test "cos/1" do
+      assert_all_close(
+        tt([-1.0, 0.4999, -1.0]),
+        Nx.cos(tt([-:math.pi(), :math.pi() / 3, :math.pi()]))
+      )
+    end
+
+    test "cosh/1" do
+      assert_all_close(
+        tt([11.5919, 1.6002, 11.5919]),
+        Nx.cosh(tt([-:math.pi(), :math.pi() / 3, :math.pi()]))
+      )
+    end
+
+    test "erfc/1" do
+      assert_all_close(
+        tt([1.0, 0.4795, 0.0]),
+        Nx.erfc(tt([0, 0.5, 10_000]))
+      )
+    end
+
+    test "erf_inv/1" do
+      assert_all_close(
+        tt([0.0, 0.4769, 0.8134]),
+        Nx.erf_inv(tt([0, 0.5, 0.75]))
+      )
+    end
+
+    test "round/1" do
+      assert_all_close(
+        tt([-2.0, -0.0, 0.0, 2.0]),
+        Nx.round(tt([-1.5, -0.5, 0.5, 1.5]))
+      )
+    end
+
+    test "logistic/1" do
+      assert_all_close(
+        tt([0.1824, 0.6224]),
+        Nx.logistic(tt([-1.5, 0.5]))
+      )
     end
   end
 end

--- a/torchx/test/torchx/nx_doctest_test.exs
+++ b/torchx/test/torchx/nx_doctest_test.exs
@@ -8,7 +8,7 @@ defmodule Torchx.NxDoctestTest do
 
   # TODO: Add backend tests for the doctests that are excluded
 
-  use ExUnit.Case, async: true
+  use Torchx.Case, async: true
 
   setup do
     Nx.default_backend(Torchx.Backend)
@@ -44,33 +44,28 @@ defmodule Torchx.NxDoctestTest do
     window_mean: 3
   ]
 
-  @inherently_unsupported_doctests [
-    # atanh - rounding error
+  @rounding_error_doctests [
     atanh: 1,
+    ceil: 1,
+    cos: 1,
+    cosh: 1,
+    erfc: 1,
+    erf_inv: 1,
+    round: 1,
+    logistic: 1
+  ]
+
+  @inherently_unsupported_doctests [
     # atan2 - depends on to_binary
     atan2: 2,
     # bitcast - no API available
     bitcast: 2,
-    # ceil - sign error -0.0 vs 0.0
-    ceil: 1,
-    # cos - rounding error
-    cos: 1,
-    # cosh - rounding error
-    cosh: 1,
     # default_backend - specific to BinaryBackend
     default_backend: 1,
-    # erfc - rounding error (on some archs)
-    erfc: 1,
-    # erf_inv - rounding error (on some archs)
-    erf_inv: 1,
-    # round - rounds to different direction
-    round: 1,
     # to_binary - not supported, must call backend_transfer before
     to_binary: 2,
     # to_flat_list - depends on to_binary
     to_flat_list: 2,
-    # logistic - rounding error
-    logistic: 1,
     # random_uniform - depends on to_binary
     random_uniform: 4
   ]
@@ -80,6 +75,57 @@ defmodule Torchx.NxDoctestTest do
       Torchx.Backend.__unimplemented__()
       |> Enum.map(fn {fun, arity} -> {fun, arity - 1} end)
       |> Kernel.++(@temporarily_broken_doctests)
+      |> Kernel.++(@rounding_error_doctests)
       |> Kernel.++(@inherently_unsupported_doctests)
       |> Kernel.++([:moduledoc])
+
+  describe "rounding error tests" do
+    test "atanh/1" do
+      assert_tensor(Nx.tensor(0.5493061542510986) == Nx.atanh(Nx.tensor(0.5)))
+    end
+
+    test "ceil/1" do
+      assert_tensor(Nx.tensor(-0.0) == Nx.ceil(Nx.tensor(-0.5)))
+      assert_tensor(Nx.tensor(1.0) == Nx.ceil(Nx.tensor(0.5)))
+    end
+
+    test "cos/1" do
+      assert_tensor(
+        Nx.tensor([-1.0, 0.4999999701976776, -1.0]) ==
+          Nx.cos(Nx.tensor([-:math.pi(), :math.pi() / 3, :math.pi()]))
+      )
+    end
+
+    test "cosh/1" do
+      assert_tensor(
+        Nx.tensor([11.591955184936523, 1.600286841392517, 11.591955184936523]) ==
+          Nx.cosh(Nx.tensor([-:math.pi(), :math.pi() / 3, :math.pi()]))
+      )
+    end
+
+    test "erfc/1" do
+      assert_tensor(
+        Nx.tensor([1.0, 0.4795001149177551, 0.0]) == Nx.erfc(Nx.tensor([0, 0.5, 10_000]))
+      )
+    end
+
+    test "erf_inv/1" do
+      assert_tensor(
+        Nx.tensor([0.0, 0.4769362807273865, 0.8134198188781738]) ==
+          Nx.erf_inv(Nx.tensor([0, 0.5, 0.75]))
+      )
+    end
+
+    test "round/1" do
+      assert_tensor(
+        Nx.tensor([-2.0, -0.0, 0.0, 2.0]) == Nx.round(Nx.tensor([-1.5, -0.5, 0.5, 1.5]))
+      )
+    end
+
+    test "logistic/1" do
+      assert_tensor(
+        Nx.tensor([0.18242552876472473, 0.622459352016449]) == Nx.logistic(Nx.tensor([-1.5, 0.5]))
+      )
+    end
+  end
 end

--- a/torchx/test/torchx/nx_doctest_test.exs
+++ b/torchx/test/torchx/nx_doctest_test.exs
@@ -8,7 +8,7 @@ defmodule Torchx.NxDoctestTest do
 
   # TODO: Add backend tests for the doctests that are excluded
 
-  use Torchx.Case, async: true
+  use ExUnit.Case, async: true
 
   setup do
     Nx.default_backend(Torchx.Backend)
@@ -76,54 +76,4 @@ defmodule Torchx.NxDoctestTest do
       |> Kernel.++(@rounding_error_doctests)
       |> Kernel.++(@inherently_unsupported_doctests)
       |> Kernel.++([:moduledoc])
-
-  describe "rounding error tests" do
-    test "atanh/1" do
-      assert_tensor(Nx.tensor(0.5493061542510986) == Nx.atanh(Nx.tensor(0.5)))
-    end
-
-    test "ceil/1" do
-      assert_tensor(Nx.tensor(-0.0) == Nx.ceil(Nx.tensor(-0.5)))
-      assert_tensor(Nx.tensor(1.0) == Nx.ceil(Nx.tensor(0.5)))
-    end
-
-    test "cos/1" do
-      assert_tensor(
-        Nx.tensor([-1.0, 0.4999999701976776, -1.0]) ==
-          Nx.cos(Nx.tensor([-:math.pi(), :math.pi() / 3, :math.pi()]))
-      )
-    end
-
-    test "cosh/1" do
-      assert_tensor(
-        Nx.tensor([11.591955184936523, 1.600286841392517, 11.591955184936523]) ==
-          Nx.cosh(Nx.tensor([-:math.pi(), :math.pi() / 3, :math.pi()]))
-      )
-    end
-
-    test "erfc/1" do
-      assert_tensor(
-        Nx.tensor([1.0, 0.4795001149177551, 0.0]) == Nx.erfc(Nx.tensor([0, 0.5, 10_000]))
-      )
-    end
-
-    test "erf_inv/1" do
-      assert_tensor(
-        Nx.tensor([0.0, 0.4769362807273865, 0.8134198188781738]) ==
-          Nx.erf_inv(Nx.tensor([0, 0.5, 0.75]))
-      )
-    end
-
-    test "round/1" do
-      assert_tensor(
-        Nx.tensor([-2.0, -0.0, 0.0, 2.0]) == Nx.round(Nx.tensor([-1.5, -0.5, 0.5, 1.5]))
-      )
-    end
-
-    test "logistic/1" do
-      assert_tensor(
-        Nx.tensor([0.18242552876472473, 0.622459352016449]) == Nx.logistic(Nx.tensor([-1.5, 0.5]))
-      )
-    end
-  end
 end


### PR DESCRIPTION
Adds specific tests for some of the functions which don't have exactly the same output as on Nx.BinaryBackend (float rounding errors, different rounding strategies, etc)