### PR TITLE
Allow users to use their own toolchain

### DIFF
--- a/torchx/Makefile
+++ b/torchx/Makefile
@@ -5,6 +5,9 @@ TORCHX_SO = $(PRIV_DIR)/torchx.so
 # CMAKE_BUILD_FLAGS = --verbose
 CMAKE_BUILD_DIR ?= $(MIX_APP_PATH)/cmake
 C_SRC = $(shell pwd)/c_src
+ifdef CMAKE_TOOLCHAIN_FILE
+	CMAKE_CONFIGURE_FLAGS=-DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)"
+endif
 
 .DEFAULT_GLOBAL := build
 
@@ -27,9 +30,6 @@ $(TORCHX_SO): c_src/torchx.cpp c_src/nx_nif_utils.hpp
 	else \
 		ln -sf $(abspath $(LIBTORCH_DIR)/lib) $(PRIV_DIR)/libtorch ; \
 	fi
-ifneq ($(CMAKE_TOOLCHAIN_FILE),)
-	CMAKE_CONFIGURE_FLAGS=-DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)"
-endif
 	@ cd $(CMAKE_BUILD_DIR) && \
 		cmake -DCMAKE_PREFIX_PATH=$(LIBTORCH_DIR) -DC_SRC=$(C_SRC) \
 			-DERTS_INCLUDE_DIR=$(ERTS_INCLUDE_DIR) -S $(shell pwd) \

--- a/torchx/Makefile
+++ b/torchx/Makefile
@@ -4,7 +4,6 @@ TORCHX_SO = $(PRIV_DIR)/torchx.so
 # If you want verbose output for debugging
 # CMAKE_BUILD_FLAGS = --verbose
 CMAKE_BUILD_DIR ?= $(MIX_APP_PATH)/cmake
-CMAKE_TOOLCHAIN_FILE ?= /dev/null
 C_SRC = $(shell pwd)/c_src
 
 .DEFAULT_GLOBAL := build
@@ -28,9 +27,13 @@ $(TORCHX_SO): c_src/torchx.cpp c_src/nx_nif_utils.hpp
 	else \
 		ln -sf $(abspath $(LIBTORCH_DIR)/lib) $(PRIV_DIR)/libtorch ; \
 	fi
+	echo "CMAKE_TOOLCHAIN_FILE: ${CMAKE_TOOLCHAIN_FILE}"
+ifneq ($(CMAKE_TOOLCHAIN_FILE),)
+	CMAKE_CONFIGURE_FLAGS=-DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)"
+endif
 	@ cd $(CMAKE_BUILD_DIR) && \
 		cmake -DCMAKE_PREFIX_PATH=$(LIBTORCH_DIR) -DC_SRC=$(C_SRC) \
 			-DERTS_INCLUDE_DIR=$(ERTS_INCLUDE_DIR) -S $(shell pwd) \
-			-DCMAKE_TOOLCHAIN_FILE=$(CMAKE_TOOLCHAIN_FILE) && \
+			$(CMAKE_CONFIGURE_FLAGS) && \
 		cmake --build . $(CMAKE_BUILD_FLAGS)
 	@ mv $(CMAKE_BUILD_DIR)/torchx.so $(TORCHX_SO)

--- a/torchx/Makefile
+++ b/torchx/Makefile
@@ -27,7 +27,6 @@ $(TORCHX_SO): c_src/torchx.cpp c_src/nx_nif_utils.hpp
 	else \
 		ln -sf $(abspath $(LIBTORCH_DIR)/lib) $(PRIV_DIR)/libtorch ; \
 	fi
-	echo "CMAKE_TOOLCHAIN_FILE: ${CMAKE_TOOLCHAIN_FILE}"
 ifneq ($(CMAKE_TOOLCHAIN_FILE),)
 	CMAKE_CONFIGURE_FLAGS=-DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)"
 endif

--- a/torchx/Makefile
+++ b/torchx/Makefile
@@ -4,7 +4,7 @@ TORCHX_SO = $(PRIV_DIR)/torchx.so
 # If you want verbose output for debugging
 # CMAKE_BUILD_FLAGS = --verbose
 CMAKE_BUILD_DIR ?= $(MIX_APP_PATH)/cmake
-CMAKE_TOOLCHAIN_FILE ?= $(shell pwd)/toolchain.cmake
+CMAKE_TOOLCHAIN_FILE ?= /dev/null
 C_SRC = $(shell pwd)/c_src
 
 .DEFAULT_GLOBAL := build
@@ -30,7 +30,7 @@ $(TORCHX_SO): c_src/torchx.cpp c_src/nx_nif_utils.hpp
 	fi
 	@ cd $(CMAKE_BUILD_DIR) && \
 		cmake -DCMAKE_PREFIX_PATH=$(LIBTORCH_DIR) -DC_SRC=$(C_SRC) \
-      	-DERTS_INCLUDE_DIR=$(ERTS_INCLUDE_DIR) -S $(shell pwd) \
-      	-DCMAKE_TOOLCHAIN_FILE=$(CMAKE_TOOLCHAIN_FILE) && \
+			-DERTS_INCLUDE_DIR=$(ERTS_INCLUDE_DIR) -S $(shell pwd) \
+			-DCMAKE_TOOLCHAIN_FILE=$(CMAKE_TOOLCHAIN_FILE) && \
 		cmake --build . $(CMAKE_BUILD_FLAGS)
 	@ mv $(CMAKE_BUILD_DIR)/torchx.so $(TORCHX_SO)

--- a/torchx/Makefile
+++ b/torchx/Makefile
@@ -4,6 +4,7 @@ TORCHX_SO = $(PRIV_DIR)/torchx.so
 # If you want verbose output for debugging
 # CMAKE_BUILD_FLAGS = --verbose
 CMAKE_BUILD_DIR ?= $(MIX_APP_PATH)/cmake
+CMAKE_TOOLCHAIN_FILE ?= $(shell pwd)/toolchain.cmake
 C_SRC = $(shell pwd)/c_src
 
 .DEFAULT_GLOBAL := build
@@ -29,6 +30,7 @@ $(TORCHX_SO): c_src/torchx.cpp c_src/nx_nif_utils.hpp
 	fi
 	@ cd $(CMAKE_BUILD_DIR) && \
 		cmake -DCMAKE_PREFIX_PATH=$(LIBTORCH_DIR) -DC_SRC=$(C_SRC) \
-      	-DERTS_INCLUDE_DIR=$(ERTS_INCLUDE_DIR) -S $(shell pwd) && \
+      	-DERTS_INCLUDE_DIR=$(ERTS_INCLUDE_DIR) -S $(shell pwd) \
+      	-DCMAKE_TOOLCHAIN_FILE=$(CMAKE_TOOLCHAIN_FILE) && \
 		cmake --build . $(CMAKE_BUILD_FLAGS)
 	@ mv $(CMAKE_BUILD_DIR)/torchx.so $(TORCHX_SO)


### PR DESCRIPTION
Allow users to use their own toolchain by setting env var "CMAKE_TOOLCHAIN_FILE". 

But I'm not sure if this is where you would like to put this empty CMake toolchain file (`torchx/toolchain.cmake`). If not, could you please suggest the best location for this file? Thanks!

Also, I had a thought that if we want to avoid adding an empty file, we can use

```
CMAKE_TOOLCHAIN_FILE ?= /dev/null
```

but that's probably not gonna work on systems that do not have a `/dev/null` (e.g., Windows), or its `/dev/null` behaves differently than what we would have expected.