### PR TITLE
Add keep_axis to argmin and argmax

### DIFF
--- a/exla/test/exla/defn/expr_test.exs
+++ b/exla/test/exla/defn/expr_test.exs
@@ -1526,6 +1526,8 @@ defmodule EXLA.Defn.ExprTest do
     defn argmin_axis(t), do: Nx.argmin(t, axis: 1)
     defn argmax_high(t), do: Nx.argmax(t, axis: 1, tie_break: :high)
     defn argmin_high(t), do: Nx.argmin(t, axis: 1, tie_break: :high)
+    defn argmax_keep_axis(t), do: Nx.argmax(t, axis: 1, keep_axis: true)
+    defn argmin_keep_axis(t), do: Nx.argmin(t, axis: 1, keep_axis: true)
 
     test "computes the argmax across types" do
       assert argmax(Nx.tensor([1, 2, 3])) == Nx.tensor(2)
@@ -1560,6 +1562,22 @@ defmodule EXLA.Defn.ExprTest do
     test "computes argmax with tie_break: :high" do
       assert argmax_axis(Nx.tensor([[1, 2, 2], [1, 2, 2]])) == Nx.tensor([1, 1])
       assert argmax_high(Nx.tensor([[1, 2, 2], [1, 2, 2]])) == Nx.tensor([2, 2])
+    end
+
+    test "computes argmax with keep_axis: true" do
+      assert argmax_keep_axis(Nx.tensor([[[4, 2, 3], [1, -5, 3]], [[6, 2, 3], [4, 8, 3]]])) ==
+               Nx.tensor([
+                 [[0, 0, 0]],
+                 [[0, 1, 0]]
+               ])
+    end
+
+    test "computes argmin with keep_axis: true" do
+      assert argmin_keep_axis(Nx.tensor([[[4, 2, 3], [1, -5, 3]], [[6, 2, 3], [4, 8, 3]]])) ==
+               Nx.tensor([
+                 [[1, 1, 0]],
+                 [[1, 0, 0]]
+               ])
     end
   end
 

--- a/nx/test/nx/defn/expr_test.exs
+++ b/nx/test/nx/defn/expr_test.exs
@@ -225,13 +225,13 @@ defmodule Nx.Defn.ExprTest do
                s64
              \s\s
                Nx.Defn.Expr
-               tensor b                                    s64[2][2]
-               parameter e:2                               s64[2][2]
-               a = iota nil                                s64[2][2]
-               c = dot a, [1], [], b, [0], []              s64[2][2]
-               d = tanh c                                  f32[2][2]
-               f = add d, e                                f32[2][2]
-               g = argmin f, tie_break: :high, axis: nil   s64
+               tensor b                                                      s64[2][2]
+               parameter e:2                                                 s64[2][2]
+               a = iota nil                                                  s64[2][2]
+               c = dot a, [1], [], b, [0], []                                s64[2][2]
+               d = tanh c                                                    f32[2][2]
+               f = add d, e                                                  f32[2][2]
+               g = argmin f, tie_break: :high, axis: nil, keep_axis: false   s64
              >\
              """
     end


### PR DESCRIPTION
ONNX supports this option in argmin and argmax, and we support this for all other reductions, so I figured it made sense :)