### PR TITLE
Return 0/1 from comparison operators in Kernel

### DIFF
--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -186,8 +186,8 @@ defmodule EXLA.Defn do
 
   ## to_operator creation
 
-  defp to_operator(:scalar, [scalar], ans, state) do
-    op = to_constant(state.builder, scalar, ans.type)
+  defp to_operator(:constant, [constant], ans, state) do
+    op = to_constant(state.builder, constant, ans.type)
 
     if ans.shape == {} do
       op

--- a/nx/lib/nx/backend.ex
+++ b/nx/lib/nx/backend.ex
@@ -38,7 +38,7 @@ defmodule Nx.Backend do
   @type axes :: Nx.Tensor.axes()
   @type backend_options :: term()
 
-  @callback scalar(out :: tensor, binary, backend_options) :: tensor
+  @callback constant(out :: tensor, binary, backend_options) :: tensor
   @callback from_binary(out :: tensor, binary, backend_options) :: tensor
   @callback eye(tensor, backend_options) :: tensor
   @callback iota(tensor, axis | nil, backend_options) :: tensor

--- a/nx/lib/nx/binary_backend.ex
+++ b/nx/lib/nx/binary_backend.ex
@@ -22,8 +22,8 @@ defmodule Nx.BinaryBackend do
   ## Creation
 
   @impl true
-  def scalar(%{type: type, shape: shape} = out, scalar, _backend_options) do
-    data = :binary.copy(number_to_binary(scalar, type), Nx.size(shape))
+  def constant(%{type: type, shape: shape} = out, constant, _backend_options) do
+    data = :binary.copy(number_to_binary(constant, type), Nx.size(shape))
     from_binary(out, data)
   end
 

--- a/nx/lib/nx/defn/evaluator.ex
+++ b/nx/lib/nx/defn/evaluator.ex
@@ -8,7 +8,7 @@ defmodule Nx.Defn.Evaluator do
   @behaviour Nx.Defn.Compiler
   alias Nx.Defn.{Expr, Tree}
 
-  @creation_ops [:scalar, :eye, :iota, :from_binary]
+  @creation_ops [:constant, :eye, :iota, :from_binary]
   @random_ops [:random_uniform, :random_normal]
 
   @impl true

--- a/nx/lib/nx/defn/expr.ex
+++ b/nx/lib/nx/defn/expr.ex
@@ -317,8 +317,13 @@ defmodule Nx.Defn.Expr do
 
       true ->
         case t2 do
-          %T{data: %Expr{op: :subtract, args: [%T{data: %Expr{op: :constant, args: [scalar]}}, t2]}}
-          when scalar == 0 ->
+          %T{
+            data: %Expr{
+              op: :subtract,
+              args: [%T{data: %Expr{op: :constant, args: [constant]}}, t2]
+            }
+          }
+          when constant == 0 ->
             binary_expr(out, context, :subtract, t1, t2)
 
           %T{} ->
@@ -361,8 +366,10 @@ defmodule Nx.Defn.Expr do
 
       true ->
         case t2 do
-          %T{data: %Expr{op: :divide, args: [%T{data: %Expr{op: :constant, args: [scalar]}}, t2]}}
-          when scalar == 1 ->
+          %T{
+            data: %Expr{op: :divide, args: [%T{data: %Expr{op: :constant, args: [constant]}}, t2]}
+          }
+          when constant == 1 ->
             binary_expr(out, context, :divide, t1, t2)
 
           %T{} ->

