### PR TITLE
Fix: Nx.LinAlg.determinant

### DIFF
--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -1205,7 +1205,8 @@ defmodule Nx.LinAlg do
     upper_tri_mask = Nx.iota(nxn, axis: 0) |> Nx.less(Nx.iota(nxn, axis: 1))
 
     parity =
-      Nx.broadcast(transitions, nxn, axes: [0])
+      transitions
+      |> Nx.broadcast(nxn, axes: [0])
       |> Nx.greater(transitions)
       |> Nx.multiply(upper_tri_mask)
       |> Nx.sum()

--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -1199,12 +1199,18 @@ defmodule Nx.LinAlg do
     {p, l, u} = Nx.LinAlg.lu(t)
 
     diag = Nx.take_diagonal(l) * Nx.take_diagonal(u)
-
     is_zero = Nx.any(diag == 0)
+    transitions = Nx.dot(p, Nx.iota({n}))
 
-    iota = Nx.iota({n})
+    parity =
+      transform(transitions, fn transitions ->
+        {m} = Nx.shape(transitions)
 
-    parity = Nx.sum(Nx.dot(p, iota) != iota)
+        for i <- 0..(m - 1), reduce: 0 do
+          parity ->
+            Nx.add(parity, Nx.sum(Nx.greater(transitions[i], transitions[i..-1//1])))
+        end
+      end)
 
     sign =
       if is_zero do

--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -1115,7 +1115,7 @@ defmodule Nx.LinAlg do
       ...> ]))
       #Nx.Tensor<
         f32
-        -48.0
+        48.0
       >
 
       iex> Nx.LinAlg.determinant(Nx.tensor([


### PR DESCRIPTION
closes #681 
It didn't calculate `parity` value properly.