### PR TITLE
Add sigil for tensors

### DIFF
--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -8483,7 +8483,17 @@ defmodule Nx do
       for row <- String.split(string, "\n", trim: true) do
         row
         |> String.split(" ", trim: true)
-        |> Enum.map(&elem(Code.eval_string(&1), 0))
+        |> Enum.map(fn str ->
+          module = if String.contains?(str, "."), do: Float, else: Integer
+
+          case module.parse(str) do
+            {number, ""} ->
+              number
+
+            _ ->
+              raise ArgumentError, "expected a numerical value for tensor, got #{str}"
+          end
+        end)
       end
     end
   end

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -8534,10 +8534,13 @@ defmodule Nx do
 
   """
   defmacro sigil_V({:<<>>, _meta, [string]}, modifiers) do
-    string
-    |> binary_to_numbers
-    |> hd()
-    |> numbers_to_tensor(modifiers)
+    case binary_to_numbers(string) do
+      [numbers] ->
+        numbers_to_tensor(numbers, modifiers)
+
+      _ ->
+        raise ArgumentError, "must be one-dimensional"
+    end
   end
 
   defp numbers_to_tensor(numbers, modifiers) do

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -8454,18 +8454,18 @@ defmodule Nx do
   ## Sigils
 
   @doc """
-  Provides `~M` sigil to build a tensor.
-
-  > Note: `~M` requires Elixir >= `1.13.0` in order to suppport type specifiers like `u8`
+  A convenient `~M` sigil for building matrices.
 
   ## Examples
 
       import Nx
 
-      ~M[-1 0 0 1
-          0 2 0 0
-          0 0 3 0
-          0 0 0 4]
+      ~M<
+        -1 0 0 1
+        0 2 0 0
+        0 0 3 0
+        0 0 0 4
+      >
 
   Is equivalent to:
 
@@ -8476,7 +8476,9 @@ defmodule Nx do
         [0, 0, 0, 4]
       ])
 
-  You can specify the tensor type:
+  If the tensor has any float type, it defaults to f32.
+  Otherwise, it is s64. If you are using Elixir 1.13+,
+  you can specify the tensor type as a sigil modifier:
 
       iex> import Nx
       iex> ~M[0.1 0.2 0.3 0.4]f16

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -8453,48 +8453,46 @@ defmodule Nx do
 
   ## Sigils
 
-  if Version.match?(System.version(), ">= 1.13.0-dev") do
-    defmacro sigil_M({:<<>>, _meta, [string]}, modifiers) do
-      numbers =
-        case binary_to_numbers(string) do
-          [vector] -> vector
-          matrix -> matrix
-        end
-
-      type =
-        case modifiers do
-          [unit | size] ->
-            Nx.Type.normalize!({List.to_atom([unit]), List.to_integer(size)})
-
-          [] ->
-            Nx.Type.infer(numbers)
-        end
-
-      {shape, binary} = flatten(numbers, type)
-
-      quote do
-        unquote(binary)
-        |> Nx.from_binary(unquote(type))
-        |> Nx.reshape(unquote(Macro.escape(shape)))
+  defmacro sigil_M({:<<>>, _meta, [string]}, modifiers) do
+    numbers =
+      case binary_to_numbers(string) do
+        [vector] -> vector
+        matrix -> matrix
       end
+
+    type =
+      case modifiers do
+        [unit | size] ->
+          Nx.Type.normalize!({List.to_atom([unit]), List.to_integer(size)})
+
+        [] ->
+          Nx.Type.infer(numbers)
+      end
+
+    {shape, binary} = flatten(numbers, type)
+
+    quote do
+      unquote(binary)
+      |> Nx.from_binary(unquote(type))
+      |> Nx.reshape(unquote(Macro.escape(shape)))
     end
+  end
 
-    defp binary_to_numbers(string) do
-      for row <- String.split(string, "\n", trim: true) do
-        row
-        |> String.split(" ", trim: true)
-        |> Enum.map(fn str ->
-          module = if String.contains?(str, "."), do: Float, else: Integer
+  defp binary_to_numbers(string) do
+    for row <- String.split(string, "\n", trim: true) do
+      row
+      |> String.split(" ", trim: true)
+      |> Enum.map(fn str ->
+        module = if String.contains?(str, "."), do: Float, else: Integer
 
-          case module.parse(str) do
-            {number, ""} ->
-              number
+        case module.parse(str) do
+          {number, ""} ->
+            number
 
-            _ ->
-              raise ArgumentError, "expected a numerical value for tensor, got #{str}"
-          end
-        end)
-      end
+          _ ->
+            raise ArgumentError, "expected a numerical value for tensor, got #{str}"
+        end
+      end)
     end
   end
 

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -8453,6 +8453,39 @@ defmodule Nx do
 
   ## Sigils
 
