### PR TITLE
Fix successive comparisons in EXLA

### DIFF
--- a/exla/test/exla/defn_expr_test.exs
+++ b/exla/test/exla/defn_expr_test.exs
@@ -499,6 +499,16 @@ defmodule EXLA.DefnExprTest do
       assert equal(Nx.tensor([1, 2, 3]), Nx.tensor([1.0, 2.0, 3.0])) ==
                Nx.tensor([1, 1, 1], type: {:u, 8})
     end
+
+    defn successive_compare(y_true, y_pred) do
+      y_pred
+      |> Nx.equal(y_pred)
+      |> Nx.equal(y_true)
+    end
+
+    test "computes successive comparisons" do
+      assert successive_compare(Nx.tensor(1), Nx.tensor(1)) == Nx.tensor(1, type: {:u, 8})
+    end
   end
 
   describe "not equal" do

--- a/nx/lib/nx/type.ex
+++ b/nx/lib/nx/type.ex
@@ -301,10 +301,11 @@ defmodule Nx.Type do
     end
   end
 
-  defp type_to_int(:f), do: 3
-  defp type_to_int(:bf), do: 2
-  defp type_to_int(:s), do: 1
-  defp type_to_int(:u), do: 0
+  defp type_to_int(:f), do: 4
+  defp type_to_int(:bf), do: 3
+  defp type_to_int(:s), do: 2
+  defp type_to_int(:u), do: 1
+  defp type_to_int(:pred), do: 0
 
   defp sort({left_type, _} = left, {right_type, _} = right) do
     if type_to_int(left_type) < type_to_int(right_type) do


### PR DESCRIPTION
Successive comparisons fail in EXLA because they always return `{:pred, 8}` types and the compare operator in turn relies on Nx.Type.merge to merge result types in a successive comparison. Test is one example of something that fails before this. Doing something like:

```elixir
y_true
|> Nx.equal(1)
|> Nx.as_type({:u, 8})
|> Nx.equal(2)
```

I'm pretty sure would workaround this, but I think this issue might manifest in other places as well, so I figured this was an easier workaround.