### PR TITLE
Implement Nx.LinAlg.dot_power/2 (#582)

### DIFF
--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -967,4 +967,48 @@ defmodule Nx.LinAlg do
       opts
     )
   end
+
+  @doc """
+  Produces the tensor taken to the given power by dot-product.
+
+  The input is always a square tensor and a non-negative integer,
+  and the output is a square tensor of the same dimensions as the input tensor.
+
+  # Examples
+
+      iex> Nx.LinAlg.matrix_power(Nx.tensor([[1, 2], [3, 4]]), 6)
+      #Nx.Tensor<
+        s64[2][2]
+        [
+          [5743, 8370],
+          [12555, 18298]
+        ]
+      >
+
+      iex> Nx.LinAlg.matrix_power(Nx.eye(3), floor(:math.pow(2, 32))-1)
+      #Nx.Tensor<
+        s64[3][3]
+        [
+          [1, 0, 0],
+          [0, 1, 0],
+          [0, 0, 1]
+        ]
+      >
+
+  """
+  @doc from_backend: false
+  def matrix_power(matrix, 0) do
+    Nx.eye(matrix)
+  end
+  def matrix_power(matrix, power) do
+    Integer.digits(power, 2)
+    |> Enum.reverse()
+    |> Enum.reduce({Nx.eye(matrix), matrix}, fn bit, {result_matrix, exp_matrix} ->
+      case bit do
+        1 -> {Nx.dot(result_matrix, exp_matrix), Nx.dot(exp_matrix, exp_matrix)}
+        0 -> {result_matrix, Nx.dot(exp_matrix, exp_matrix)}
+      end
+    end)
+    |> elem(0)
+  end
 end

--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -1014,6 +1014,9 @@ defmodule Nx.LinAlg do
           [1.5, -0.5]
         ]
       >
+
+      iex> Nx.LinAlg.dot_power(Nx.tensor([[1, 2], [3, 4], [5, 6]]), 1)
+      ** (ArgumentError) expected tensor to match shape {x, x}, got tensor with shape {3, 2}
   """
   @doc from_backend: false
   def dot_power(tensor, power) when is_integer(power) and power < 0 do
@@ -1030,14 +1033,18 @@ defmodule Nx.LinAlg do
     # We also need a special case for 1, because the code
     # below is optimized for calculating powers for
     # integers where `length(Integer.digits(n, 2)) > 1`.
+    Nx.Defn.Kernel.assert_shape_pattern(tensor, {x, x})
+
     tensor
   end
 
   def dot_power(tensor, power) when is_integer(power) do
+    Nx.Defn.Kernel.assert_shape_pattern(tensor, {x, x})
+
     {result, exp_tensor} =
       power
       |> Integer.digits(2)
-      |> tl
+      |> tl()
       |> Enum.reverse()
       |> Enum.reduce({nil, tensor}, fn
         1, {nil, exp_tensor} ->

--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -1006,15 +1006,20 @@ defmodule Nx.LinAlg do
 
   """
   @doc from_backend: false
-  def matrix_power(matrix, power) when is_integer(power) and power >= 0 do
-    Integer.digits(power, 2)
+  def matrix_power(matrix, power) when is_integer(power) and power < 0 do
+    matrix_power(Nx.LinAlg.invert(matrix), -power)
+  end
+  def matrix_power(matrix, power) when is_integer(power) do
+    {result, _exp_matrix} = power
+    |> Integer.digits(2)
     |> Enum.reverse()
