### PR TITLE
use :dll_loader_helper from hex.pm

### DIFF
--- a/torchx/mix.exs
+++ b/torchx/mix.exs
@@ -46,7 +46,7 @@ defmodule Torchx.MixProject do
   defp deps do
     [
       {:nx, path: "../nx"},
-      {:dll_loader_helper, git: "https://github.com/cocoa-xu/dll_loader_helper.git"},
+      {:dll_loader_helper, "~> 0.1.0"},
       {:elixir_make, "~> 0.6"},
       {:ex_doc, "~> 0.23", only: :dev}
     ]

--- a/torchx/mix.lock
+++ b/torchx/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "dll_loader_helper": {:git, "https://github.com/cocoa-xu/dll_loader_helper.git", "b257702395aa424858e55ef68720a3a1bd64c2c4", []},
+  "dll_loader_helper": {:hex, :dll_loader_helper, "0.1.0", "904c3cec32e6e0fc5914e41989ce9350d2bfd06b32f952a658fe63342b993e83", [:make, :mix], [{:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm", "b9db9151af610a2db375af543e912b3dd9cad87377d829328888386c65681473"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.12", "b245e875ec0a311a342320da0551da407d9d2b65d98f7a9597ae078615af3449", [:mix], [], "hexpm", "711e2cc4d64abb7d566d43f54b78f7dc129308a63bc103fbd88550d2174b3160"},
   "elixir_make": {:hex, :elixir_make, "0.6.2", "7dffacd77dec4c37b39af867cedaabb0b59f6a871f89722c25b28fcd4bd70530", [:mix], [], "hexpm", "03e49eadda22526a7e5279d53321d1cced6552f344ba4e03e619063de75348d9"},
   "ex_doc": {:hex, :ex_doc, "0.23.0", "a069bc9b0bf8efe323ecde8c0d62afc13d308b1fa3d228b65bca5cf8703a529d", [:mix], [{:earmark_parser, "~> 1.4.0", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "f5e2c4702468b2fd11b10d39416ddadd2fcdd173ba2a0285ebd92c39827a5a16"},


### PR DESCRIPTION
I've published the `:dll_loader_helper` library to hex.pm, and now we can use it as a hex package.