+  @doc """
+  Provides `~M` sigil to build a tensor.
+
+  > Note: `~M` requires Elixir >= `1.13.0` in order to suppport type specifiers like `u8`
+
+  ## Examples
+
+      import Nx
+
+      ~M[-1 0 0 1
+          0 2 0 0
+          0 0 3 0
+          0 0 0 4]
+
+  Is equivalent to:
+
+      Nx.tensor([
+        [-1, 0, 0, 1],
+        [0, 2, 0, 0],
+        [0, 0, 3, 0],
+        [0, 0, 0, 4]
+      ])
+
+  You can specify the tensor type:
+
+      iex> import Nx
+      iex> ~M[0.1 0.2 0.3 0.4]f16
+      #Nx.Tensor<
+        f16[4]
+        [0.0999755859375, 0.199951171875, 0.300048828125, 0.39990234375]
+      >
+
+  """
   defmacro sigil_M({:<<>>, _meta, [string]}, modifiers) do
     numbers =
       case binary_to_numbers(string) do

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -8491,18 +8491,52 @@ defmodule Nx do
       iex> import Nx
       iex> ~M[0.1 0.2 0.3 0.4]f16
       #Nx.Tensor<
+        f16[1][4]
+        [
+          [0.0999755859375, 0.199951171875, 0.300048828125, 0.39990234375]
+        ]
+      >
+
+  """
+  defmacro sigil_M({:<<>>, _meta, [string]}, modifiers) do
+    string
+    |> binary_to_numbers
+    |> numbers_to_tensor(modifiers)
+  end
+
+  @doc """
+  Provides `~V` sigil to build a vector (one-dimensional tensor).
+
+  > Note: `~V` requires Elixir >= `1.13.0` in order to suppport type specifiers like `u8`
+
+  ## Examples
+
+      import Nx
+
+      ~V[-1 0 0 1]
+
+  Is equivalent to:
+
+      Nx.tensor([-1, 0, 0, 1])
+
+  You can specify the vector type:
+
+      iex> import Nx
+      iex> ~V[0.1 0.2 0.3 0.4]f16
+      #Nx.Tensor<
         f16[4]
         [0.0999755859375, 0.199951171875, 0.300048828125, 0.39990234375]
       >
 
   """
-  defmacro sigil_M({:<<>>, _meta, [string]}, modifiers) do
-    numbers =
-      case binary_to_numbers(string) do
-        [vector] -> vector
-        matrix -> matrix
-      end
+  defmacro sigil_V({:<<>>, _meta, [string]}, modifiers) do
+    string
+    |> binary_to_numbers
+    |> hd()
+    |> numbers_to_tensor(modifiers)
+  end
 
+  defp numbers_to_tensor(numbers, modifiers) do
     type =
       case modifiers do
         [unit | size] ->

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -8458,7 +8458,15 @@ defmodule Nx do
 
   ## Examples
 
-      import Nx
+  Before using sigils, you must first import them:
+
+      import Nx, only: [sigil_M: 2]
+
+  If you are using Elixir v1.13+, then you can write instead:
+
+      import Nx, only: :sigils
+
+  Then you use the sigil to create matrices. The sigil:
 
       ~M<
         -1 0 0 1

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -8454,7 +8454,7 @@ defmodule Nx do
   ## Sigils
 
   @doc """
