### PR TITLE
Debug log with platform info

### DIFF
--- a/exla/lib/exla/client.ex
+++ b/exla/lib/exla/client.ex
@@ -64,12 +64,15 @@ defmodule EXLA.Client do
     preallocate_int = if preallocate, do: 1, else: 0
     
     platforms = Map.keys(EXLA.Client.get_supported_platforms())
-    Logger.debug("Available platforms are: #{inspect(platforms)}")
 
     ref =
       case platform do
         nil ->
-          Logger.debug("No platform configuration specified, falling back to host platform")
+          Logger.debug("""
+            No platform configuration specified, falling back to host platform
+            Available platforms are: #{inspect(platforms)}
+            """
+          )
           EXLA.NIF.get_host_client()
         :host -> EXLA.NIF.get_host_client()
         :cuda -> EXLA.NIF.get_gpu_client(memory_fraction, preallocate_int)


### PR DESCRIPTION
Minor change. Currently we silently fallback to host. This isn't really bad because we annotate configuration stuff in the docs, but this is a little nudge to indicate that EXLA is using the host platform because none is specified. Also logs out the available platforms on initialization, which provides some useful feedback to determine if you've got everything installed correctly for CUDA/ROCm.