### PR TITLE
explicitly cast to ErlNifSInt64* so that it compiles on 32bit platforms

### DIFF
--- a/torchx/c_src/torchx.cpp
+++ b/torchx/c_src/torchx.cpp
@@ -29,7 +29,7 @@ inline std::string type2string(const torch::ScalarType type)
   double double_##VAR;          \
   if (enif_get_double(env, argv[ARGN], &double_##VAR) == 0) { \
     long long_##VAR;                                  \
-    enif_get_int64(env, argv[ARGN], &long_##VAR);     \
+    enif_get_int64(env, argv[ARGN], (ErlNifSInt64*)&long_##VAR);     \
     new (&VAR) torch::Scalar((int64_t)long_##VAR);             \
   } else {                                            \
     new (&VAR) torch::Scalar(double_##VAR);           \


### PR DESCRIPTION
Hi, I'm trying to compile this on a 32bit Raspberry Pi, and the compiler throws an error about the implicit cast at [torchx.cpp:32](https://github.com/elixir-nx/nx/blob/ce070e239b3c2c933c1e14e04f0fcc32b2da470e/torchx/c_src/torchx.cpp#L32).

The fix is as easy as adding an explicitly cast to ErlNifSInt64* so that it compiles on 32bit platforms. Please don't hesitate to let me know if there are any issues! Thank you :)

```
$ gcc -v
Using built-in specs.
COLLECT_GCC=/usr/bin/gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/arm-linux-gnueabihf/9/lto-wrapper
Target: arm-linux-gnueabihf
Configured with: ../src/configure -v --with-pkgversion='Ubuntu 9.3.0-17ubuntu1~20.04' --with-bugurl=file:///usr/share/doc/gcc-9/README.Bugs --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,gm2 --prefix=/usr --with-gcc-major-version-only --program-suffix=-9 --program-prefix=arm-linux-gnueabihf- --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-libitm --disable-libquadmath --disable-libquadmath-support --enable-plugin --enable-default-pie --with-system-zlib --with-target-system-zlib=auto --enable-objc-gc=auto --enable-multiarch --enable-multilib --disable-sjlj-exceptions --with-arch=armv7-a --with-fpu=vfpv3-d16 --with-float=hard --with-mode=thumb --disable-werror --enable-multilib --enable-checking=release --build=arm-linux-gnueabihf --host=arm-linux-gnueabihf --target=arm-linux-gnueabihf
Thread model: posix
gcc version 9.3.0 (Ubuntu 9.3.0-17ubuntu1~20.04)

$ g++ -fPIC -I/root/.asdf/installs/erlang/24.0.6/erts-12.0.4/include -I/root/.libtorch/include/ -I/root/.libtorch/include/torch/csrc/api/include -O3 -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -shared -std=c++14 -fopenmp c_src/torchx.cpp -o /src/livebook/_build/prod/lib/torchx/priv/torchx.so -L/root/.libtorch/lib/ -ltorch -Wl,-rpath,'$ORIGIN/lib' -lpthread -lc10 -ltorch_cpu -lkineto
c_src/torchx.cpp: In function ‘ERL_NIF_TERM scalar_tensor(ErlNifEnv*, int, const ERL_NIF_TERM*)’:
c_src/torchx.cpp:32:37: error: cannot convert ‘long int*’ to ‘ErlNifSInt64*’ {aka ‘long long int*’}
   32 |     enif_get_int64(env, argv[ARGN], &long_##VAR);     \
      |                                     ^~~~~~
      |                                     |
      |                                     long int*
c_src/torchx.cpp:346:3: note: in expansion of macro ‘SCALAR_PARAM’
  346 |   SCALAR_PARAM(0, scalar);
      |   ^~~~~~~~~~~~
```