--- a/nx/lib/nx/defn/grad.ex
+++ b/nx/lib/nx/defn/grad.ex
@@ -878,7 +878,7 @@ defmodule Nx.Defn.Grad do
     """
   end
 
-  @constants [:scalar, :tensor, :parameter, :eye, :iota, :random_uniform, :random_normal] ++
+  @constants [:constant, :tensor, :parameter, :eye, :iota, :random_uniform, :random_normal] ++
                [:all?, :any?, :argmax, :argmin] ++
                [:bitwise_and, :bitwise_or, :bitwise_xor, :bitwise_not] ++
                [:logical_and, :logical_or, :logical_xor, :logical_not] ++
@@ -1135,7 +1135,7 @@ defmodule Nx.Defn.Grad do
 
   defp surface_nuldim_scalar(expr) do
     case expr do
-      %T{data: %Expr{op: :scalar, args: [scalar]}, shape: {}} -> scalar
+      %T{data: %Expr{op: :constant, args: [scalar]}, shape: {}} -> scalar
       %T{} -> expr
     end
   end

--- a/nx/lib/nx/defn/kernel.ex
+++ b/nx/lib/nx/defn/kernel.ex
@@ -536,23 +536,19 @@ defmodule Nx.Defn.Kernel do
   def not tensor when is_number(tensor), do: logical_not(tensor)
   def not tensor, do: Nx.logical_not(tensor)
 
-  defp logical_and(l, r) when Kernel.==(l, 0), do: zero(l, r)
-  defp logical_and(l, r) when Kernel.==(r, 0), do: zero(l, r)
-  defp logical_and(l, r), do: one(l, r)
+  defp logical_and(l, _) when Kernel.==(l, 0), do: zero()
+  defp logical_and(_, r) when Kernel.==(r, 0), do: zero()
+  defp logical_and(_, _), do: one()
 
-  defp logical_or(l, r) when Kernel.and(Kernel.==(l, 0), Kernel.==(r, 0)), do: zero(l, r)
-  defp logical_or(l, r), do: one(l, r)
+  defp logical_or(l, r) when Kernel.and(Kernel.==(l, 0), Kernel.==(r, 0)), do: zero()
+  defp logical_or(_, _), do: one()
 
-  defp logical_not(0), do: 1
-  defp logical_not(0.0), do: 1.0
-  defp logical_not(n) when is_float(n), do: 0.0
-  defp logical_not(n) when is_integer(n), do: 0
+  defp logical_not(0), do: one()
+  defp logical_not(0.0), do: one()
+  defp logical_not(_), do: zero()
 
-  defp zero(l, r) when Kernel.or(is_float(l), is_float(r)), do: 0.0
-  defp zero(_, _), do: 0
-
-  defp one(l, r) when Kernel.or(is_float(l), is_float(r)), do: 1.0
-  defp one(_, _), do: 1
+  defp zero(), do: Nx.Defn.Expr.constant(0, %Nx.Tensor{type: {:u, 8}, shape: {}, names: []})
+  defp one(), do: Nx.Defn.Expr.constant(1, %Nx.Tensor{type: {:u, 8}, shape: {}, names: []})
 
   @doc """
   Element-wise bitwise AND operation.
@@ -651,7 +647,7 @@ defmodule Nx.Defn.Kernel do
 
   """
   def left == right when Kernel.and(is_number(left), is_number(right)),
-    do: to_int(Kernel.==(left, right))
+    do: to_constant(Kernel.==(left, right))
 
   def left == right, do: Nx.equal(left, right)
 
@@ -665,7 +661,7 @@ defmodule Nx.Defn.Kernel do
       end
   """
   def left != right when Kernel.and(is_number(left), is_number(right)),
-    do: to_int(Kernel.!=(left, right))
+    do: to_constant(Kernel.!=(left, right))
 
   def left != right, do: Nx.not_equal(left, right)
 
@@ -679,7 +675,7 @@ defmodule Nx.Defn.Kernel do
       end
   """
   def left < right when Kernel.and(is_number(left), is_number(right)),
-    do: to_int(Kernel.<(left, right))
+    do: to_constant(Kernel.<(left, right))
 
   def left < right, do: Nx.less(left, right)
 
@@ -693,7 +689,7 @@ defmodule Nx.Defn.Kernel do
       end
   """
   def left > right when Kernel.and(is_number(left), is_number(right)),
-    do: to_int(Kernel.>(left, right))
+    do: to_constant(Kernel.>(left, right))
 
   def left > right, do: Nx.greater(left, right)
 
