### PR TITLE
fix: do not re-sort contracting axes for generalized dot product

### DIFF
--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -7180,7 +7180,6 @@ defmodule Nx do
         50.0
       >
 
-
   """
   @doc type: :ndim
   def dot(t1, contract_axes1, t2, contract_axes2) do

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -7172,6 +7172,15 @@ defmodule Nx do
         ]
       >
 
+      iex> t1 = Nx.tensor([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]])
+      iex> t2 = Nx.tensor([[0.0, 1.0], [2.0, 3.0], [4.0, 5.0]])
+      iex> Nx.dot(t1, [0, 1], t2, [1, 0])
+      #Nx.Tensor<
+        f32
+        50.0
+      >
+
+
   """
   @doc type: :ndim
   def dot(t1, contract_axes1, t2, contract_axes2) do

--- a/nx/lib/nx/binary_backend.ex
+++ b/nx/lib/nx/binary_backend.ex
@@ -534,6 +534,10 @@ defmodule Nx.BinaryBackend do
   end
 
   defp bin_dot_transpose_contract_axes(tensor, contract_axes) do
+    # The intution here is that we can pre-condense the contracting axes into a
+    # single dimension, which will then be contracted through bin_zip_reduce below.
+    # This takes a shape {a, m, n, b} which contracts on m, n and turns it into
+    # {m * n, a, b}, contracting on the first dimension.
     remaining_axes =
       contract_axes
       |> Enum.sort(:desc)

--- a/nx/lib/nx/binary_backend.ex
+++ b/nx/lib/nx/binary_backend.ex
@@ -525,11 +525,10 @@ defmodule Nx.BinaryBackend do
 
     {right, right_contract_axes} = bin_dot_transpose_contract_axes(right, contract_axes2)
 
