### PR TITLE
Add: elementwise ops for numbers + Fix: window_reduce + Fix: typo

### DIFF
--- a/nx/lib/nx/binary_backend.ex
+++ b/nx/lib/nx/binary_backend.ex
@@ -593,6 +593,12 @@ defmodule Nx.BinaryBackend do
     end
   end
 
+  defp element_wise_bin_op(out, left, right, fun) when is_number(left) or is_number(right) do
+    left = if is_number(left), do: Nx.to_tensor(left), else: left
+    right = if is_number(right), do: Nx.to_tensor(right), else: right
+    element_wise_bin_op(out, left, right, fun)
+  end
+
   defp element_wise_bin_op(%{type: type} = out, %{shape: {}} = left, right, fun) do
     number = to_number(left)
 
@@ -761,7 +767,9 @@ defmodule Nx.BinaryBackend do
   defp element_popcount(0, count), do: count
   defp element_popcount(n, count), do: element_popcount(n &&& n - 1, count + 1)
 
-  defp element_wise_unary_op(out, tensor, fun) do
+  defp element_wise_unary_op(out, arg, fun) do
+    tensor = if is_number(arg), do: Nx.to_tensor(arg), else: arg
+
     data =
       match_types [tensor.type, out.type] do
         for <<match!(seg, 0) <- to_binary(tensor)>>, into: <<>> do
@@ -1352,7 +1360,7 @@ defmodule Nx.BinaryBackend do
               reduce: acc,
               do: (acc -> fun.(read!(x, 0), acc))
 
-          <<write!(window_val, 0)>>
+          <<write!(to_number(window_val), 0)>>
         end
       end
 

--- a/nx/lib/nx/defn/tree.ex
+++ b/nx/lib/nx/defn/tree.ex
@@ -45,7 +45,7 @@ defmodule Nx.Defn.Tree do
   end
 
   @doc """
-  Replces args in the given tensor expression.
+  Replaces args in the given tensor expression.
 
   Use this function with extreme care. Changing the args but keeping
   the same id may mean you have different versions of the same node.
@@ -57,7 +57,7 @@ defmodule Nx.Defn.Tree do
   end
 
   @doc """
-  Apples the given function and accumulator to the args of the node.
+  Applies the given function and accumulator to the args of the node.
 
   Warning: be very careful when using this function to traverse the expression
   recursively. If you plan to do so, you should consider also storing the visited

--- a/nx/lib/nx/defn/tree.ex
+++ b/nx/lib/nx/defn/tree.ex
@@ -57,7 +57,7 @@ defmodule Nx.Defn.Tree do
   end
 
   @doc """
-  Applies the given function and accumulator to the args of the node.
+  Applies the given function to the arguments of the node, with the given accumulator as a starting value.
 
   Warning: be very careful when using this function to traverse the expression
   recursively. If you plan to do so, you should consider also storing the visited

--- a/nx/test/nx/defn/evaluator_test.exs
+++ b/nx/test/nx/defn/evaluator_test.exs
@@ -32,6 +32,13 @@ defmodule Nx.Defn.EvaluatorTest do
     assert %T{shape: {3, 2}, type: {:s, 64}} = reshape(Nx.iota({2, 3}))
   end
 
+  defn reduce_window(t1, acc),
+    do: Nx.window_reduce(t1, acc, {2}, [padding: :valid], fn x, acc -> x + acc end)
+
+  test "window reduce" do
+    assert reduce_window(Nx.tensor([1, 2, 3]), 0) == Nx.tensor([3, 5])
+  end
+
   describe "decompositions" do
     defn lu(t), do: Nx.LinAlg.lu(t)
 


### PR DESCRIPTION
#587 
There's a case when an element_wise operation is appled to a number. Maybe it's ok to convert it to scalar just before the operation.