### PR TITLE
Fix warnings in EXLA docs

### DIFF
--- a/exla/lib/exla.ex
+++ b/exla/lib/exla.ex
@@ -228,7 +228,7 @@ defmodule EXLA do
   end
 
   @doc """
-  A shortcut for `Nx.Defn.jit/4` with the EXLA compiler.
+  A shortcut for `Nx.Defn.jit/3` with the EXLA compiler.
 
       iex> EXLA.jit(&Nx.add(&1, &1), [Nx.tensor([1, 2, 3])])
       #Nx.Tensor<

--- a/exla/lib/exla/client.ex
+++ b/exla/lib/exla/client.ex
@@ -66,7 +66,7 @@ defmodule EXLA.Client do
   end
 
   @doc """
-  Sends buffer from device outfeed to the given process tagged by `ref``.
+  Sends buffer from device outfeed to the given process tagged by `ref`.
 
   > Note: XLA does not support tuple outfeed shapes. Passing one will simply
   > block the operation indefinitely. Instead, convert the tuple into multiple


### PR DESCRIPTION
This PR fixes the warnings passed by generating docs for EXLA.