@@ -707,7 +703,7 @@ defmodule Nx.Defn.Kernel do
       end
   """
   def left <= right when Kernel.and(is_number(left), is_number(right)),
-    do: to_int(Kernel.<=(left, right))
+    do: to_constant(Kernel.<=(left, right))
 
   def left <= right, do: Nx.less_equal(left, right)
 
@@ -721,12 +717,12 @@ defmodule Nx.Defn.Kernel do
       end
   """
   def left >= right when Kernel.and(is_number(left), is_number(right)),
-    do: to_int(Kernel.>=(left, right))
+    do: to_constant(Kernel.>=(left, right))
 
   def left >= right, do: Nx.greater_equal(left, right)
 
-  defp to_int(true), do: 1
-  defp to_int(false), do: 0
+  defp to_constant(true), do: one()
+  defp to_constant(false), do: zero()
 
   @doc """
   Ensures the first argument is a `keyword` with the given

--- a/nx/lib/nx/defn/kernel.ex
+++ b/nx/lib/nx/defn/kernel.ex
@@ -651,7 +651,7 @@ defmodule Nx.Defn.Kernel do
 
   """
   def left == right when Kernel.and(is_number(left), is_number(right)),
-    do: Kernel.==(left, right)
+    do: to_int(Kernel.==(left, right))
 
   def left == right, do: Nx.equal(left, right)
 
@@ -665,7 +665,7 @@ defmodule Nx.Defn.Kernel do
       end
   """
   def left != right when Kernel.and(is_number(left), is_number(right)),
-    do: Kernel.!=(left, right)
+    do: to_int(Kernel.!=(left, right))
 
   def left != right, do: Nx.not_equal(left, right)
 
@@ -679,7 +679,7 @@ defmodule Nx.Defn.Kernel do
       end
   """
   def left < right when Kernel.and(is_number(left), is_number(right)),
-    do: Kernel.<(left, right)
+    do: to_int(Kernel.<(left, right))
 
   def left < right, do: Nx.less(left, right)
 
@@ -693,7 +693,7 @@ defmodule Nx.Defn.Kernel do
       end
   """
   def left > right when Kernel.and(is_number(left), is_number(right)),
-    do: Kernel.>(left, right)
+    do: to_int(Kernel.>(left, right))
 
   def left > right, do: Nx.greater(left, right)
 
@@ -707,7 +707,7 @@ defmodule Nx.Defn.Kernel do
       end
   """
   def left <= right when Kernel.and(is_number(left), is_number(right)),
-    do: Kernel.<=(left, right)
+    do: to_int(Kernel.<=(left, right))
 
   def left <= right, do: Nx.less_equal(left, right)
 
@@ -721,9 +721,12 @@ defmodule Nx.Defn.Kernel do
       end
   """
   def left >= right when Kernel.and(is_number(left), is_number(right)),
-    do: Kernel.>=(left, right)
+    do: to_int(Kernel.>=(left, right))
 
   def left >= right, do: Nx.greater_equal(left, right)
+
+  defp to_int(true), do: 1
+  defp to_int(false), do: 0
 
   @doc """
   Ensures the first argument is a `keyword` with the given

--- a/nx/lib/nx/defn/tree.ex
+++ b/nx/lib/nx/defn/tree.ex
@@ -216,7 +216,7 @@ defmodule Nx.Defn.Tree do
     rewrite_type_args(t, type, [Nx.as_type(arg, type)])
   end
 
-  defp rewrite_type(:scalar, [arg], t, type_fun) do
+  defp rewrite_type(:constant, [arg], t, type_fun) do
     type = type_fun.(t.type)
     rewrite_type_args(t, type, [arg])
   end

--- a/nx/test/nx/defn/expr_test.exs
+++ b/nx/test/nx/defn/expr_test.exs
@@ -8,9 +8,9 @@ defmodule Nx.Defn.ExprTest do
   import Nx.Defn
   @default_defn_compiler Nx.Defn.Identity
 
-  describe "scalar optimizations" do
+  describe "constant optimizations" do
     test "broadcast" do
