### PR TITLE
Add container protocol

### DIFF
--- a/nx/lib/nx/defn/container.ex
+++ b/nx/lib/nx/defn/container.ex
@@ -1,4 +1,5 @@
 defprotocol Nx.Defn.Container do
+  @fallback_to_any true
   def decompose(container)
 end
 
@@ -10,24 +11,14 @@ defimpl Nx.Defn.Container, for: Tuple do
   defp decompose_impl([], {leaves, fun}), do: {List.flatten(Enum.reverse(leaves)), fun}
 
   defp decompose_impl([obj | rest], {leaves, fun}) do
-    case Nx.Defn.Container.impl_for(obj) do
-      nil ->
-        # The object is a leaf, so no nesting
-        {leaves, fun} = {[obj | leaves], fn x -> Tuple.append(fun.(x), obj) end}
+    {child_leaves, child_fun} = Nx.Defn.Container.decompose(obj)
 
-        decompose_impl(rest, {leaves, fun})
-
-      _ ->
-        # Otherwise, we need to get leaves of nested obj
-        {child_leaves, child_fun} = Nx.Defn.Container.decompose(obj)
-
-        fun = fn x ->
-          child = child_fun.(child_leaves)
-          Tuple.append(fun.(x), child)
-        end
-
-        decompose_impl(rest, {[child_leaves | leaves], fun})
+    fun = fn x ->
+      child = child_fun.(child_leaves)
+      Tuple.append(fun.(x), child)
     end
+
+    decompose_impl(rest, {[child_leaves | leaves], fun})
   end
 end
 
@@ -36,24 +27,35 @@ defimpl Nx.Defn.Container, for: Map do
     {leaves, fun} =
       map
       |> Enum.reduce({[], fn _ -> %{} end}, fn {k, obj}, {leaves, fun} ->
-        case Nx.Defn.Container.impl_for(obj) do
-          nil ->
-            # The object is a leaf, no nesting
-            {[obj | leaves], fn x -> Map.put(fun.(x), k, obj) end}
+        {child_leaves, child_fun} = Nx.Defn.Container.decompose(obj)
 
-          _ ->
-            # Otherwise, we need to get leaves of nested obj
-            {child_leaves, child_fun} = Nx.Defn.Container.decompose(obj)
-
-            fun = fn x ->
-              child = child_fun.(child_leaves)
-              Map.put(fun.(x), k, child)
-            end
-
-            {[child_leaves | leaves], fun}
+        fun = fn x ->
+          child = child_fun.(child_leaves)
+          Map.put(fun.(x), k, child)
         end
+
+        {[child_leaves | leaves], fun}
       end)
 
     {List.flatten(Enum.reverse(leaves)), fun}
+  end
+end
+
+# Fallback for structs and leaf values, this is really so
+# we can have a generic struct implementation which matches
+# how we handle structs now. It doesn't feel like the best way
+# though.
+defimpl Nx.Defn.Container, for: Any do
+  def decompose(map) when is_struct(map) do
+    {leaves, fun} =
+      map
+      |> Map.from_struct()
+      |> Nx.Defn.Container.decompose()
+
+    {leaves, fn x -> struct(map.__struct__, fun.(x)) end}
+  end
+
+  def decompose(any) do
+    {any, & &1}
   end
 end

--- a/nx/lib/nx/defn/container.ex
+++ b/nx/lib/nx/defn/container.ex
@@ -1,0 +1,61 @@
+defprotocol Nx.Defn.Container do
+  def decompose(container)
+end
+
+defimpl Nx.Defn.Container, for: Tuple do
+
+  def decompose(tuple) do
+    decompose_impl(Tuple.to_list(tuple), {[], fn _ -> {} end})
+  end
+
+  defp decompose_impl([], {leaves, fun}), do: {List.flatten(Enum.reverse(leaves)), fun}
+
+  defp decompose_impl([obj | rest], {leaves, fun}) do
+    case Nx.Defn.Container.impl_for(obj) do
+      nil ->
+        # The object is a leaf, so no nesting
+        {leaves, fun} = {[obj | leaves], fn x -> Tuple.append(fun.(x), obj) end}
+
+        decompose_impl(rest, {leaves, fun})
+
+      _ ->
+        # Otherwise, we need to get leaves of nested obj
+        {child_leaves, child_fun} = Nx.Defn.Container.decompose(obj)
+
+        fun = fn x ->
+          child = child_fun.(child_leaves)
+          Tuple.append(fun.(x), child)
+        end
+
+        decompose_impl(rest, {[child_leaves | leaves], fun})
+    end
+  end
+end
+
+defimpl Nx.Defn.Container, for: Map do
+
+  def decompose(map) do
+    {leaves, fun} =
+      map
+      |> Enum.reduce({[], fn _ -> %{} end}, fn {k, obj}, {leaves, fun} ->
+        case Nx.Defn.Container.impl_for(obj) do
+          nil ->
+            # The object is a leaf, no nesting
+            {[obj | leaves], fn x -> Map.put(fun.(x), k, obj) end}
+
+          _ ->
+            # Otherwise, we need to get leaves of nested obj
+            {child_leaves, child_fun} = Nx.Defn.Container.decompose(obj)
+
+            fun = fn x ->
+              child = child_fun.(child_leaves)
+              Map.put(fun.(x), k, child)
+            end
+
+            {[child_leaves | leaves], fun}
+        end
+      end)
+
+    {List.flatten(Enum.reverse(leaves)), fun}
+  end
+end

--- a/nx/lib/nx/defn/container.ex
+++ b/nx/lib/nx/defn/container.ex
@@ -3,7 +3,6 @@ defprotocol Nx.Defn.Container do
 end
 
 defimpl Nx.Defn.Container, for: Tuple do
-
   def decompose(tuple) do
     decompose_impl(Tuple.to_list(tuple), {[], fn _ -> {} end})
   end
@@ -33,7 +32,6 @@ defimpl Nx.Defn.Container, for: Tuple do
 end
 
 defimpl Nx.Defn.Container, for: Map do
-
   def decompose(map) do
     {leaves, fun} =
       map


### PR DESCRIPTION
This defines a protocol and implements it for Tuples and Maps which can be integrated into Nx defn so we can return pretty much any container from defn. All you have to do is define a function `decompose` which returns `{leaves, fun}`, where `leaves` are a flat list of leaf (tensor) values and `fun` is a function which rebuilds the container structure from leaves.

Opening now for feedback on the API. Will integrate once the API is ironed out