### PR TITLE
feat(torchx): overhaul window functions (+ sum and product)

### DIFF
--- a/torchx/c_src/torchx.cpp
+++ b/torchx/c_src/torchx.cpp
@@ -368,6 +368,16 @@ NIF(flip)
   TENSOR(torch::flip(*input, dims));
 }
 
+NIF(unfold)
+{
+  TENSOR_PARAM(0, input);
+  PARAM(1, int64_t, dim);
+  PARAM(2, int64_t, size);
+  PARAM(3, int64_t, step);
+
+  TENSOR(at::native::unfold(*input, dim, size, step));
+}
+
 NIF(permute)
 {
   TENSOR_PARAM(0, t);
@@ -940,6 +950,7 @@ static ErlNifFunc nif_functions[] = {
     DF(indexed_add, 4),
     DF(argsort, 3),
     DF(flip, 2),
+    DF(unfold, 4),
 
     DF(add, 2),
     DF(subtract, 2),

--- a/torchx/lib/torchx.ex
+++ b/torchx/lib/torchx.ex
@@ -163,6 +163,7 @@ defmodule Torchx do
   deftensor indexed_add(tensor_input, tensor_indices, tensor_updates, axis)
   deftensor argsort(tensor, axis, is_descending)
   deftensor flip(tensor, axis)
+  deftensor unfold(tensor, dimension, size, step)
   deftensor where(tensorA, tensorB, tensorC)
 
   ## Aggregation

--- a/torchx/lib/torchx/backend.ex
+++ b/torchx/lib/torchx/backend.ex
@@ -1019,8 +1019,8 @@ defmodule Torchx.Backend do
     end)
   end
 
-  def window_op(out, tensor, window_dims_tuple, opts, reduce_fun)
-      when is_function(reduce_fun, 2) do
+  defp window_op(out, tensor, window_dims_tuple, opts, reduce_fun)
+       when is_function(reduce_fun, 2) do
     if opts[:window_dilations] != List.duplicate(1, tuple_size(tensor.shape)) do
       raise ArgumentError, "window_dilations unsupported"
     end

--- a/torchx/test/torchx/nx_doctest_test.exs
+++ b/torchx/test/torchx/nx_doctest_test.exs
@@ -75,14 +75,15 @@ defmodule Torchx.NxDoctestTest do
   @pending_doctests [
     # window_max - still needs to support padding and window_dilations
     window_max: 3,
-    put_slice: 3,
     # window_min - still needs to support padding and window_dilations
     window_min: 3,
+    # window_product - still needs to support padding and window_dilations
     window_product: 3,
-    window_scatter_max: 5,
-    window_scatter_min: 5,
     # window_sum - still needs to support padding and window_dilations
-    window_sum: 3
+    window_sum: 3,
+    put_slice: 3,
+    window_scatter_max: 5,
+    window_scatter_min: 5
   ]
 
   doctest Nx,

--- a/torchx/test/torchx/nx_doctest_test.exs
+++ b/torchx/test/torchx/nx_doctest_test.exs
@@ -73,15 +73,16 @@ defmodule Torchx.NxDoctestTest do
   ]
 
   @pending_doctests [
-    # window_max - still needs to support padding
+    # window_max - still needs to support padding and window_dilations
     window_max: 3,
     put_slice: 3,
-    # window_min - still needs to support padding
+    # window_min - still needs to support padding and window_dilations
     window_min: 3,
     window_product: 3,
     window_scatter_max: 5,
     window_scatter_min: 5,
-    # window_sum: 3
+    # window_sum - still needs to support padding and window_dilations
+    window_sum: 3
   ]
 
   doctest Nx,

--- a/torchx/test/torchx/nx_doctest_test.exs
+++ b/torchx/test/torchx/nx_doctest_test.exs
@@ -81,7 +81,7 @@ defmodule Torchx.NxDoctestTest do
     window_product: 3,
     window_scatter_max: 5,
     window_scatter_min: 5,
