### PR TITLE
Allow structs in defn

### DIFF
--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -63,6 +63,16 @@ defmodule EXLA.Defn do
   defp outputs(tuple) when is_tuple(tuple),
     do: {:tuple, tuple |> Tuple.to_list() |> Enum.map(&outputs/1)}
 
+  defp outputs(map) when is_struct(map) do
+    out =
+      map
+      |> Map.from_struct()
+      |> Enum.sort()
+      |> Enum.map(fn {k, v} -> {k, outputs(v)} end)
+
+    {:struct, out, map.__struct__}
+  end
+
   defp outputs(map) when is_map(map),
     do: {:map, map |> Enum.sort() |> Enum.map(fn {k, v} -> {k, outputs(v)} end)}
 
@@ -99,6 +109,15 @@ defmodule EXLA.Defn do
     list = Tuple.to_list(tuple)
 
     Enum.reduce(list, {acc, cache}, fn expr, {acc, cache} ->
+      to_root_result(expr, acc, state, cache)
+    end)
+  end
+
+  defp to_root_result(map, acc, state, cache) when is_struct(map) do
+    map
+    |> Map.from_struct()
+    |> Enum.sort()
+    |> Enum.reduce({acc, cache}, fn {_, expr}, {acc, cache} ->
       to_root_result(expr, acc, state, cache)
     end)
   end
@@ -1127,6 +1146,16 @@ defmodule EXLA.Defn do
   defp each_buffer_to_nx({:tuple, outputs}, acc) when is_list(outputs) do
     {exprs, acc} = Enum.map_reduce(outputs, acc, &each_buffer_to_nx/2)
     {List.to_tuple(exprs), acc}
+  end
+
+  defp each_buffer_to_nx({:struct, outputs, mod}, acc) when is_list(outputs) do
+    {exprs, acc} =
+      Enum.map_reduce(outputs, acc, fn {k, v}, acc ->
+        {v, acc} = each_buffer_to_nx(v, acc)
+        {{k, v}, acc}
+      end)
+
+    {struct(mod, exprs), acc}
   end
 
   defp each_buffer_to_nx({:map, outputs}, acc) when is_list(outputs) do

--- a/nx/lib/nx/defn/tree.ex
+++ b/nx/lib/nx/defn/tree.ex
@@ -126,10 +126,21 @@ defmodule Nx.Defn.Tree do
     {List.to_tuple(list), acc}
   end
 
+  def composite(map, acc, fun) when is_struct(map) and is_function(fun, 2) do
+    {list, acc} =
+      map
+      |> Map.from_struct()
+      |> Enum.map_reduce(acc, fn {k, v}, acc ->
+        {v, acc} = composite(v, acc, fun)
+        {{k, v}, acc}
+      end)
+
+    {struct(map.__struct__, list), acc}
+  end
+
   def composite(map, acc, fun) when is_map(map) and is_function(fun, 2) do
     {list, acc} =
       map
-      |> assert_no_struct!()
       |> Enum.map_reduce(acc, fn {k, v}, acc ->
         {v, acc} = composite(v, acc, fun)
         {{k, v}, acc}
@@ -250,10 +261,16 @@ defmodule Nx.Defn.Tree do
   defp flatten_each(tuple, acc, fun) when is_tuple(tuple),
     do: tuple |> Tuple.to_list() |> Enum.reduce(acc, &flatten_each(&1, &2, fun))
 
+  defp flatten_each(map, acc, fun) when is_struct(map),
+    do:
+      map
+      |> Map.from_struct()
+      |> Enum.sort()
+      |> Enum.reduce(acc, &flatten_each(elem(&1, 1), &2, fun))
+
   defp flatten_each(map, acc, fun) when is_map(map),
     do:
       map
-      |> assert_no_struct!()
       |> Enum.sort()
       |> Enum.reduce(acc, &flatten_each(elem(&1, 1), &2, fun))
 
@@ -332,8 +349,15 @@ defmodule Nx.Defn.Tree do
   def to_result(%T{data: %Expr{}} = t),
     do: t
 
+  def to_result(map) when is_struct(map),
+    do:
+      map
+      |> Map.from_struct()
+      |> Enum.map(fn {k, v} -> {k, to_result(v)} end)
+      |> then(&struct(map.__struct__, &1))
+
   def to_result(map) when is_map(map),
-    do: map |> assert_no_struct!() |> Enum.map(fn {k, v} -> {k, to_result(v)} end) |> Map.new()
+    do: map |> Enum.map(fn {k, v} -> {k, to_result(v)} end) |> Map.new()
 
   def to_result(tuple) when is_tuple(tuple),
     do: tuple |> Tuple.to_list() |> Enum.map(&to_result/1) |> List.to_tuple()
@@ -368,10 +392,22 @@ defmodule Nx.Defn.Tree do
     {List.to_tuple(list), acc}
   end
 
+  defp args_to_each(map, acc, fun) when is_struct(map) do
+    {list, acc} =
+      map
+      |> Map.from_struct()
+      |> Enum.sort()
+      |> Enum.map_reduce(acc, fn {k, v}, acc ->
+        {v, acc} = args_to_each(v, acc, fun)
+        {{k, v}, acc}
+      end)
+
+    {struct(map.__struct__, list), acc}
+  end
+
   defp args_to_each(map, acc, fun) when is_map(map) do
     {list, acc} =
       map
-      |> assert_no_struct!()
       |> Enum.sort()
       |> Enum.map_reduce(acc, fn {k, v}, acc ->
         {v, acc} = args_to_each(v, acc, fun)
@@ -384,10 +420,4 @@ defmodule Nx.Defn.Tree do
   defp args_to_each(arg, acc, fun) do
     fun.(arg, acc)
   end
-
-  defp assert_no_struct!(%_{} = struct),
-    do: raise("unexpected struct inside defn: #{inspect(struct)}")
-
-  defp assert_no_struct!(map),
-    do: map
 end


### PR DESCRIPTION
This extends defn to allow structs. I plan on using this in Axon training loops. The training loop depends on certain fields being populated from within a map. If users write custom training steps and somehow delete or overwrite those fields, it will lead to access errors or other issues. By enforcing that training steps return a `%State{}` struct, we have some sort of contract on what the step needs to return.