### PR TITLE
Fix race condition on preloaded buffers

### DIFF
--- a/exla/c_src/exla/exla.cc
+++ b/exla/c_src/exla/exla.cc
@@ -207,8 +207,8 @@ ERL_NIF_TERM binary_to_device_mem(ErlNifEnv* env, int argc, const ERL_NIF_TERM a
   }
 
   EXLA_ASSIGN_OR_RETURN_NIF(exla::ExlaBuffer* buffer,
-    (*client)->BufferFromBinary(bin, *shape, device_id, false), env);
-
+    (*client)->BufferFromBinary(bin, *shape, device_id), env);
+  EXLA_EFFECT_OR_RETURN_NIF(buffer->BlockHostUntilReady(), env);
   return exla::nif::ok(env, exla::nif::make<exla::ExlaBuffer*>(env, buffer));
 }
 

--- a/exla/c_src/exla/exla.cc
+++ b/exla/c_src/exla/exla.cc
@@ -207,7 +207,7 @@ ERL_NIF_TERM binary_to_device_mem(ErlNifEnv* env, int argc, const ERL_NIF_TERM a
   }
 
   EXLA_ASSIGN_OR_RETURN_NIF(exla::ExlaBuffer* buffer,
-    (*client)->BufferFromBinary(bin, *shape, device_id), env);
+    (*client)->BufferFromBinary(bin, *shape, device_id, false), env);
   EXLA_EFFECT_OR_RETURN_NIF(buffer->BlockHostUntilReady(), env);
   return exla::nif::ok(env, exla::nif::make<exla::ExlaBuffer*>(env, buffer));
 }

