### PR TITLE
Add from_numpy and from_numpy_archive

### DIFF
--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -8478,10 +8478,10 @@ defmodule Nx do
   def from_numpy_archive(archive) do
     archive = File.read!(archive)
 
-    case :zip.unzip(archive) do
+    case :zip.unzip(archive, [:memory]) do
       {:ok, files} ->
         files
-        |> Enum.map(&from_numpy/1)
+        |> Enum.map(fn {_, data} -> parse_numpy(data) end)
 
       _ ->
         raise ArgumentError,


### PR DESCRIPTION
I separated the functions to avoid possibly different return types. Currently `from_numpy_archive` unzips a bunch of `.npy` files into whatever folder these functions are called from. Should these be cleaned up after execution? Or left as is