-    window_sum: 3
+    # window_sum: 3
   ]
 
   doctest Nx,

--- a/torchx/test/torchx/nx_test.exs
+++ b/torchx/test/torchx/nx_test.exs
@@ -583,12 +583,29 @@ defmodule Torchx.NxTest do
       )
     end
 
-    test "fails with non-zero padding" do
-      assert_raise ArgumentError, fn ->
-        Nx.window_max(Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]]), {1, 2, 1},
-          padding: [{0, 1}, {2, 0}, {1, 1}]
-        )
-      end
+    test "supports padding" do
+      t = Nx.tensor([[[4.0, 2.0, 3.0], [2.0, 5.0, 6.5]], [[1.2, 2.2, 3.2], [4.0, 5.0, 6.2]]])
+      result = Nx.window_max(t, {2, 1, 1}, strides: [2, 1, 1], padding: [{1, 1}, {0, 0}, {1, 1}])
+
+      assert_all_close(
+        result,
+        Nx.tensor([
+          [
+            [-3.4028234663852886e38, 4.0, 2.0, 3.0, -3.4028234663852886e38],
+            [-3.4028234663852886e38, 2.0, 5.0, 6.5, -3.4028234663852886e38]
+          ],
+          [
+            [
+              -3.4028234663852886e38,
+              1.2000000476837158,
+              2.200000047683716,
+              3.200000047683716,
+              -3.4028234663852886e38
+            ],
+            [-3.4028234663852886e38, 4.0, 5.0, 6.199999809265137, -3.4028234663852886e38]
+          ]
+        ])
+      )
     end
 
     # window dilations temporarily broken
@@ -629,11 +646,28 @@ defmodule Torchx.NxTest do
     end
 
     test "fails with non-zero padding" do
-      assert_raise ArgumentError, fn ->
-        Nx.window_min(Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]]), {1, 2, 1},
-          padding: [{0, 1}, {2, 0}, {1, 1}]
-        )
-      end
+      t = Nx.tensor([[[4.0, 2.0, 3.0], [2.0, 5.0, 6.5]], [[1.2, 2.2, 3.2], [4.0, 5.0, 6.2]]])
+      result = Nx.window_min(t, {2, 1, 1}, strides: [2, 1, 1], padding: [{1, 1}, {0, 0}, {1, 1}])
+
+      assert_all_close(
+        result,
+        Nx.tensor([
+          [
+            [3.4028234663852886e38, 4.0, 2.0, 3.0, 3.4028234663852886e38],
+            [3.4028234663852886e38, 2.0, 5.0, 6.5, 3.4028234663852886e38]
+          ],
+          [
+            [
+              3.4028234663852886e38,
+              1.2000000476837158,
+              2.200000047683716,
+              3.200000047683716,
+              3.4028234663852886e38
+            ],
+            [3.4028234663852886e38, 4.0, 5.0, 6.199999809265137, 3.4028234663852886e38]
+          ]
+        ])
+      )
     end
 
     # window dilations temporarily broken
@@ -672,6 +706,25 @@ defmodule Torchx.NxTest do
         ])
       )
     end
+
+    test "works with non default options" do
+      t = Nx.tensor([[[4.0, 2.0, 3.0], [2.0, 5.0, 6.5]], [[1.2, 2.2, 3.2], [4.0, 5.0, 6.2]]])
+      result = Nx.window_sum(t, {2, 1, 1}, strides: [2, 1, 1], padding: [{1, 1}, {0, 0}, {1, 1}])
+
+      assert_all_close(
+        result,
+        Nx.tensor([
+          [
+            [0.0, 4.0, 2.0, 3.0, 0.0],
+            [0.0, 2.0, 5.0, 6.5, 0.0]
+          ],
+          [
+            [0.0, 1.2000000476837158, 2.200000047683716, 3.200000047683716, 0.0],
+            [0.0, 4.0, 5.0, 6.199999809265137, 0.0]
+          ]
+        ])
+      )
+    end
   end
 
   describe "window_product" do
