### PR TITLE
feat: add grads for conjugate,imag,real and validate complex functions

### DIFF
--- a/nx/lib/nx/defn/grad.ex
+++ b/nx/lib/nx/defn/grad.ex
@@ -921,6 +921,26 @@ defmodule Nx.Defn.Grad do
     [{x, g}]
   end
 
+  defp grad(:conjugate, [%{type: {type, _}} = t], _ans, g) do
+    if type == :c do
+      [{t, Nx.conjugate(g)}]
+    else
+      [{t, Nx.real(g)}]
+    end
+  end
+
+  defp grad(:real, [t], _ans, g) do
+    # real(z) = (z + conj(z))/2
+    # real'(z) = (z' + (conj(z))')/2 = (z' + conj(z'))/2 = real(z')
+    [{t, Nx.real(g)}]
+  end
+
+  defp grad(:imag, [t], _ans, g) do
+    # imag(z) = (z - z*) / 2i
+    # imag'(z) = z' - z'* / 2i = imag(z')
+    [{t, Nx.imag(g)}]
+  end
+
   defp grad(:quotient, _, _, _) do
     raise ArgumentError, """
     cannot compute gradient for Nx.quotient/2.

--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -611,14 +611,16 @@ defmodule Nx.LinAlg do
 
     tensor
     |> invert_tensor()
-    |> custom_grad(fn %{type: {type, _}} = ans, g ->
+    |> custom_grad(fn ans, g ->
       # As defined in https://juliadiff.org/ChainRulesCore.jl/stable/maths/arrays.html#Matrix-inversion-2
       ans_h =
-        if type == :c do
-          ans |> Nx.transpose() |> Nx.conjugate()
-        else
-          Nx.transpose(ans)
-        end
+        transform(ans, fn
+          %{type: {:c, _}} = ans ->
+            ans |> Nx.transpose() |> Nx.conjugate()
+
+          ans ->
+            Nx.transpose(ans)
+        end)
 
       [{tensor, ans_h |> Nx.negate() |> Nx.dot(g) |> Nx.dot(ans_h)}]
     end)

--- a/nx/test/nx/defn/grad_test.exs
+++ b/nx/test/nx/defn/grad_test.exs
@@ -1449,6 +1449,20 @@ defmodule Nx.Defn.GradTest do
     end
   end
 
+  for fun <- [:real, :imag, :conjugate] do
+    describe "#{fun}" do
+      grad_fun = :"grad_#{fun}"
+      defn unquote(grad_fun)(t), do: grad(t, &(Nx.unquote(fun) / 1))
+
+      test "computes gradient" do
+        for _ <- @iters do
+          t = Nx.random_uniform({}, 0.1, 10.0, type: {:c, 128})
+          check_grads!(&Nx.unquote(fun)(&1), &(__MODULE__.unquote(grad_fun) / 1), t)
+        end
+      end
+    end
+  end
+
   describe "tan" do
     defn grad_tan(t), do: grad(t, &Nx.tan/1)
 

--- a/nx/test/nx/defn/grad_test.exs
+++ b/nx/test/nx/defn/grad_test.exs
@@ -5,6 +5,7 @@ defmodule Nx.Defn.GradTest do
   import Nx.Helpers
 
   @iters 1..25
+  @types [{:f, 64}, {:c, 128}]
 
   describe "simple" do
     defn grad_itself(t), do: grad(t, fn t -> t end)
@@ -139,7 +140,7 @@ defmodule Nx.Defn.GradTest do
     test "computes gradient of compound rules" do
       assert grad_addition_rule(Nx.tensor(1.0)) == Nx.tensor(0.15662670135498047)
 
-      for _ <- @iters, type <- [f: 64, c: 128] do
+      for _ <- @iters, type <- @types do
         check_grads!(
           &addition_rule/1,
           &grad_addition_rule/1,
@@ -156,7 +157,7 @@ defmodule Nx.Defn.GradTest do
     test "computes gradient for scalars" do
       assert grad_product_rule(Nx.tensor(1.0)) == Nx.tensor(1.2343397629215758)
 
-      for _ <- @iters, type <- [f: 64, c: 128] do
+      for _ <- @iters, type <- @types do
         check_grads!(
           &product_rule/1,
           &grad_product_rule/1,
@@ -181,7 +182,7 @@ defmodule Nx.Defn.GradTest do
     test "computes gradient" do
       assert grad_division_rule(Nx.tensor(1.0)) == Nx.tensor(-0.3416198492050171)
 
-      for _ <- @iters, type <- [f: 64, c: 128] do
+      for _ <- @iters, type <- @types do
         check_grads!(
           &division_rule/1,
           &grad_division_rule/1,
@@ -267,11 +268,11 @@ defmodule Nx.Defn.GradTest do
     test "computes gradient" do
       assert grad_power_rule(Nx.tensor(5.0)) == Nx.tensor(75.0)
 
-      for _ <- @iters do
+      for _ <- @iters, type <- @types do
         check_grads!(
           &power_rule/1,
           &grad_power_rule/1,
-          Nx.random_uniform({}, 0.0, 10.0, type: {:f, 64})
+          Nx.random_uniform({}, 0.0, 10.0, type: type)
         )
       end
     end

--- a/nx/test/nx/defn/grad_test.exs
+++ b/nx/test/nx/defn/grad_test.exs
@@ -136,14 +136,14 @@ defmodule Nx.Defn.GradTest do
     defn addition_rule(t), do: Nx.tanh(Nx.tanh(Nx.add(Nx.power(t, 2), Nx.power(t, 3))))
     defn grad_addition_rule(t), do: grad(t, &addition_rule/1)
 
-    test "computes gradient of complex rules" do
+    test "computes gradient of compound rules" do
       assert grad_addition_rule(Nx.tensor(1.0)) == Nx.tensor(0.15662670135498047)
 
-      for _ <- @iters do
+      for _ <- @iters, type <- [f: 64, c: 128] do
         check_grads!(
           &addition_rule/1,
           &grad_addition_rule/1,
-          Nx.random_uniform({}, 0.0, 1000.0, type: {:f, 64})
+          Nx.random_uniform({}, -5.0, 5.0, type: type)
         )
       end
     end
@@ -156,11 +156,11 @@ defmodule Nx.Defn.GradTest do
     test "computes gradient for scalars" do
       assert grad_product_rule(Nx.tensor(1.0)) == Nx.tensor(1.2343397629215758)
 
-      for _ <- @iters do
+      for _ <- @iters, type <- [f: 64, c: 128] do
         check_grads!(
           &product_rule/1,
           &grad_product_rule/1,
-          Nx.random_uniform({}, 0.0, 1000.0, type: {:f, 64})
+          Nx.random_uniform({}, -0.5, 0.5, type: type)
         )
       end
     end

--- a/nx/test/nx/defn/grad_test.exs
+++ b/nx/test/nx/defn/grad_test.exs
@@ -285,11 +285,11 @@ defmodule Nx.Defn.GradTest do
     test "computes gradient" do
       assert grad_exp_rule(Nx.tensor(1.0)) == Nx.tensor(1.3704876904488987)
 
-      for _ <- @iters do
+      for _ <- @iters, type <- @types do
         check_grads!(
           &exp_rule/1,
           &grad_exp_rule/1,
-          Nx.random_uniform({}, 0.0, 10.0, type: {:f, 64})
+          Nx.random_uniform({}, 0.0, 10.0, type: type)
         )
       end
     end

--- a/nx/test/nx/defn/grad_test.exs
+++ b/nx/test/nx/defn/grad_test.exs
@@ -181,11 +181,11 @@ defmodule Nx.Defn.GradTest do
     test "computes gradient" do
       assert grad_division_rule(Nx.tensor(1.0)) == Nx.tensor(-0.3416198492050171)
 
-      for _ <- @iters do
+      for _ <- @iters, type <- [f: 64, c: 128] do
         check_grads!(
           &division_rule/1,
           &grad_division_rule/1,
-          Nx.random_uniform({}, 0.0, 10.0, type: {:f, 64})
+          Nx.random_uniform({}, 0.0, 10.0, type: type)
         )
       end
     end

--- a/nx/test/nx/defn/grad_test.exs
+++ b/nx/test/nx/defn/grad_test.exs
@@ -330,6 +330,12 @@ defmodule Nx.Defn.GradTest do
                Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
              ) ==
                Nx.tensor([6.0, 15.0])
+
+      assert grad_dot_lhs_rule(
+               Nx.tensor([Complex.new(0, 3), -2, Complex.new(0, 1)]),
+               Nx.tensor([1.0, Complex.new(0, 2), 3.0])
+             ) ==
+               Nx.tensor([1, Complex.new(0, 2), 3])
     end
 
     defn grad_dot_rhs_rule(x, y), do: grad(y, &Nx.sum(Nx.dot(x, &1)))


### PR DESCRIPTION
Reference taken from Jax:

```python
def _conj_transpose_rule(t, x, *, input_dtype):
  assert ad.is_undefined_primal(x)
  if dtypes.issubdtype(input_dtype, np.complexfloating):
    return [conj(t)]
  else:
    return [real(t)]
```

real and imag grads were derived from the fact that they can be written as functions of conj, + and /

Also adds tests for most of #695 