### PR TITLE
Avoid accidental Markdown list

### DIFF
--- a/nx/lib/nx/defn.ex
+++ b/nx/lib/nx/defn.ex
@@ -179,8 +179,8 @@ defmodule Nx.Defn do
         %{map | a: Nx.add(map.a, 1)}
       end
 
-  The following code increments the value under the key `:a` by
-  1. However, because the function receives the whole map and
+  The following code increments the value under the key `:a`
+  by 1. However, because the function receives the whole map and
   returns the whole map, it means if the map has 120 keys, the
   whole map will be copied to the CPU/GPU, and then brought back.
 


### PR DESCRIPTION
Starting a line with a number followed by a period causes Markdown to format the line as a list.

Screenshot:
![Screen Shot 2022-03-20 at 12 17 45 PM](https://user-images.githubusercontent.com/1191/159172047-22ca95bd-5306-464a-8c9d-0425badc6aaa.png)

