### PR TITLE
Propagate device_id option to EXLA computation

### DIFF
--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -318,7 +318,7 @@ defmodule EXLA.Defn do
         {computation, extra, hooks} =
           to_computation.(expr || fun.(vars), inputs_and_shapes, used_hooks)
 
-        executable = EXLA.Computation.compile(computation, client, shapes)
+        executable = EXLA.Computation.compile(computation, client, shapes, options)
         {nil, {executable, extra, hooks}}
       end)
 

--- a/exla/test/exla/defn/api_test.exs
+++ b/exla/test/exla/defn/api_test.exs
@@ -33,6 +33,12 @@ defmodule EXLA.Defn.APITest do
                    ~r"called on deleted or donated buffer",
                    fn -> Nx.backend_transfer(tensor) end
     end
+
+    test "raises on invalid device_id" do
+      assert_raise RuntimeError, ~r"Invalid device ordinal value \(1\)", fn ->
+        EXLA.jit(&add_two_keep_on_device/2, [2, 3], device_id: 1)
+      end
+    end
   end
 
   describe "containers" do


### PR DESCRIPTION
Currently the `device_id` configured in global defn options is ignored by EXLA.