-      assert %T{data: %Expr{op: :scalar, args: [1.0]}, type: {:f, 32}, shape: {1, 2, 3}} =
+      assert %T{data: %Expr{op: :constant, args: [1.0]}, type: {:f, 32}, shape: {1, 2, 3}} =
                Nx.broadcast(Expr.tensor(1.0), {1, 2, 3})
 
       param = Expr.parameter(nil, {:s, 64}, {2, 2}, 1)
@@ -19,7 +19,7 @@ defmodule Nx.Defn.ExprTest do
                data: %Expr{
                  op: :add,
                  args: [
-                   %T{shape: {}, data: %Expr{op: :scalar, args: [1.0]}},
+                   %T{shape: {}, data: %Expr{op: :constant, args: [1.0]}},
                    %T{shape: {2, 2}, data: %Expr{op: :parameter}}
                  ]
                },
@@ -29,12 +29,12 @@ defmodule Nx.Defn.ExprTest do
     end
 
     test "as_type" do
-      assert %T{data: %Expr{op: :scalar, args: [1.0]}, type: {:f, 32}, shape: {}} =
+      assert %T{data: %Expr{op: :constant, args: [1.0]}, type: {:f, 32}, shape: {}} =
                Nx.as_type(Expr.tensor(1), {:f, 32})
     end
 
     test "add" do
-      assert %T{data: %Expr{op: :scalar, args: [3.0]}, type: {:f, 32}} =
+      assert %T{data: %Expr{op: :constant, args: [3.0]}, type: {:f, 32}} =
                Nx.add(Expr.tensor(1.0), Expr.tensor(2))
 
       param1 = Expr.parameter(nil, {:s, 64}, {2, 2}, 1)
@@ -66,7 +66,7 @@ defmodule Nx.Defn.ExprTest do
     end
 
     test "multiply" do
-      assert %T{data: %Expr{op: :scalar, args: [4.0]}, type: {:f, 32}} =
+      assert %T{data: %Expr{op: :constant, args: [4.0]}, type: {:f, 32}} =
                Nx.multiply(Expr.tensor(2.0), Expr.tensor(2))
 
       param1 = Expr.parameter(nil, {:s, 64}, {2, 2}, 1)
@@ -116,7 +116,7 @@ defmodule Nx.Defn.ExprTest do
                data: %Expr{
                  op: :add,
                  args: [
-                   %T{data: %Expr{op: :scalar, args: [3.0]}, shape: {}, type: {:f, 32}},
+                   %T{data: %Expr{op: :constant, args: [3.0]}, shape: {}, type: {:f, 32}},
                    %T{data: %Expr{op: :add, args: [^param2, ^param1]}, shape: {2, 2}}
                  ]
                },
