### PR TITLE
Adding the Upsample layer support to AxonOnnx.Deserialize

### DIFF
--- a/torchx/c_src/nx_nif_utils.hpp
+++ b/torchx/c_src/nx_nif_utils.hpp
@@ -272,6 +272,25 @@ namespace nx
       return 1;
     }
 
+    int get_list(ErlNifEnv *env, ERL_NIF_TERM list, std::vector<double> &var)
+    {
+      unsigned int length;
+      if (!enif_get_list_length(env, list, &length))
+        return 0;
+      var.reserve(length);
+      ERL_NIF_TERM head, tail;
+
+      while (enif_get_list_cell(env, list, &head, &tail))
+      {
+        double elem;
+        if (!get(env, head, &elem))
+          return 0;
+        var.push_back(elem);
+        list = tail;
+      }
+      return 1;
+    }
+
     int get_list(ErlNifEnv *env, ERL_NIF_TERM list, std::vector<torch::Tensor> &var)
     {
       unsigned int length;

--- a/torchx/c_src/torchx.cpp
+++ b/torchx/c_src/torchx.cpp
@@ -395,7 +395,7 @@ NIF(interpolate)
   torch::Tensor result;
   if (argc == 2) 
   {
-    // The default mode is kNearest
+    // In case we receive (tensor, size) the default mode is kNearest
     LIST_PARAM(1, std::vector<int64_t>, size);
     result = F::interpolate(*t, 
 		    F::InterpolateFuncOptions()
@@ -403,7 +403,7 @@ NIF(interpolate)
 		    .size(size)
 	     );
   } else if (argc == 4) {
-    // In case we receive (tensor, size, mode, align_corners) we ignore the second parameter
+    // In case we receive (tensor, size, mode, align_corners) 
     LIST_PARAM(1, std::vector<int64_t>, size);
     MODE_PARAM(2, mode);
     PARAM(3, bool, align_corners);
@@ -414,11 +414,11 @@ NIF(interpolate)
 		    .align_corners(align_corners)
 	     );
   } else if (argc == 5) {
-    // In case we receive (tensor, size, align_corners, scale_factor, mode) we ignore the second parameter
+    // In case we receive (tensor, size, mode, align_corners, scale_factor) we ignore the size parameter
     TORCH_WARN("Ignoring size parameter");
-    PARAM(2, bool, align_corners);
-    LIST_PARAM(3, std::vector<double>, scale_factor);
-    MODE_PARAM(4, mode);
+    MODE_PARAM(2, mode);
+    PARAM(3, bool, align_corners);
+    LIST_PARAM(4, std::vector<double>, scale_factor);
     result = F::interpolate(*t, 
 		    F::InterpolateFuncOptions()
 		    .mode(mode)

--- a/torchx/lib/torchx.ex
+++ b/torchx/lib/torchx.ex
@@ -164,6 +164,9 @@ defmodule Torchx do
   deftensor gather(tensor_input, tensor_indices, axis)
   deftensor argsort(tensor, axis, is_descending)
   deftensor flip(tensor, axis)
+  deftensor interpolate(tensor, size)
+  deftensor interpolate(tensor, size, mode, align_corners)
+  deftensor interpolate(tensor, size, mode, align_corners, scale_factor)
 
   ## Aggregation
 


### PR DESCRIPTION
In order to start working on adding upsample layer type support for AxonOnnx, I started adding the interpolate Libtorch function (which is the current function superseding the upsample one).
So I added some new code trying to follow as much as possible the code style and function conventions.
Next steps will be:
1. add this somewhere into Nx (Maybe into Nx.LinAlg?) 
2. create the function into Axon.Deserialize

Are you interested into this functionality?