### PR TITLE
Added instructions for downloading precompiled libtorch for Apple M1

### DIFF
--- a/torchx/README.md
+++ b/torchx/README.md
@@ -59,7 +59,13 @@ Once downloaded, we will compile `Torchx` bindings. You will need `make`/`nmake`
 - [Microsoft Visual C++ 2019 Redistributable](https://visualstudio.microsoft.com/downloads/)
 - [CMake](https://cmake.org/)
 
-Currently there are no precompiled versions available for Apple M1. [See this issue
+For Apple M1-series, you can download precompiled LibTorch binaries if you are using HomeBrew,
+```shell
+brew install libtorch
+export LIBTORCH_DIR="$(brew --cellar libtorch)/$(brew list --versions libtorch | tr ' ' '\n' | tail -1)"
+```
+
+Currently there are no other precompiled versions available for Apple M1. [See this issue
 for more context](https://github.com/elixir-nx/nx/issues/593). Other platforms may
 also require compiling `libtorch` from scratch.
 

--- a/torchx/README.md
+++ b/torchx/README.md
@@ -63,11 +63,12 @@ For Apple M1-series, you can download precompiled LibTorch binaries if you are u
 ```shell
 brew install libtorch
 export LIBTORCH_DIR="$(brew --cellar libtorch)/$(brew list --versions libtorch | tr ' ' '\n' | tail -1)"
+# for convenience, the export above can be added to your .bashrc, .zshrc or equivalent
+# adding to .bashrc for example
+echo -e "\nexport LIBTORCH_DIR=\"${LIBTORCH_DIR}\"" >> .bashrc
 ```
 
-Currently there are no other precompiled versions available for Apple M1. [See this issue
-for more context](https://github.com/elixir-nx/nx/issues/593). Other platforms may
-also require compiling `libtorch` from scratch.
+Other platforms may require compiling `libtorch` from scratch.
 
 ## Usage
 

--- a/torchx/mix.exs
+++ b/torchx/mix.exs
@@ -10,7 +10,10 @@ defmodule Torchx.MixProject do
   @libtorch_target System.get_env("LIBTORCH_TARGET", "cpu")
 
   @libtorch_base "libtorch"
-  @libtorch_dir System.get_env("LIBTORCH_DIR", Path.join(__DIR__, "cache/libtorch-#{@libtorch_version}-#{@libtorch_target}"))
+  @libtorch_dir System.get_env(
+                  "LIBTORCH_DIR",
+                  Path.join(__DIR__, "cache/libtorch-#{@libtorch_version}-#{@libtorch_target}")
+                )
   @libtorch_compilers [:torchx, :elixir_make]
 
   def project do
@@ -107,9 +110,13 @@ defmodule Torchx.MixProject do
             # MacOS
             # pytorch only provides pre-built binaries for x86_64
             case List.to_string(:erlang.system_info(:system_architecture)) do
-              "x86_64" <> _ -> "https://download.pytorch.org/libtorch/#{@libtorch_target}/libtorch-macos-#{@libtorch_version}.zip"
+              "x86_64" <> _ ->
+                "https://download.pytorch.org/libtorch/#{@libtorch_target}/libtorch-macos-#{@libtorch_version}.zip"
+
               _ ->
-                Mix.error("Please download pre-built/compile LibTorch and set environment variable LIBTORCH_DIR")
+                Mix.error(
+                  "Please download pre-built/compile LibTorch and set environment variable LIBTORCH_DIR"
+                )
             end
 
           {:win32, :nt} ->

--- a/torchx/mix.exs
+++ b/torchx/mix.exs
@@ -108,7 +108,7 @@ defmodule Torchx.MixProject do
 
           {:unix, :darwin} ->
             # MacOS
-            # pytorch only provides pre-built binaries for x86_64
+            # pytorch only provides official pre-built binaries for x86_64
             case List.to_string(:erlang.system_info(:system_architecture)) do
               "x86_64" <> _ ->
                 "https://download.pytorch.org/libtorch/#{@libtorch_target}/libtorch-macos-#{@libtorch_version}.zip"

--- a/torchx/mix.exs
+++ b/torchx/mix.exs
@@ -10,7 +10,7 @@ defmodule Torchx.MixProject do
   @libtorch_target System.get_env("LIBTORCH_TARGET", "cpu")
 
   @libtorch_base "libtorch"
-  @libtorch_dir Path.join(__DIR__, "cache/libtorch-#{@libtorch_version}-#{@libtorch_target}")
+  @libtorch_dir System.get_env("LIBTORCH_DIR", Path.join(__DIR__, "cache/libtorch-#{@libtorch_version}-#{@libtorch_target}"))
   @libtorch_compilers [:torchx, :elixir_make]
 
   def project do
@@ -105,7 +105,12 @@ defmodule Torchx.MixProject do
 
           {:unix, :darwin} ->
             # MacOS
-            "https://download.pytorch.org/libtorch/#{@libtorch_target}/libtorch-macos-#{@libtorch_version}.zip"
+            # pytorch only provides pre-built binaries for x86_64
+            case List.to_string(:erlang.system_info(:system_architecture)) do
+              "x86_64" <> _ -> "https://download.pytorch.org/libtorch/#{@libtorch_target}/libtorch-macos-#{@libtorch_version}.zip"
+              _ ->
+                Mix.error("Please download pre-built/compile LibTorch and set environment variable LIBTORCH_DIR")
+            end
 
           {:win32, :nt} ->
             # Windows


### PR DESCRIPTION
Currently the `mix.exs` script downloads precompiled LibTorch binaries for `x86_64` on Apple M1-series Macs. This patch checks for the system architecture and adds instructions for downloading precompiled LibTorch for Apple M1-series with HomeBrew.