### PR TITLE
Use macro escape to work with empty map

### DIFF
--- a/nx/lib/nx/container.ex
+++ b/nx/lib/nx/container.ex
@@ -125,7 +125,7 @@ defimpl Nx.Container, for: Any do
       defimpl Nx.Container, for: unquote(module) do
         def traverse(%{unquote_splicing(full_pattern)} = struct, var!(acc), var!(fun)) do
           unquote_splicing(updates)
-          {%{unquote_splicing(return)}, var!(acc)}
+          {%{unquote_splicing(Macro.escape(return))}, var!(acc)}
         end
 
         def reduce(%{unquote_splicing(container_pattern)} = struct, var!(acc), var!(fun)) do

--- a/nx/lib/nx/container.ex
+++ b/nx/lib/nx/container.ex
@@ -119,13 +119,23 @@ defimpl Nx.Container, for: Any do
         end
       end
 
-    return = struct |> Map.to_list() |> Keyword.merge(full_pattern)
+    return =
+      struct
+      |> Map.to_list()
+      |> Keyword.merge(full_pattern)
+      |> Enum.map(fn {k, v} = x ->
+        if k in keep or k in containers do
+          x
+        else
+          {k, Macro.escape(v)}
+        end
+      end)
 
     quote do
       defimpl Nx.Container, for: unquote(module) do
         def traverse(%{unquote_splicing(full_pattern)} = struct, var!(acc), var!(fun)) do
           unquote_splicing(updates)
-          {%{unquote_splicing(Macro.escape(return))}, var!(acc)}
+          {%{unquote_splicing(return)}, var!(acc)}
         end
 
         def reduce(%{unquote_splicing(container_pattern)} = struct, var!(acc), var!(fun)) do

--- a/nx/test/nx/defn/evaluator_test.exs
+++ b/nx/test/nx/defn/evaluator_test.exs
@@ -279,10 +279,10 @@ defmodule Nx.Defn.EvaluatorTest do
       container = %Container{a: 1, b: -1, c: :reset, d: :kept}
 
       assert container_cond(container, 1) ==
-               %Container{a: Nx.tensor(2), b: Nx.tensor(-1), c: nil, d: :kept}
+               %Container{a: Nx.tensor(2), b: Nx.tensor(-1), c: %{}, d: :kept}
 
       assert container_cond(container, 0) ==
-               %Container{a: Nx.tensor(1), b: Nx.tensor(-2), c: nil, d: :kept}
+               %Container{a: Nx.tensor(1), b: Nx.tensor(-2), c: %{}, d: :kept}
     end
   end
 

--- a/nx/test/support/container.ex
+++ b/nx/test/support/container.ex
@@ -1,4 +1,4 @@
 defmodule Container do
   @derive {Nx.Container, containers: [:a, :b], keep: [:d]}
-  defstruct [:a, :b, :c, :d, e: %{}]
+  defstruct [:a, :b, :c, d: %{}, e: %{}]
 end

--- a/nx/test/support/container.ex
+++ b/nx/test/support/container.ex
@@ -1,4 +1,4 @@
 defmodule Container do
   @derive {Nx.Container, containers: [:a, :b], keep: [:d]}
-  defstruct [:a, :b, :c, :d]
+  defstruct [:a, :b, :c, :d, e: %{}]
 end

--- a/nx/test/support/container.ex
+++ b/nx/test/support/container.ex
@@ -1,4 +1,4 @@
 defmodule Container do
   @derive {Nx.Container, containers: [:a, :b], keep: [:d]}
-  defstruct [:a, :b, :c, d: %{}, e: %{}]
+  defstruct [:a, :b, c: %{}, d: %{}]
 end


### PR DESCRIPTION
This fixed a compilation error for me for "reset" values in containers