### PR TITLE
Add make_diagonal tests for Torchx

### DIFF
--- a/torchx/test/torchx/nx_doctest_test.exs
+++ b/torchx/test/torchx/nx_doctest_test.exs
@@ -18,8 +18,6 @@ defmodule Torchx.NxDoctestTest do
     broadcast: 3,
     # dot - Batching not supported
     dot: 6,
-    # make_diagonal - depends on indexed_add
-    make_diagonal: 2,
     # mean - Torchx does not support unsigned 64 bit integer
     mean: 2,
     # quotient - Torchx does not support unsigned 32 bit integer

--- a/torchx/test/torchx/nx_test.exs
+++ b/torchx/test/torchx/nx_test.exs
@@ -148,6 +148,16 @@ defmodule Torchx.NxTest do
                Nx.tensor([[0, 1, 2], [3, 4, 5]], backend: Nx.BinaryBackend)
     end
 
+    test "make_diagonal" do
+      t =
+        [1, 2, 3]
+        |> Nx.tensor()
+        |> Nx.make_diagonal()
+
+      assert Nx.backend_transfer(t) ==
+               Nx.tensor([[1, 0, 0], [0, 2, 0], [0, 0, 3]], backend: Nx.BinaryBackend)
+    end
+
     test "random_uniform" do
       t = Nx.random_uniform({30, 50})
 

--- a/torchx/test/torchx/nx_test.exs
+++ b/torchx/test/torchx/nx_test.exs
@@ -154,8 +154,7 @@ defmodule Torchx.NxTest do
         |> Nx.tensor()
         |> Nx.make_diagonal()
 
-      assert Nx.backend_transfer(t) ==
-               Nx.tensor([[1, 0, 0], [0, 2, 0], [0, 0, 3]], backend: Nx.BinaryBackend)
+      assert_all_close(t, Nx.tensor([[1, 0, 0], [0, 2, 0], [0, 0, 3]]))
     end
 
     test "random_uniform" do


### PR DESCRIPTION
This commit adds the make_diagonal doctests and a make_diagonal
nx test to the Torchx backend.

See #682.