### PR TITLE
EXLA: use -I flag instead of -isystem

### DIFF
--- a/exla/Makefile
+++ b/exla/Makefile
@@ -14,7 +14,7 @@ EXLA_SO = $(PRIV_DIR)/libexla.so
 EXLA_LIB_DIR = $(PRIV_DIR)/lib
 
 # Build Flags
-CFLAGS = -fPIC -I$(ERTS_INCLUDE_DIR) -isystem $(XLA_INCLUDE_PATH) -O3 -Wall -Wextra \
+CFLAGS = -fPIC -I$(ERTS_INCLUDE_DIR) -I$(XLA_INCLUDE_PATH) -O3 -Wall -Wextra \
 	 -Wno-unused-parameter -Wno-missing-field-initializers -Wno-comment \
 	 -shared -std=c++14
 


### PR DESCRIPTION
Close #511. Note that I did not investigate why `-isystem` fails instead!