-    |> Enum.reduce({Nx.eye(matrix), matrix}, fn bit, {result_matrix, exp_matrix} ->
-      case bit do
-        1 -> {Nx.dot(result_matrix, exp_matrix), Nx.dot(exp_matrix, exp_matrix)}
-        0 -> {result_matrix, Nx.dot(exp_matrix, exp_matrix)}
-      end
+    |> Enum.reduce({Nx.eye(matrix), matrix}, fn
+      1, {result_matrix, exp_matrix} ->
+        {Nx.dot(result_matrix, exp_matrix), Nx.dot(exp_matrix, exp_matrix)}
+      0, {result_matrix, exp_matrix} ->
+        {result_matrix,                     Nx.dot(exp_matrix, exp_matrix)}
     end)
-    |> elem(0)
+
+    result
   end
 end

--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -975,7 +975,7 @@ defmodule Nx.LinAlg do
   and the output is a square tensor of the same dimensions as the input tensor.
 
   ## Examples
-  
+
       iex> Nx.LinAlg.matrix_power(Nx.tensor([[1, 2], [3, 4]]), 0)
       #Nx.Tensor<
         s64[2][2]
@@ -994,7 +994,7 @@ defmodule Nx.LinAlg do
         ]
       >
 
-      iex> Nx.LinAlg.matrix_power(Nx.eye(3), floor(:math.pow(2, 32))-1)
+      iex> Nx.LinAlg.matrix_power(Nx.eye(3), 65535)
       #Nx.Tensor<
         s64[3][3]
         [

--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -974,7 +974,8 @@ defmodule Nx.LinAlg do
   The input is always a square tensor and a non-negative integer,
   and the output is a square tensor of the same dimensions as the input tensor.
 
-  # Examples
+  ## Examples
+  
       iex> Nx.LinAlg.matrix_power(Nx.tensor([[1, 2], [3, 4]]), 0)
       #Nx.Tensor<
         s64[2][2]

--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -975,6 +975,14 @@ defmodule Nx.LinAlg do
   and the output is a square tensor of the same dimensions as the input tensor.
 
   # Examples
+      iex> Nx.LinAlg.matrix_power(Nx.tensor([[1, 2], [3, 4]]), 0)
+      #Nx.Tensor<
+        s64[2][2]
+        [
+          [1, 0],
+          [0, 1]
+        ]
+      >
 
       iex> Nx.LinAlg.matrix_power(Nx.tensor([[1, 2], [3, 4]]), 6)
       #Nx.Tensor<
@@ -997,10 +1005,7 @@ defmodule Nx.LinAlg do
 
   """
   @doc from_backend: false
-  def matrix_power(matrix, 0) do
-    Nx.eye(matrix)
-  end
-  def matrix_power(matrix, power) do
+  def matrix_power(matrix, power) when is_integer(power) and power >= 0 do
     Integer.digits(power, 2)
     |> Enum.reverse()
     |> Enum.reduce({Nx.eye(matrix), matrix}, fn bit, {result_matrix, exp_matrix} ->

--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -1020,7 +1020,7 @@ defmodule Nx.LinAlg do
   """
   @doc from_backend: false
   def dot_power(tensor, power) when is_integer(power) and power < 0 do
-    dot_power(Nx.LinAlg.invert(tensor), -power)
+    dot_power(invert(tensor), abs(power))
   end
 
   def dot_power(tensor, 0) do

--- a/torchx/test/torchx/nx_linalg_doctest_test.exs
+++ b/torchx/test/torchx/nx_linalg_doctest_test.exs
@@ -22,10 +22,10 @@ defmodule Torchx.NxLinAlgDoctestTest do
     norm: 2,
     # qr - Torchx: "geqrf_cpu" not implemented for 'Long' in NIF.qr/2
     qr: 2,
-    # invert - Depends on QR
+    # depends on QR
     invert: 1,
-    # solve - Depends on QR
     solve: 2,
+    dot_power: 2,
     # cholesky - returns the transposed result
     cholesky: 1
   ]


### PR DESCRIPTION
This PR implements the matrix_power function as requested in #582, using repeated squaring to calculate the power in logarithmic time.

Two doctests are provided, one to make sure that identity matrices don't change, and one to test a simple exponent case. This should be enoguh to catch serious implementation issues, and enough to provide documentation on what this function actually does.

Note that technically, if we were to ever support arbitrarily large numbers, this algorithm would take more in the neighborhood of linear time, as the multiplication of very large integers becomes slower with the width of such integers.