### PR TITLE
Fix conv zero-sized shape bug

### DIFF
--- a/nx/lib/nx/shape.ex
+++ b/nx/lib/nx/shape.ex
@@ -724,10 +724,12 @@ defmodule Nx.Shape do
 
   defp do_conv_spatial_dims([cur | spatial], [f | filters], [s | strides]) do
     dim = floor((cur - f) / s) + 1
+
     if dim <= 0 do
-      raise ArgumentError, "conv would result in empty tensor which is" <>
-                              " not currently supported in Nx, please open an" <>
-                              " issue if you'd like this behavior to change"
+      raise ArgumentError,
+            "conv would result in empty tensor which is" <>
+              " not currently supported in Nx, please open an" <>
+              " issue if you'd like this behavior to change"
     else
       [dim | do_conv_spatial_dims(spatial, filters, strides)]
     end

--- a/nx/lib/nx/shape.ex
+++ b/nx/lib/nx/shape.ex
@@ -722,8 +722,16 @@ defmodule Nx.Shape do
 
   defp do_conv_spatial_dims([], [], []), do: []
 
-  defp do_conv_spatial_dims([cur | spatial], [f | filters], [s | strides]),
-    do: [floor((cur - f) / s) + 1 | do_conv_spatial_dims(spatial, filters, strides)]
+  defp do_conv_spatial_dims([cur | spatial], [f | filters], [s | strides]) do
+    dim = floor((cur - f) / s) + 1
+    if dim <= 0 do
+      raise ArgumentError, "conv would result in empty tensor which is" <>
+                              " not currently supported in Nx, please open an" <>
+                              " issue if you'd like this behavior to change"
+    else
+      [dim | do_conv_spatial_dims(spatial, filters, strides)]
+    end
+  end
 
   @doc """
   Output shape after a pooling or reduce window operation.

--- a/nx/test/nx/shape_test.exs
+++ b/nx/test/nx/shape_test.exs
@@ -2,4 +2,25 @@ defmodule Nx.ShapeTest do
   use ExUnit.Case, async: true
 
   doctest Nx.Shape
+
+  test "conv with empty dimensions raises" do
+    assert_raise ArgumentError, ~r/conv would result/, fn ->
+      names = [nil, nil, nil]
+      Nx.Shape.conv(
+        {1, 1, 1},
+        names,
+        {1, 1, 2},
+        names,
+        [1],
+        [{0, 0}],
+        1,
+        1,
+        [1],
+        [1],
+        [0, 1, 2],
+        [0, 1, 2],
+        [0, 1, 2]
+      )
+    end
+  end
 end

--- a/nx/test/nx/shape_test.exs
+++ b/nx/test/nx/shape_test.exs
@@ -6,6 +6,7 @@ defmodule Nx.ShapeTest do
   test "conv with empty dimensions raises" do
     assert_raise ArgumentError, ~r/conv would result/, fn ->
       names = [nil, nil, nil]
+
       Nx.Shape.conv(
         {1, 1, 1},
         names,


### PR DESCRIPTION
Previously, Nx.conv would fail silently if the convolution would result in zero-sized dimensions. This adds a shape check + error message