@@ -687,6 +740,27 @@ defmodule Torchx.NxTest do
           ],
           [
             [4, 10, 18]
+          ]
+        ])
+      )
+    end
+
+    test "works with non default options" do
+      t = Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]])
+
+      result =
+        Nx.window_product(t, {2, 2, 1}, strides: [1, 2, 3], padding: [{0, 1}, {2, 0}, {1, 1}])
+
+      assert_all_close(
+        result,
+        Nx.tensor([
+          [
+            [1, 1],
+            [1, 324]
+          ],
+          [
+            [1, 1],
+            [1, 18]
           ]
         ])
       )

--- a/torchx/test/torchx/nx_test.exs
+++ b/torchx/test/torchx/nx_test.exs
@@ -640,7 +640,7 @@ defmodule Torchx.NxTest do
     @tag :skip
     test "works with non-default options" do
       t = Nx.tensor([[[4, 2, 1, 3], [4, 2, 1, 7]], [[1, 2, 5, 7], [1, 8, 9, 2]]])
-      opts = [strides: [2, 1, 1], padding: :valid, window_dilations: [1, 2, 1]]
+      opts = [strides: [2, 1, 1], padding: :valid, window_dilations: [1, 2, 2]]
       result = Nx.window_min(t, {1, 1, 2}, opts)
 
       assert_all_close(

--- a/torchx/test/torchx/nx_test.exs
+++ b/torchx/test/torchx/nx_test.exs
@@ -673,4 +673,23 @@ defmodule Torchx.NxTest do
       )
     end
   end
+
+  describe "window_product" do
+    test "works with simple params" do
+      t = Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]])
+      result = Nx.window_product(t, {1, 2, 1})
+
+      assert_all_close(
+        result,
+        Nx.tensor([
+          [
+            [4, 10, 18]
+          ],
+          [
+            [4, 10, 18]
+          ]
+        ])
+      )
+    end
+  end
 end

--- a/torchx/test/torchx/nx_test.exs
+++ b/torchx/test/torchx/nx_test.exs
@@ -591,6 +591,8 @@ defmodule Torchx.NxTest do
       end
     end
 
+    # window dilations temporarily broken
+    @tag :skip
     test "works with non-default options" do
       t = Nx.tensor([[[4, 2, 1, 3], [4, 2, 1, 7]], [[1, 2, 5, 7], [1, 8, 9, 2]]])
       opts = [strides: [2, 1, 1], padding: :valid, window_dilations: [1, 2, 2]]
@@ -634,9 +636,11 @@ defmodule Torchx.NxTest do
       end
     end
 
+    # window dilations temporarily broken
+    @tag :skip
     test "works with non-default options" do
       t = Nx.tensor([[[4, 2, 1, 3], [4, 2, 1, 7]], [[1, 2, 5, 7], [1, 8, 9, 2]]])
-      opts = [strides: [2, 1, 1], padding: :valid, window_dilations: [1, 2, 2]]
+      opts = [strides: [2, 1, 1], padding: :valid, window_dilations: [1, 2, 1]]
       result = Nx.window_min(t, {1, 1, 2}, opts)
 
       assert_all_close(
@@ -645,6 +649,25 @@ defmodule Torchx.NxTest do
           [
             [1, 2],
             [1, 2]
+          ]
+        ])
+      )
+    end
+  end
+
+  describe "window_sum" do
+    test "works with simple params" do
+      t = Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]])
+      result = Nx.window_sum(t, {1, 2, 1})
+
+      assert_all_close(
+        result,
+        Nx.tensor([
+          [
+            [5, 7, 9]
+          ],
+          [
+            [5, 7, 9]
           ]
         ])
       )


### PR DESCRIPTION
This PR is a major refactor upon the Torchx implementation for windowed functions. It's a little bit of a step back in the sense that dilations aren't supported anymore, ~but padding will be easier to implement now through `Torchx.pad`~ but padding is now supported through `Torchx.pad` and we get the basic implementations for `window_sum` and `window_product` working as well