-  A convenient `~M` sigil for building matrices.
+  A convenient `~M` sigil for building matrices (two-dimensional tensors).
 
   ## Examples
 

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -8505,13 +8505,15 @@ defmodule Nx do
   end
 
   @doc """
-  Provides `~V` sigil to build a vector (one-dimensional tensor).
-
-  > Note: `~V` requires Elixir >= `1.13.0` in order to suppport type specifiers like `u8`
+  A convenient `~V` sigil for building vectors (one-dimensional tensors).
 
   ## Examples
 
-      import Nx
+  Before using sigils, you must first import them:
+
+      import Nx, only: [sigil_V: 2]
+
+  Then you use the sigil to create vectors. The sigil:
 
       ~V[-1 0 0 1]
 
@@ -8519,7 +8521,9 @@ defmodule Nx do
 
       Nx.tensor([-1, 0, 0, 1])
 
-  You can specify the vector type:
+  If the tensor has any float type, it defaults to f32.
+  Otherwise, it is s64. If you are using Elixir 1.13+,
+  you can specify the tensor type as a sigil modifier:
 
       iex> import Nx
       iex> ~V[0.1 0.2 0.3 0.4]f16

--- a/nx/test/nx_test.exs
+++ b/nx/test/nx_test.exs
@@ -1644,6 +1644,17 @@ defmodule NxTest do
       assert ~V[4 3 2 1] == Nx.tensor([4, 3, 2, 1])
     end
 
+    test "raises when vector has more than one dimension" do
+      assert_raise(
+        ArgumentError,
+        "must be one-dimensional",
+        fn ->
+          eval(~S[~V<0 0 0 1
+                     1 0 0 0>])
+        end
+      )
+    end
+
     if Version.match?(System.version(), ">= 1.13.0-dev") do
       test "evaluates with proper type" do
         assert eval("~M[1 2 3 4]f32") == Nx.tensor([[1, 2, 3, 4]], type: {:f, 32})
@@ -1671,12 +1682,12 @@ defmodule NxTest do
           end
         )
       end
+    end
 
-      defp eval(expresion) do
-        "import Nx; #{expresion}"
-        |> Code.eval_string()
-        |> elem(0)
-      end
+    defp eval(expresion) do
+      "import Nx; #{expresion}"
+      |> Code.eval_string()
+      |> elem(0)
     end
   end
 end

--- a/nx/test/nx_test.exs
+++ b/nx/test/nx_test.exs
@@ -1675,6 +1675,22 @@ defmodule NxTest do
           end
         )
       end
+
+      test "raises on non-numerical values" do
+        assert_raise(
+          ArgumentError,
+          "expected a numerical value for tensor, got x",
+          fn ->
+            defmodule Test3 do
+              import Nx
+
+              def case do
+                unquote(Code.string_to_quoted!("~M[1 2 x 4]u8"))
+              end
+            end
+          end
+        )
+      end
     end
   end
 end

--- a/nx/test/nx_test.exs
+++ b/nx/test/nx_test.exs
@@ -1,7 +1,7 @@
 defmodule NxTest do
   use ExUnit.Case, async: true
 
-  doctest Nx, except: [sigil_M: 2]
+  doctest Nx, except: [sigil_M: 2, sigil_V: 2]
 
   defp commute(a, b, fun) do
     fun.(a, b)

--- a/nx/test/nx_test.exs
+++ b/nx/test/nx_test.exs
@@ -1629,20 +1629,20 @@ defmodule NxTest do
     end
   end
 
-  if Version.match?(System.version(), ">= 1.13.0-dev") do
-    describe "sigil" do
-      test "evaluates to tensor" do
-        import Nx
+  describe "sigil" do
+    test "evaluates to tensor" do
+      import Nx
 
-        assert ~M[-1 2 3 4] == Nx.tensor([-1, 2, 3, 4])
-        assert ~M[1
-                  2
-                  3
-                  4] == Nx.tensor([[1], [2], [3], [4]])
-        assert ~M[1.0 2  3
-                  11  12 13] == Nx.tensor([[1.0, 2, 3], [11, 12, 13]])
-      end
+      assert ~M[-1 2 3 4] == Nx.tensor([-1, 2, 3, 4])
+      assert ~M[1
+                2
+                3
+                4] == Nx.tensor([[1], [2], [3], [4]])
+      assert ~M[1.0 2  3
+                11  12 13] == Nx.tensor([[1.0, 2, 3], [11, 12, 13]])
+    end
 
+    if Version.match?(System.version(), ">= 1.13.0-dev") do
       test "evaluates with proper type" do
         assert eval("~M[1 2 3 4]f32") == Nx.tensor([1, 2, 3, 4], type: {:f, 32})
         assert eval("~M[4 3 2 1]u8") == Nx.tensor([4, 3, 2, 1], type: {:u, 8})

--- a/nx/test/nx_test.exs
+++ b/nx/test/nx_test.exs
@@ -1629,23 +1629,27 @@ defmodule NxTest do
     end
   end
 
-  describe "sigil" do
+  describe "sigils" do
     test "evaluates to tensor" do
       import Nx
 
-      assert ~M[-1 2 3 4] == Nx.tensor([-1, 2, 3, 4])
+      assert ~M[-1 2 3 4] == Nx.tensor([[-1, 2, 3, 4]])
       assert ~M[1
                 2
                 3
                 4] == Nx.tensor([[1], [2], [3], [4]])
       assert ~M[1.0 2  3
                 11  12 13] == Nx.tensor([[1.0, 2, 3], [11, 12, 13]])
+
+      assert ~V[4 3 2 1] == Nx.tensor([4, 3, 2, 1])
     end
 
     if Version.match?(System.version(), ">= 1.13.0-dev") do
       test "evaluates with proper type" do
-        assert eval("~M[1 2 3 4]f32") == Nx.tensor([1, 2, 3, 4], type: {:f, 32})
-        assert eval("~M[4 3 2 1]u8") == Nx.tensor([4, 3, 2, 1], type: {:u, 8})
+        assert eval("~M[1 2 3 4]f32") == Nx.tensor([[1, 2, 3, 4]], type: {:f, 32})
+        assert eval("~M[4 3 2 1]u8") == Nx.tensor([[4, 3, 2, 1]], type: {:u, 8})
+
+        assert eval("~V[0 1 0 1]u8") == Nx.tensor([0, 1, 0, 1], type: {:u, 8})
       end
 
       test "raises on invalid type" do
@@ -1663,7 +1667,7 @@ defmodule NxTest do
           ArgumentError,
           "expected a numerical value for tensor, got x",
           fn ->
-            eval("~M[1 2 x 4]u8")
+            eval("~V[1 2 x 4]u8")
           end
         )
       end

--- a/nx/test/nx_test.exs
+++ b/nx/test/nx_test.exs
@@ -1,7 +1,7 @@
 defmodule NxTest do
   use ExUnit.Case, async: true
 
-  doctest Nx
+  doctest Nx, except: [sigil_M: 2]
 
   defp commute(a, b, fun) do
     fun.(a, b)

--- a/nx/test/nx_test.exs
+++ b/nx/test/nx_test.exs
@@ -1644,20 +1644,8 @@ defmodule NxTest do
       end
 
       test "evaluates with proper type" do
-        defmodule Test do
-          import Nx
-
-          def case1 do
-            unquote(Code.string_to_quoted!("~M[1 2 3 4]f32"))
-          end
-
-          def case2 do
-            unquote(Code.string_to_quoted!("~M[4 3 2 1]u8"))
-          end
-        end
-
-        assert Test.case1() == Nx.tensor([1, 2, 3, 4], type: {:f, 32})
-        assert Test.case2() == Nx.tensor([4, 3, 2, 1], type: {:u, 8})
+        assert eval("~M[1 2 3 4]f32") == Nx.tensor([1, 2, 3, 4], type: {:f, 32})
+        assert eval("~M[4 3 2 1]u8") == Nx.tensor([4, 3, 2, 1], type: {:u, 8})
       end
 
       test "raises on invalid type" do
@@ -1665,13 +1653,7 @@ defmodule NxTest do
           ArgumentError,
           "invalid numerical type: {:f, 8} (see Nx.Type docs for all supported types)",
           fn ->
-            defmodule Test2 do
-              import Nx
-
-              def case do
-                unquote(Code.string_to_quoted!("~M[1 2 3 4]f8"))
-              end
-            end
+            eval("~M[1 2 3 4]f8")
           end
         )
       end
@@ -1681,15 +1663,15 @@ defmodule NxTest do
           ArgumentError,
           "expected a numerical value for tensor, got x",
           fn ->
-            defmodule Test3 do
-              import Nx
-
-              def case do
-                unquote(Code.string_to_quoted!("~M[1 2 x 4]u8"))
-              end
-            end
+            eval("~M[1 2 x 4]u8")
           end
         )
+      end
+
+      defp eval(expresion) do
+        "import Nx; #{expresion}"
+        |> Code.eval_string()
+        |> elem(0)
       end
     end
   end

--- a/torchx/test/torchx/nx_doctest_test.exs
+++ b/torchx/test/torchx/nx_doctest_test.exs
@@ -39,7 +39,10 @@ defmodule Torchx.NxDoctestTest do
     # to_batched_list - Shape mismatch due to unsupported options in some tests
     to_batched_list: 3,
     # window_mean - depends on window_sum which is not implemented
-    window_mean: 3
+    window_mean: 3,
+    # require Elixir 1.13+
+    sigil_M: 2,
+    sigil_V: 2
   ]
 
   @rounding_error_doctests [


### PR DESCRIPTION
This PR adds `~M[]` sigil that evaluates to `#Nx.Tensor<>` as discussed in #358, but with type in the modifier.

I've added conditional compilation since support for digits in sigils was just merged to Elixir (elixir-lang/elixir#11283).