-    bin_zip_reduce(left, left_contract_axes, right, right_contract_axes, type, 0, fn lhs,
-                                                                                     rhs,
-                                                                                     acc ->
-      res = binary_to_number(lhs, t1) * binary_to_number(rhs, t2) + acc
-      {res, res}
+    bin_zip_reduce(left, left_contract_axes, right, right_contract_axes, type, 0, fn
+      lhs, rhs, acc ->
+        res = binary_to_number(lhs, t1) * binary_to_number(rhs, t2) + acc
+        {res, res}
     end)
   end
 

--- a/nx/lib/nx/binary_backend.ex
+++ b/nx/lib/nx/binary_backend.ex
@@ -538,7 +538,7 @@ defmodule Nx.BinaryBackend do
     # This takes a shape {a, m, n, b} which contracts on m, n and turns it into
     # {m * n, a, b}, contracting on the first dimension.
 
-    axes = Enum.to_list(0..(tuple_size(tensor.shape) - 1)//1)
+    axes = Nx.axes(tensor)
 
     remaining_axes =
       contract_axes

--- a/nx/lib/nx/binary_backend.ex
+++ b/nx/lib/nx/binary_backend.ex
@@ -536,7 +536,9 @@ defmodule Nx.BinaryBackend do
     # The intution here is that we can pre-condense the contracting axes into a
     # single dimension, which will then be contracted through bin_zip_reduce below.
     # This takes a shape {a, m, n, b} which contracts on m, n and turns it into
-    # {a, b, m * n}, contracting on the last dimension.
+    # {a, b, m * n}, contracting on the last dimension. This is necessary because
+    # bin_zip_reduce and aggregate_axes are order independent but dot depends
+    # on the axes order.
 
     axes = Nx.axes(tensor)
 

--- a/nx/lib/nx/binary_backend.ex
+++ b/nx/lib/nx/binary_backend.ex
@@ -520,11 +520,84 @@ defmodule Nx.BinaryBackend do
     from_binary(out, bin_result)
   end
 
-  defp bin_dot(%{type: t1} = left, contract_axes1, %{type: t2} = right, contract_axes2, type) do
+  defp bin_dot(
+         %{type: t1} = left,
+         [_] = contract_axes1,
+         %{type: t2} = right,
+         [_] = contract_axes2,
+         type
+       ) do
+    # base clause for when there's only one contracting axis
     bin_zip_reduce(left, contract_axes1, right, contract_axes2, type, 0, fn lhs, rhs, acc ->
       res = binary_to_number(lhs, t1) * binary_to_number(rhs, t2) + acc
       {res, res}
     end)
+  end
+
+  defp bin_dot(left, left_contracting_axes, right, right_contracting_axes, type) do
+    # First, we transpose the contracting axes to the inner dimensions.
+    # That is, we transpose the contracting axes of the left tensor to
+    # the rightmost dimensions and and the contracting axes of the right
+    # tensor to the leftmost dimensions.
+    # This is so we can intuively make an analogy with matrix multiplication
+    # in which A(m x n) . B(n x k) results in C(m x k).
+
+    left_axes = Nx.axes(left)
+    right_axes = Nx.axes(right)
+
+    remove_contracting_axes = fn axes, to_remove ->
+      to_remove
+      |> Enum.sort(:desc)
+      |> Enum.reduce(axes, &List.delete_at(&2, &1))
+    end
+
+    left_remaining_axes = remove_contracting_axes.(left_axes, left_contracting_axes)
+    right_remaining_axes = remove_contracting_axes.(right_axes, right_contracting_axes)
+
+    left_transpose_axes = left_remaining_axes ++ left_contracting_axes
+
+    {left_transposed_shape, _} = Nx.Shape.transpose(left.shape, left_transpose_axes, left.names)
+
+    left_transposed =
+      transpose(
+        %{left | shape: left_transposed_shape},
+        left,
+        left_transpose_axes
+      )
+
+    right_transpose_axes = right_contracting_axes ++ right_remaining_axes
+
+    {right_transposed_shape, _} =
+      Nx.Shape.transpose(right.shape, right_transpose_axes, right.names)
+
+    right_transposed =
+      transpose(
+        %{right | shape: right_transposed_shape},
+        right,
+        right_transpose_axes
+      )
+
+    {left_outer_axes, left_contracting_dims} =
+      left_transposed_shape |> Tuple.to_list() |> Enum.split(-length(left_contracting_axes))
+
+    left_reduced_shape =
+      left_outer_axes |> Enum.concat([Enum.product(left_contracting_dims)]) |> List.to_tuple()
+
+    {right_contracting_dims, right_outer_axes} =
+      right_transposed_shape |> Tuple.to_list() |> Enum.split(length(right_contracting_axes))
+
+    right_reduced_shape = List.to_tuple([Enum.product(right_contracting_dims) | right_outer_axes])
+
+    IO.inspect(left_reduced_shape, label: "left_reduced_shape")
+    IO.inspect(right_reduced_shape, label: "right_reduced_shape")
+
+    bin_dot(
+      %{left_transposed | shape: left_reduced_shape},
+      [-1],
+      %{right_transposed | shape: right_reduced_shape},
+      [0],
+      type
+    )
   end
 
   ## Element wise ternary ops

--- a/nx/test/nx_test.exs
+++ b/nx/test/nx_test.exs
@@ -1109,13 +1109,39 @@ defmodule NxTest do
     end
   end
 
+  describe "dot/4" do
+    test "does not re-sort the contracting axes" do
+      left = Nx.iota({2, 7, 8, 3, 1})
+      right = Nx.iota({1, 8, 3, 7, 3})
+
+      result = Nx.dot(left, [3, 1, 2], right, [2, 3, 1])
+
+      assert {2, 1, 1, 3} == result.shape
+
+      # Expected result obtained from pytorch
+      assert result ==
+               Nx.tensor([
+                 [
+                   [
+                     [3_731_448, 3_745_476, 3_759_504]
+                   ]
+                 ],
+                 [
+                   [
+                     [10_801_560, 10_843_812, 10_886_064]
+                   ]
+                 ]
+               ])
+    end
+  end
+
   describe "dot/6" do
     test "works with batched dot and different size non-batch dims" do
       t1 = Nx.iota({3, 2, 4, 1})
       t2 = Nx.iota({3, 4, 2, 2})
 
       assert Nx.dot(t1, [1, 2], [0], t2, [2, 1], [0]) ==
-               Nx.tensor([[[280, 308]], [[2200, 2292]], [[6168, 6324]]])
+               Nx.tensor([[[252, 280]], [[2172, 2264]], [[6140, 6296]]])
     end
 
     test "works with multiple batch dimensions" do


### PR DESCRIPTION
closes #612