@@ -128,7 +128,7 @@ defmodule Nx.Defn.ExprTest do
                data: %Expr{
                  op: :add,
                  args: [
-                   %T{data: %Expr{op: :scalar, args: [3.0]}, shape: {}, type: {:f, 32}},
+                   %T{data: %Expr{op: :constant, args: [3.0]}, shape: {}, type: {:f, 32}},
                    %T{
                      data: %Expr{
                        op: :broadcast,
@@ -154,7 +154,7 @@ defmodule Nx.Defn.ExprTest do
                data: %Expr{
                  op: :add,
                  args: [
-                   %T{data: %Expr{op: :scalar, args: [3.0]}, shape: {}, type: {:f, 32}},
+                   %T{data: %Expr{op: :constant, args: [3.0]}, shape: {}, type: {:f, 32}},
                    %T{
                      data: %Expr{
                        op: :broadcast,

--- a/nx/test/nx/defn/kernel_test.exs
+++ b/nx/test/nx/defn/kernel_test.exs
@@ -1,6 +1,9 @@
 defmodule Nx.Defn.KernelTest do
   use ExUnit.Case, async: true
 
+  defp zero(), do: Nx.Defn.Expr.constant(0, %Nx.Tensor{type: {:u, 8}, shape: {}, names: []})
+  defp one(), do: Nx.Defn.Expr.constant(1, %Nx.Tensor{type: {:u, 8}, shape: {}, names: []})
+
   describe "doctests" do
     use Nx.Defn.Kernel
     doctest Nx.Defn.Kernel
@@ -24,46 +27,46 @@ defmodule Nx.Defn.KernelTest do
     end
 
     test "comparison" do
-      assert Nx.Defn.Kernel.==(0, 0) == 1
-      assert Nx.Defn.Kernel.!=(0, 0) == 0
-      assert Nx.Defn.Kernel.>(0, 0) == 0
-      assert Nx.Defn.Kernel.>=(0, 0) == 1
-      assert Nx.Defn.Kernel.<(0, 0) == 0
-      assert Nx.Defn.Kernel.<=(0, 0) == 1
+      assert Nx.Defn.Kernel.==(0, 0) == one()
+      assert Nx.Defn.Kernel.!=(0, 0) == zero()
+      assert Nx.Defn.Kernel.>(0, 0) == zero()
+      assert Nx.Defn.Kernel.>=(0, 0) == one()
+      assert Nx.Defn.Kernel.<(0, 0) == zero()
+      assert Nx.Defn.Kernel.<=(0, 0) == one()
     end
 
     test "and" do
-      assert Nx.Defn.Kernel.and(0, 0) == 0
-      assert Nx.Defn.Kernel.and(1, 0) == 0
-      assert Nx.Defn.Kernel.and(0, 2) == 0
-      assert Nx.Defn.Kernel.and(1, 1) == 1
+      assert Nx.Defn.Kernel.and(0, 0) == zero()
+      assert Nx.Defn.Kernel.and(1, 0) == zero()
+      assert Nx.Defn.Kernel.and(0, 2) == zero()
+      assert Nx.Defn.Kernel.and(1, 1) == one()
 
-      assert Nx.Defn.Kernel.and(0, 0.0) == 0.0
-      assert Nx.Defn.Kernel.and(1, 0.0) == 0.0
-      assert Nx.Defn.Kernel.and(0, 2.0) == 0.0
-      assert Nx.Defn.Kernel.and(1, 1.0) == 1.0
+      assert Nx.Defn.Kernel.and(0, 0.0) == zero()
+      assert Nx.Defn.Kernel.and(1, 0.0) == zero()
+      assert Nx.Defn.Kernel.and(0, 2.0) == zero()
+      assert Nx.Defn.Kernel.and(1, 1.0) == one()
     end
 
     test "or" do
-      assert Nx.Defn.Kernel.or(0, 0) == 0
-      assert Nx.Defn.Kernel.or(1, 0) == 1
-      assert Nx.Defn.Kernel.or(0, 2) == 1
-      assert Nx.Defn.Kernel.or(1, 1) == 1
+      assert Nx.Defn.Kernel.or(0, 0) == zero()
+      assert Nx.Defn.Kernel.or(1, 0) == one()
+      assert Nx.Defn.Kernel.or(0, 2) == one()
+      assert Nx.Defn.Kernel.or(1, 1) == one()
 
-      assert Nx.Defn.Kernel.or(0, 0.0) == 0.0
-      assert Nx.Defn.Kernel.or(1, 0.0) == 1.0
-      assert Nx.Defn.Kernel.or(0, 2.0) == 1.0
-      assert Nx.Defn.Kernel.or(1, 1.0) == 1.0
+      assert Nx.Defn.Kernel.or(0, 0.0) == zero()
+      assert Nx.Defn.Kernel.or(1, 0.0) == one()
+      assert Nx.Defn.Kernel.or(0, 2.0) == one()
+      assert Nx.Defn.Kernel.or(1, 1.0) == one()
     end
 
     test "not" do
-      assert Nx.Defn.Kernel.not(0) == 1
-      assert Nx.Defn.Kernel.not(1) == 0
-      assert Nx.Defn.Kernel.not(2) == 0
+      assert Nx.Defn.Kernel.not(0) == one()
+      assert Nx.Defn.Kernel.not(1) == zero()
+      assert Nx.Defn.Kernel.not(2) == zero()
 
-      assert Nx.Defn.Kernel.not(0.0) == 1.0
-      assert Nx.Defn.Kernel.not(1.0) == 0.0
-      assert Nx.Defn.Kernel.not(2.0) == 0.0
+      assert Nx.Defn.Kernel.not(0.0) == one()
+      assert Nx.Defn.Kernel.not(1.0) == zero()
+      assert Nx.Defn.Kernel.not(2.0) == zero()
     end
 
     test "&&&" do

--- a/nx/test/nx/defn/kernel_test.exs
+++ b/nx/test/nx/defn/kernel_test.exs
@@ -23,6 +23,15 @@ defmodule Nx.Defn.KernelTest do
       assert Nx.Defn.Kernel./(1, 2) == 0.5
     end
 
+    test "comparison" do
+      assert Nx.Defn.Kernel.==(0, 0) == 1
+      assert Nx.Defn.Kernel.!=(0, 0) == 0
+      assert Nx.Defn.Kernel.>(0, 0) == 0
+      assert Nx.Defn.Kernel.>=(0, 0) == 1
+      assert Nx.Defn.Kernel.<(0, 0) == 0
+      assert Nx.Defn.Kernel.<=(0, 0) == 1
+    end
+
     test "and" do
       assert Nx.Defn.Kernel.and(0, 0) == 0
       assert Nx.Defn.Kernel.and(1, 0) == 0

--- a/nx/test/nx/defn/tree_test.exs
+++ b/nx/test/nx/defn/tree_test.exs
@@ -54,12 +54,12 @@ defmodule Nx.Defn.TreeTest do
     test "converts scalars" do
       expr = Expr.tensor(Nx.tensor(3, type: {:s, 64}))
 
-      assert %T{data: %Expr{op: :scalar}, type: {:s, 32}} =
+      assert %T{data: %Expr{op: :constant}, type: {:s, 32}} =
                Tree.rewrite_types(expr, max_signed_type: {:s, 32})
 
       expr = Expr.tensor(Nx.tensor(3.0, type: {:f, 64}))
 
-      assert %T{data: %Expr{op: :scalar}, type: {:f, 32}} =
+      assert %T{data: %Expr{op: :constant}, type: {:f, 32}} =
                Tree.rewrite_types(expr, max_float_type: {:f, 32})
     end
 

--- a/nx/test/nx/defn_test.exs
+++ b/nx/test/nx/defn_test.exs
@@ -1166,7 +1166,7 @@ defmodule Nx.DefnTest do
       assert %T{data: %Expr{op: :parameter}, shape: {}, type: {:s, 64}} = initial
       assert %T{data: %Expr{op: :parameter}, shape: {}, type: {:s, 64}} = arg
       assert %T{data: %Expr{op: :less}, shape: {}, type: {:u, 8}} = condition
-      assert %T{data: %Expr{op: :scalar, args: [1]}, shape: {}, type: {:s, 64}} = body
+      assert %T{data: %Expr{op: :constant, args: [1]}, shape: {}, type: {:s, 64}} = body
     end
 
     defn factorial(x) do

--- a/torchx/lib/torchx/backend.ex
+++ b/torchx/lib/torchx/backend.ex
@@ -42,12 +42,12 @@ defmodule Torchx.Backend do
   ## Creation
 
   @impl true
-  def scalar(%T{shape: {}, type: type} = out, scalar, backend_options) do
+  def constant(%T{shape: {}, type: type} = out, scalar, backend_options) do
     Torchx.scalar_tensor(scalar, to_torch_type(type), device_option(backend_options))
     |> to_nx(out)
   end
 
-  def scalar(%T{shape: shape, type: type} = out, scalar, backend_options) do
+  def constant(%T{shape: shape, type: type} = out, scalar, backend_options) do
     Torchx.full(shape, scalar, to_torch_type(type), device_option(backend_options))
     |> to_nx(out)
   end


### PR DESCRIPTION
Otherwise someone can write this code:

```elixir
defn example(matrix) do
  {m, n} = Nx.shape(matrix)
  if m == n do
    ...
  else
    ...
  end
end
```

And a boolean would be given to `if`, making it raise. Alternatively we could allow booleans in `if`, `and`, etc. But I don't think we should go down this slippery slope yet. :D