### PR TITLE
feat: add bitcast Torchx implementation

### DIFF
--- a/torchx/lib/torchx/backend.ex
+++ b/torchx/lib/torchx/backend.ex
@@ -175,19 +175,8 @@ defmodule Torchx.Backend do
     do: Torchx.to_type(from_nx(t), to_torch_type(type)) |> to_nx(out)
 
   @impl true
-  def bitcast(%T{} = out, %T{} = t) do
-    case {out.type, t.type} do
-      {{_, s}, {_, s}} ->
-        :ok
-
-      {out_type, in_type} ->
-        raise ArgumentError,
-              "input type width must match new type width," <>
-                " got input type #{inspect(in_type)} and" <>
-                " output type #{inspect(out_type)}"
-    end
-
-    as_type(out, t)
+  def bitcast(_, _) do
+    raise ArgumentError, "bitcast cannot be called from Torchx. Use the BinaryBackend instead"
   end
 
   @impl true

--- a/torchx/lib/torchx/backend.ex
+++ b/torchx/lib/torchx/backend.ex
@@ -176,8 +176,6 @@ defmodule Torchx.Backend do
 
   @impl true
   def bitcast(%T{} = out, %T{} = t) do
-    out_type = to_torch_type(out.type)
-
     case {out.type, t.type} do
       {{_, s}, {_, s}} -> :ok
       {out_type, in_type} ->
@@ -187,10 +185,7 @@ defmodule Torchx.Backend do
               " output type #{inspect(out_type)}"
     end
 
-    t
-    |> from_nx()
-    |> Torchx.to_type(out_type)
-    |> to_nx(out)
+    as_type(out, t)
   end
 
   @impl true

--- a/torchx/lib/torchx/backend.ex
+++ b/torchx/lib/torchx/backend.ex
@@ -177,12 +177,14 @@ defmodule Torchx.Backend do
   @impl true
   def bitcast(%T{} = out, %T{} = t) do
     case {out.type, t.type} do
-      {{_, s}, {_, s}} -> :ok
+      {{_, s}, {_, s}} ->
+        :ok
+
       {out_type, in_type} ->
         raise ArgumentError,
-            "input type width must match new type width," <>
-              " got input type #{inspect(in_type)} and" <>
-              " output type #{inspect(out_type)}"
+              "input type width must match new type width," <>
+                " got input type #{inspect(in_type)} and" <>
+                " output type #{inspect(out_type)}"
     end
 
     as_type(out, t)

--- a/torchx/lib/torchx/backend.ex
+++ b/torchx/lib/torchx/backend.ex
@@ -175,6 +175,25 @@ defmodule Torchx.Backend do
     do: Torchx.to_type(from_nx(t), to_torch_type(type)) |> to_nx(out)
 
   @impl true
+  def bitcast(%T{} = out, %T{} = t) do
+    out_type = to_torch_type(out.type)
+
+    case {out.type, t.type} do
+      {{_, s}, {_, s}} -> :ok
+      {out_type, in_type} ->
+        raise ArgumentError,
+            "input type width must match new type width," <>
+              " got input type #{inspect(in_type)} and" <>
+              " output type #{inspect(out_type)}"
+    end
+
+    t
+    |> from_nx()
+    |> Torchx.to_type(out_type)
+    |> to_nx(out)
+  end
+
+  @impl true
   def squeeze(out, %T{} = t, _axes) do
     Torchx.squeeze(from_nx(t)) |> to_nx(out)
   end

--- a/torchx/lib/torchx/backend.ex
+++ b/torchx/lib/torchx/backend.ex
@@ -523,7 +523,7 @@ defmodule Torchx.Backend do
 
   ## Functionality we can't provide
 
-  not_possible = [bitcast: 2, map: 4, reduce: 5, reduce_window: 6]
+  not_possible = [map: 4, reduce: 5, reduce_window: 6]
 
   for {fun, arity} <- not_possible do
     args = Macro.generate_arguments(arity, __MODULE__)

--- a/torchx/test/torchx/backend_test.exs
+++ b/torchx/test/torchx/backend_test.exs
@@ -105,6 +105,17 @@ defmodule Torchx.BackendTest do
     end
   end
 
+  describe "bitcast" do
+    test "raises" do
+      assert_raise ArgumentError,
+                   "bitcast cannot be called from Torchx. Use the BinaryBackend instead",
+                   fn ->
+                     t = Nx.tensor([[[1]]])
+                     Torchx.Backend.bitcast(t, t)
+                   end
+    end
+  end
+
   # Division and power with bfloat16 are special cases in PyTorch,
   # because it upcasts bfloat16 args to float for numerical accuracy purposes.
   # So, e.g., the result of division is different from what direct bf16 by bf16 division gives us.

--- a/torchx/test/torchx/nx_doctest_test.exs
+++ b/torchx/test/torchx/nx_doctest_test.exs
@@ -54,8 +54,6 @@ defmodule Torchx.NxDoctestTest do
   ]
 
   @inherently_unsupported_doctests [
-    # bitcast - no API available
-    bitcast: 2,
     # default_backend - specific to BinaryBackend
     default_backend: 1
   ]

--- a/torchx/test/torchx/nx_doctest_test.exs
+++ b/torchx/test/torchx/nx_doctest_test.exs
@@ -54,6 +54,8 @@ defmodule Torchx.NxDoctestTest do
   ]
 
   @inherently_unsupported_doctests [
+    # bitcast - cannot be implemented in libtorch
+    bitcast: 2,
     # default_backend - specific to BinaryBackend
     default_backend: 1
   ]


### PR DESCRIPTION
Altough this isn't necessarily a "no-read" conversion, this makes for a more complete API implementation for `Nx.Backend` on Torchx