### PR TITLE
to avoid divided by 0.0 when all the elements of the tensor data are the same value.

### DIFF
--- a/nx/lib/nx/heatmap.ex
+++ b/nx/lib/nx/heatmap.ex
@@ -75,7 +75,7 @@ defmodule Nx.Heatmap do
     defp render(%{shape: {size}} = tensor, _opts, _doc, entry_fun, line_fun) do
       data = Nx.to_flat_list(tensor)
       {data, [], min, max} = take_min_max(data, size)
-      base = max - min
+      base = if max == min, do: 1, else: max - min
 
       data
       |> Enum.map(fn elem -> entry_fun.((elem - min) / base) end)
@@ -104,7 +104,7 @@ defmodule Nx.Heatmap do
 
     defp chunk([], acc, limit, {rows, cols, entry_fun, line_fun}, _docs) do
       {acc, rest, min, max} = take_min_max(acc, rows * cols)
-      base = max - min
+      base = if max == min, do: 1, else: max - min
 
       {[], doc} =
         Enum.reduce(1..rows, {acc, empty()}, fn _, {acc, doc} ->


### PR DESCRIPTION
The `to_heatmap` function causes exceptions by zero division when all the elements of the given tensor data are the same. In that case, the values of both `max` and `min` are the same so `base` becomes zero that will used as the divisor.
I made a quick hack to use 1 as the divisor instead of `base` to avoid zero-division. In this case, all the cell will be displayed as black. I use the integer 1 as the divisor because I expect the compiler might optimize to limit divide operations, but I am not sure about that.