### PR TITLE
Fix heading in `Nx.to_scalar` docs

### DIFF
--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -1286,7 +1286,7 @@ defmodule Nx do
 
   If the tensor has a dimension, it raises.
 
-    ## Examples
+  ## Examples
 
       iex> Nx.to_scalar(1)
       1


### PR DESCRIPTION
This pr fixes a heading in the `Nx.to_scalar` docs