--- a/exla/c_src/exla/exla_client.cc
+++ b/exla/c_src/exla/exla_client.cc
@@ -8,9 +8,7 @@
 
 namespace exla {
 
-ExlaBuffer::ExlaBuffer(std::unique_ptr<xla::PjRtBuffer> buffer,
-                       bool can_be_released_after_run): buffer_(std::move(buffer)),
-                                                        can_be_released_after_run_(can_be_released_after_run) {}
+ExlaBuffer::ExlaBuffer(std::unique_ptr<xla::PjRtBuffer> buffer): buffer_(std::move(buffer)) {}
 
 void CopyLiteralToBinary(xla::Literal* literal, ErlNifBinary* binary, exla::int64 size) {
   exla::int64 actual_size = literal->size_bytes();
@@ -20,7 +18,7 @@ void CopyLiteralToBinary(xla::Literal* literal, ErlNifBinary* binary, exla::int6
 }
 
 xla::StatusOr<ERL_NIF_TERM> ExlaBuffer::ToBinary(ErlNifEnv* env, exla::int64 size) {
-  buffer_->BlockHostUntilReady();
+  EXLA_EFFECT_OR_RETURN(buffer_->BlockHostUntilReady());
   EXLA_ASSIGN_OR_RETURN(std::shared_ptr<xla::Literal> literal, buffer_->ToLiteral());
 
   ErlNifBinary binary;
@@ -35,6 +33,10 @@ xla::StatusOr<ERL_NIF_TERM> ExlaBuffer::ToBinary(ErlNifEnv* env, exla::int64 siz
   }
 
   return nif::make(env, binary);
+}
+
+xla::Status ExlaBuffer::BlockHostUntilReady() {
+  return buffer_->BlockHostUntilReady();
 }
 
 xla::Status ExlaBuffer::Deallocate() {
@@ -76,7 +78,7 @@ xla::StatusOr<std::vector<ExlaBuffer*>> UnpackRunArguments(ErlNifEnv* env,
         return xla::InvalidArgument("Expected argument to be shape reference.");
       }
 
-      EXLA_ASSIGN_OR_RETURN(ExlaBuffer* buf, client->BufferFromBinary(data, *shape, device_id, true));
+      EXLA_ASSIGN_OR_RETURN(ExlaBuffer* buf, client->BufferFromBinary(data, *shape, device_id));
 
       arg_buffers.push_back(buf);
 
@@ -136,14 +138,8 @@ xla::StatusOr<ERL_NIF_TERM> ExlaExecutable::Run(ErlNifEnv* env,
   terms.reserve(input_buffers.size());
 
   for (auto buf : input_buffers) {
+    EXLA_EFFECT_OR_RETURN_NIF(buf->BlockHostUntilReady(), env);
     pjrt_buffers.push_back(buf->buffer());
-    // If the buffer was not received as a resource (e.g. we converted
-    // it from a binary to a buffer), we need to make it a resource so
-    // it's tracked and GC'ed along with other buffers that are no longer
-    // in use
-    if (buf->release_after_run()) {
-      terms.push_back(nif::make<ExlaBuffer*>(env, buf));
-    }
   }
 
   ERL_NIF_TERM ret;
@@ -165,14 +161,13 @@ ExlaClient::ExlaClient(std::shared_ptr<xla::PjRtClient> client) : client_(std::m
 
 xla::StatusOr<ExlaBuffer*> ExlaClient::BufferFromBinary(const ErlNifBinary& binary,
                                                         xla::Shape& shape,
-                                                        int device_id,
-                                                        bool can_be_released_after_run) {
-  xla::PjRtClient::HostBufferSemantics semantics = xla::PjRtClient::HostBufferSemantics::kZeroCopy;
+                                                        int device_id) {
+  xla::PjRtClient::HostBufferSemantics semantics = xla::PjRtClient::HostBufferSemantics::kImmutableUntilTransferCompletes;
 
   EXLA_ASSIGN_OR_RETURN(xla::PjRtDevice* device, client_->LookupDevice(device_id));
   EXLA_ASSIGN_OR_RETURN(auto buffer, client_->BufferFromHostBuffer(binary.data, shape, semantics, nullptr, device));
 
-  return new ExlaBuffer(std::move(buffer), can_be_released_after_run);
+  return new ExlaBuffer(std::move(buffer));
 }
 
 xla::StatusOr<ExlaExecutable*> ExlaClient::Compile(const xla::XlaComputation& computation,

--- a/exla/c_src/exla/exla_client.h
+++ b/exla/c_src/exla/exla_client.h
@@ -32,20 +32,15 @@ class ExlaDevice {
 
 class ExlaBuffer {
  public:
-  ExlaBuffer(std::unique_ptr<xla::PjRtBuffer> buffer,
-             bool can_be_released_after_run_ = false);
+  ExlaBuffer(std::unique_ptr<xla::PjRtBuffer> buffer);
 
   xla::PjRtBuffer* buffer() { return buffer_.get(); }
-
-  bool release_after_run() { return can_be_released_after_run_; }
-
   xla::StatusOr<ERL_NIF_TERM> ToBinary(ErlNifEnv* env, exla::int64 size);
-
+  xla::Status BlockHostUntilReady();
   xla::Status Deallocate();
 
  private:
   std::unique_ptr<xla::PjRtBuffer> buffer_;
-  bool can_be_released_after_run_;
 };
 
 class ExlaExecutable {
@@ -75,8 +70,7 @@ class ExlaClient {
 
   xla::PjRtClient* client() { return client_.get(); }
 
-  // Compiles the given computation with the given compile
-  // options
+  // Compiles the given computation with the given compile options
   xla::StatusOr<ExlaExecutable*> Compile(const xla::XlaComputation&,
                                          std::vector<xla::Shape*> argument_layouts,
                                          xla::ExecutableBuildOptions& options,
@@ -84,8 +78,7 @@ class ExlaClient {
 
   xla::StatusOr<ExlaBuffer*> BufferFromBinary(const ErlNifBinary& binary,
                                               xla::Shape& shape,
-                                              int device_id,
-                                              bool can_be_released_after_run);
+                                              int device_id);
 
   std::vector<ExlaDevice*> GetDevices();
 

--- a/exla/c_src/exla/exla_client.h
+++ b/exla/c_src/exla/exla_client.h
@@ -32,8 +32,10 @@ class ExlaDevice {
 
 class ExlaBuffer {
  public:
-  ExlaBuffer(std::unique_ptr<xla::PjRtBuffer> buffer);
+  ExlaBuffer(std::unique_ptr<xla::PjRtBuffer> buffer,
+             bool can_be_released_after_run_ = false);
 
+  bool release_after_run() { return can_be_released_after_run_; }
   xla::PjRtBuffer* buffer() { return buffer_.get(); }
   xla::StatusOr<ERL_NIF_TERM> ToBinary(ErlNifEnv* env, exla::int64 size);
   xla::Status BlockHostUntilReady();
@@ -41,6 +43,7 @@ class ExlaBuffer {
 
  private:
   std::unique_ptr<xla::PjRtBuffer> buffer_;
+  bool can_be_released_after_run_;
 };
 
 class ExlaExecutable {
@@ -78,7 +81,8 @@ class ExlaClient {
 
   xla::StatusOr<ExlaBuffer*> BufferFromBinary(const ErlNifBinary& binary,
                                               xla::Shape& shape,
-                                              int device_id);
+                                              int device_id,
+                                              bool can_be_released_after_run);
 
   std::vector<ExlaDevice*> GetDevices();
 

--- a/exla/c_src/exla/exla_nif_util.h
+++ b/exla/c_src/exla/exla_nif_util.h
@@ -337,6 +337,30 @@ ERL_NIF_TERM make_shape_info(ErlNifEnv* env, xla::Shape shape);
 
 #define EXLA_STATUS_MACROS_CONCAT_NAME_IMPL(x, y) x##y
 
+// Macro to be used to consume Status from within a NIF.
+// Return `{:error, msg}` if not ok.
+#define EXLA_EFFECT_OR_RETURN_NIF(rexpr, env)                                \
+  EXLA_EFFECT_OR_RETURN_NIF_IMPL(                                            \
+    EXLA_STATUS_MACROS_CONCAT_NAME(_status, __COUNTER__), rexpr, env)
+
+#define EXLA_EFFECT_OR_RETURN_NIF_IMPL(status, rexpr, env)                   \
+  auto status = (rexpr);                                                     \
+  if (!status.ok()) {                                                        \
+    return exla::nif::error(env, status.error_message().c_str());            \
+  }
+
+// Macro to be used to consume Status from within a NIF.
+// Return status if not ok.
+#define EXLA_EFFECT_OR_RETURN(rexpr)                                         \
+  EXLA_EFFECT_OR_RETURN_IMPL(                                                \
+    EXLA_STATUS_MACROS_CONCAT_NAME(_status, __COUNTER__), rexpr)
+
+#define EXLA_EFFECT_OR_RETURN_IMPL(status, rexpr)                            \
+  auto status = (rexpr);                                                     \
+  if (!status.ok()) {                                                        \
+    return status;                                                           \
+  }
+
 // Macro to be used to consume StatusOr from within a NIF. Will
 // bind lhs to value if the status is OK, otherwise will return
 // `{:error, msg}`.

--- a/exla/test/exla/buffer_test.exs
+++ b/exla/test/exla/buffer_test.exs
@@ -25,7 +25,7 @@ defmodule EXLA.BufferTest do
       :ok = Buffer.deallocate(b1.ref)
       assert binary == <<1::32, 2::32, 3::32, 4::32>>
 
-      assert_raise RuntimeError, "CopyToHostAsync() called on deleted or donated buffer", fn ->
+      assert_raise RuntimeError, ~r"called on deleted or donated buffer", fn ->
         Buffer.read(b1.ref)
       end
     end

--- a/exla/test/exla/defn/api_test.exs
+++ b/exla/test/exla/defn/api_test.exs
@@ -22,11 +22,11 @@ defmodule EXLA.Defn.APITest do
                <<4::64-native, 5::64-native, 6::64-native, 7::64-native>>
 
       assert_raise RuntimeError,
-                   "Invalid buffer passed to Execute() as argument 1 to replica 0: Invalid argument: Buffer has been deleted or donated.",
+                   ~r"called on deleted or donated buffer",
                    fn -> add_two_keep_on_device(Nx.tensor([[1, 2], [3, 4]]), tensor) end
 
       assert_raise RuntimeError,
-                   "CopyToHostAsync() called on deleted or donated buffer",
+                   ~r"called on deleted or donated buffer",
                    fn -> Nx.backend_transfer(tensor) end
     end
   end

--- a/exla/test/exla/defn/api_test.exs
+++ b/exla/test/exla/defn/api_test.exs
@@ -22,7 +22,7 @@ defmodule EXLA.Defn.APITest do
                <<4::64-native, 5::64-native, 6::64-native, 7::64-native>>
 
       assert_raise RuntimeError,
-                   ~r"called on deleted or donated buffer",
+                   ~r"Buffer has been deleted or donated",
                    fn -> add_two_keep_on_device(Nx.tensor([[1, 2], [3, 4]]), tensor) end
 
       assert_raise RuntimeError,

--- a/exla/test/exla/device_backend_test.exs
+++ b/exla/test/exla/device_backend_test.exs
@@ -18,7 +18,7 @@ defmodule EXLA.DeviceBackendTest do
     nt = Nx.backend_transfer(et)
     assert Nx.to_binary(nt) == <<1::64-native, 2::64-native, 3::64-native, 4::64-native>>
 
-    assert_raise RuntimeError, "CopyToHostAsync() called on deleted or donated buffer", fn ->
+    assert_raise RuntimeError, ~r"called on deleted or donated buffer", fn ->
       Nx.backend_transfer(et)
     end
   end
@@ -33,7 +33,7 @@ defmodule EXLA.DeviceBackendTest do
     nt = Nx.backend_transfer(et)
     assert Nx.to_binary(nt) == <<1::64-native, 2::64-native, 3::64-native, 4::64-native>>
 
-    assert_raise RuntimeError, "CopyToHostAsync() called on deleted or donated buffer", fn ->
+    assert_raise RuntimeError, ~r"called on deleted or donated buffer", fn ->
       Nx.backend_transfer(et)
     end
   end


### PR DESCRIPTION
We tagged the buffers as zero copy but the VM only
guarantees the binary won't be relocated during the
NIF call. So we set it to immutable until transfer
and block until ready.