### PR TITLE
Always keep data on the EXLA device after computation

### DIFF
--- a/exla/bench/softmax.exs
+++ b/exla/bench/softmax.exs
@@ -22,16 +22,13 @@ benches =
     dt64 = Nx.backend_transfer(t64, {EXLA.Backend, client: :cuda})
 
     cuda = [client: :cuda]
-    cuda_keep = [client: :cuda, run_options: [keep_on_device: true]]
 
     Map.merge(benches, %{
-      "xla jit-gpu f32" => fn -> EXLA.jit(&Softmax.softmax/1, [t32], cuda) end,
-      "xla jit-gpu f64" => fn -> EXLA.jit(&Softmax.softmax/1, [t64], cuda) end,
-      "xla jit-gpu f32 keep" =>
-        {fn -> EXLA.jit(&Softmax.softmax/1, [dt32], cuda_keep) end,
+      "xla jit-gpu f32" =>
+        {fn -> EXLA.jit(&Softmax.softmax/1, [dt32], cuda) end,
          after_each: &Nx.backend_deallocate/1},
-      "xla jit-gpu f64 keep" =>
-        {fn -> EXLA.jit(&Softmax.softmax/1, [dt64], cuda_keep) end,
+      "xla jit-gpu f64" =>
+        {fn -> EXLA.jit(&Softmax.softmax/1, [dt64], cuda) end,
          after_each: &Nx.backend_deallocate/1}
     })
   else

--- a/exla/c_src/exla/exla.cc
+++ b/exla/c_src/exla/exla.cc
@@ -2205,13 +2205,12 @@ ERL_NIF_TERM compile(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
 // ExlaExecutable Functions
 
 ERL_NIF_TERM run(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
-  if (argc != 5) {
+  if (argc != 4) {
     return exla::nif::error(env, "Bad argument count.");
   }
 
   exla::ExlaClient** client;
   exla::ExlaExecutable** executable;
-  bool keep_on_device;
   int device_id;
 
   ERL_NIF_TERM arguments = argv[2];
@@ -2222,15 +2221,12 @@ ERL_NIF_TERM run(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
   if (!exla::nif::get<exla::ExlaExecutable*>(env, argv[1], executable)) {
     return exla::nif::error(env, "Unable to get executable.");
   }
-  if (!exla::nif::get(env, argv[3], &keep_on_device)) {
-    return exla::nif::error(env, "Unable to get keep on device flag.");
-  }
-  if (!exla::nif::get(env, argv[4], &device_id)) {
+  if (!exla::nif::get(env, argv[3], &device_id)) {
     return exla::nif::error(env, "Unable to get device ID.");
   }
 
   EXLA_ASSIGN_OR_RETURN_NIF(ERL_NIF_TERM term,
-     (*executable)->Run(env, arguments, keep_on_device, device_id), env);
+     (*executable)->Run(env, arguments, device_id), env);
 
   return term;
 }
@@ -2281,8 +2277,8 @@ static ErlNifFunc exla_funcs[] = {
   {"transfer_from_outfeed", 5, transfer_from_outfeed, ERL_NIF_DIRTY_JOB_IO_BOUND},
   {"copy_buffer_to_device", 3, copy_buffer_to_device, ERL_NIF_DIRTY_JOB_IO_BOUND},
   // ExlaExecutable
-  {"run_io", 5, run, ERL_NIF_DIRTY_JOB_IO_BOUND},
-  {"run_cpu", 5, run, ERL_NIF_DIRTY_JOB_CPU_BOUND},
+  {"run_io", 4, run, ERL_NIF_DIRTY_JOB_IO_BOUND},
+  {"run_cpu", 4, run, ERL_NIF_DIRTY_JOB_CPU_BOUND},
   // Shape
   {"make_shape", 2, make_shape},
   {"make_token_shape", 0, make_token_shape},

--- a/exla/c_src/exla/exla_client.h
+++ b/exla/c_src/exla/exla_client.h
@@ -47,7 +47,6 @@ class ExlaExecutable {
 
   xla::StatusOr<ERL_NIF_TERM> Run(ErlNifEnv* env,
                                   ERL_NIF_TERM arguments,
-                                  bool keep_on_device,
                                   int device_id);
 
  private:

--- a/exla/lib/exla.ex
+++ b/exla/lib/exla.ex
@@ -36,12 +36,6 @@ defmodule EXLA do
     * `:device_id` - the default device id to run the computation
         on. Defaults to the `:default_device_id` on the client
 
-    * `:run_options` - options given when running the computation:
-
-      * `:keep_on_device` - if the data should be kept on the device,
-        useful if multiple computations are done in a row. See
-        "Device allocation" section
-
   ## Clients
 
   The `EXLA` library uses a client for compiling and executing code.

--- a/exla/lib/exla.ex
+++ b/exla/lib/exla.ex
@@ -101,39 +101,44 @@ defmodule EXLA do
 
   ## Device allocation
 
-  EXLA also ships with a `EXLA.Backend` that allows data
-  to be either be explicitly allocated or kept on the EXLA device
-  after a computation:
+  EXLA also ships with a `EXLA.Backend` that allows data to be explicitly
+  allocated on the EXLA device. You can create tensors with `EXLA.Backend`
+  directly:
 
-      config :nx, :default_defn_options,
-        [compiler: EXLA, client: :cuda, run_options: [keep_on_device: true]]
+      Nx.tensor([1, 2, 3, 4], backend: EXLA.Backend)
 
-  Will keep the computation on the device, either the CPU or GPU.
-  For CPU, this is actually detrimental, as allocating an Elixir
-  binary has the same cost as keeping it on CPU, but this yields
-  important performance benefits on the GPU.
+  or you can configure `EXLA.Backend` as the default backend, so that
+  all tensors are allocated on the EXLA device by default.
 
-  If data is kept on the device, you can pipe it into other `defn`
-  computations running on the same compiler (in this case, the
-  `EXLA` compiler) but you cannot use the regular `Nx` operations,
-  unless you transfer it back:
+  In some cases you may want to explicitly move an existing tensor to
+  the device:
+
+      tensor = Nx.tensor([1, 2, 3, 4], backend: Nx.BinaryBackend)
+      Nx.backend_transfer(tensor, EXLA.Backend)
+
+  Note that you can use regular `Nx` operations, so the following works:
+
+      tensor = Nx.tensor([1, 2, 3, 4], backend: EXLA.Backend)
+      Nx.sum(tensor)
+
+  Under the hood, EXLA will create a computation for the sum operation
+  and invoke it on the device. This is essentially an "eager mode"
+  that provides acceleration during prototyping. However, eventually
+  you should wrap your computations in a `defn` to utilize the full
+  performance of JIT.
+
+  To bring the tensor data back to Elixir you need an explicit transfer:
 
       Nx.tensor([1, 2, 3, 4])
       |> softmax()
-      |> Nx.backend_transfer() # bring the data back to Elixir
-
-  You can also use `Nx.backend_transfer/1` to put data on a given
-  device before invoking a `defn` function:
-
-      # Explicitly move data to the device, useful for GPU
-      Nx.backend_transfer(Nx.tensor([1, 2, 3, 4]), EXLA.Backend)
-
-  `EXLA.Backend` will use the same client as the one
-  configured for `Nx.Defn` by default.
+      |> Nx.backend_transfer()
 
   If instead you want to make a copy of the data, you can use
   `Nx.backend_copy/1` instead. However, when working with large
   data, be mindful of memory allocations.
+
+  `EXLA.Backend` will use the same client as the one configured for
+  `Nx.Defn` by default.
 
   > **Important!** EXLA operations and the `defn` compiler do not
   > take the input devices into account when executing. So, if you
@@ -200,10 +205,7 @@ defmodule EXLA do
 
   If additional options are given, they are given as compiler options:
 
-      EXLA.set_as_nx_default(
-        [:tpu, :cuda, :rocm, :host],
-        run_options: [keep_on_device: true]
-      )
+      EXLA.set_as_nx_default([:tpu, :cuda, :rocm, :host])
 
   To use the GPU or TPUs, don't forget to also set the appropriate value
   for the [`XLA_TARGET`](https://github.com/elixir-nx/xla#xla_target)

--- a/exla/lib/exla/backend.ex
+++ b/exla/lib/exla/backend.ex
@@ -125,21 +125,18 @@ defmodule EXLA.Backend do
 
   ## JIT callbacks
 
-  # TODO: remove keep_on_device entirely
-  @jit_opts [run_options: [keep_on_device: true]]
-
   @impl true
   def concatenate(out, tensors, axis) do
     expr_fn = fn tensors ->
       Nx.Defn.Expr.concatenate(out, Tuple.to_list(tensors), axis)
     end
 
-    EXLA.jit(expr_fn, [List.to_tuple(tensors)], @jit_opts)
+    EXLA.jit(expr_fn, [List.to_tuple(tensors)])
   end
 
   @impl true
   def optional(_name, args, fun) do
-    EXLA.jit(fun, args, @jit_opts)
+    EXLA.jit(fun, args)
   end
 
   binary_ops =
@@ -220,7 +217,7 @@ defmodule EXLA.Backend do
         Nx.Defn.Expr.unquote(name)(unquote_splicing(args))
       end
 
-      EXLA.jit(expr_fn, [unquote_splicing(tensor_args)], @jit_opts)
+      EXLA.jit(expr_fn, [unquote_splicing(tensor_args)])
     end
   end
 end

--- a/exla/lib/exla/defn/buffers.ex
+++ b/exla/lib/exla/defn/buffers.ex
@@ -4,10 +4,10 @@ defmodule EXLA.Defn.Buffers do
   @doc """
   binary + EXLA.DeviceBuffer + EXLA.BinaryBuffer -> Nx.
   """
-  def to_nx!(buffers, outputs, fun \\ & &1) do
+  def to_nx!(buffers, outputs) do
     {res, []} =
       Nx.Defn.Composite.traverse(outputs, buffers, fn %Nx.Tensor{} = hole, [buffer | acc] ->
-        {fun.(%{hole | data: buffer_to_data(hole, buffer)}), acc}
+        {%{hole | data: buffer_to_data(hole, buffer)}, acc}
       end)
 
     res

--- a/exla/lib/exla/defn/stream.ex
+++ b/exla/lib/exla/defn/stream.ex
@@ -3,9 +3,9 @@ defmodule EXLA.Defn.Stream do
 
   keys =
     [:lock, :outfeed, :pid, :runner, :send, :recv, :send_shape] ++
-      [:recv_length, :done, :client, :device_id, :keep_on_device]
+      [:recv_length, :done, :client, :device_id]
 
-  @derive {Inspect, only: [:pid, :client, :device_id, :keep_on_device, :send, :recv]}
+  @derive {Inspect, only: [:pid, :client, :device_id, :send, :recv]}
   @enforce_keys keys
   defstruct keys
 
@@ -18,8 +18,7 @@ defmodule EXLA.Defn.Stream do
         send_shape,
         recv,
         recv_shapes,
-        done,
-        keep_on_device?
+        done
       ) do
     %{client: client, device_id: device_id} = executable
 
@@ -44,8 +43,7 @@ defmodule EXLA.Defn.Stream do
       recv_length: length(recv_shapes),
       client: client,
       device_id: device_id,
-      done: done,
-      keep_on_device: keep_on_device?
+      done: done
     }
   end
 
@@ -122,7 +120,6 @@ defmodule EXLA.Defn.Stream do
           outfeed: outfeed,
           pid: pid,
           runner: runner,
-          keep_on_device: keep_on_device,
           done: done
         }) do
       if pid != self() do
@@ -146,9 +143,8 @@ defmodule EXLA.Defn.Stream do
           raise "cannot mark stream as done when there are recv messages pending"
 
         {:DOWN, ^outfeed_ref, _, _, _} ->
-          fun = if keep_on_device, do: & &1, else: &Nx.backend_transfer/1
           [result] = EXLA.Defn.Runner.read(runner)
-          EXLA.Defn.Buffers.to_nx!(result, done, fun)
+          EXLA.Defn.Buffers.to_nx!(result, done)
       end
     end
   end

--- a/exla/lib/exla/executable.ex
+++ b/exla/lib/exla/executable.ex
@@ -11,12 +11,6 @@ defmodule EXLA.Executable do
 
   @doc """
   Runs the given executable with a list of lists as inputs and the given options.
-
-  ## Options
-
-    * `:keep_on_device` - if the data should be kept on the device
-      after the computation (defaults to `false`).
-
   """
   def run(%Executable{} = executable, [subinputs | _] = inputs, options \\ [])
       when is_list(subinputs) do
@@ -27,10 +21,7 @@ defmodule EXLA.Executable do
     end
   end
 
-  defp run(client, ref, device_id, inputs, options) do
-    keep_on_device = Keyword.get(options, :keep_on_device, false)
-    keep_on_device_int = if keep_on_device, do: 1, else: 0
-
+  defp run(client, ref, device_id, inputs, _options) do
     inputs =
       for subinputs <- inputs do
         Enum.map(subinputs, fn
@@ -41,8 +32,8 @@ defmodule EXLA.Executable do
 
     data =
       case client.platform do
-        :host -> EXLA.NIF.run_cpu(client.ref, ref, inputs, keep_on_device_int, device_id)
-        _ -> EXLA.NIF.run_io(client.ref, ref, inputs, keep_on_device_int, device_id)
+        :host -> EXLA.NIF.run_cpu(client.ref, ref, inputs, device_id)
+        _ -> EXLA.NIF.run_io(client.ref, ref, inputs, device_id)
       end
 
     unwrap!(data)

--- a/exla/lib/exla/nif.ex
+++ b/exla/lib/exla/nif.ex
@@ -255,7 +255,6 @@ defmodule EXLA.NIF do
         _client,
         _executable,
         _arguments,
-        _keep_on_device,
         _device_id
       ),
       do: :erlang.nif_error(:undef)
@@ -264,7 +263,6 @@ defmodule EXLA.NIF do
         _client,
         _executable,
         _arguments,
-        _keep_on_device,
         _device_id
       ),
       do: :erlang.nif_error(:undef)

--- a/exla/test/exla/defn/api_test.exs
+++ b/exla/test/exla/defn/api_test.exs
@@ -1,5 +1,5 @@
 defmodule EXLA.Defn.APITest do
-  use ExUnit.Case, async: true
+  use EXLA.Case, async: true
 
   import Nx.Defn
 
@@ -9,34 +9,11 @@ defmodule EXLA.Defn.APITest do
   end
 
   describe "options" do
-    defn add_two_keep_on_device(a, b), do: a + b
-
-    # Ignored logged errors, since they are expected
-    @tag capture_log: true
-    test "keeps data on device" do
-      Nx.Defn.default_options(compiler: EXLA, run_options: [keep_on_device: true])
-
-      tensor = add_two_keep_on_device(1, 2)
-      assert %EXLA.Backend{buffer: %EXLA.DeviceBuffer{}} = tensor.data
-
-      tensor = add_two_keep_on_device(Nx.tensor([[1, 2], [3, 4]]), tensor)
-      assert %EXLA.Backend{buffer: %EXLA.DeviceBuffer{}} = tensor.data
-
-      assert tensor |> Nx.backend_transfer() |> Nx.to_binary() ==
-               <<4::64-native, 5::64-native, 6::64-native, 7::64-native>>
-
-      assert_raise RuntimeError,
-                   ~r"Buffer has been deleted or donated",
-                   fn -> add_two_keep_on_device(Nx.tensor([[1, 2], [3, 4]]), tensor) end
-
-      assert_raise RuntimeError,
-                   ~r"called on deleted or donated buffer",
-                   fn -> Nx.backend_transfer(tensor) end
-    end
+    defn add_two(a, b), do: a + b
 
     test "raises on invalid device_id" do
       assert_raise RuntimeError, ~r"Invalid device ordinal value \(1024\)", fn ->
-        EXLA.jit(&add_two_keep_on_device/2, [2, 3], device_id: 1024)
+        EXLA.jit(&add_two/2, [2, 3], device_id: 1024)
       end
     end
   end
@@ -62,27 +39,27 @@ defmodule EXLA.Defn.APITest do
     test "matched as input" do
       inp = %Container{a: Nx.tensor(5), b: Nx.tensor(3)}
 
-      assert container_as_input(inp) == Nx.tensor(15)
+      assert_equal(container_as_input(inp), Nx.tensor(15))
     end
 
     test "updated" do
       inp = %Container{a: Nx.tensor(1), b: 2, c: :reset, d: :keep}
 
       assert %Container{a: a, b: b, c: c, d: d} = update_container(inp, Nx.tensor(8))
-      assert a == Nx.tensor(1)
-      assert b == Nx.tensor(8)
+      assert_equal(a, Nx.tensor(1))
+      assert_equal(b, Nx.tensor(8))
       assert c == nil
       assert d == :keep
     end
 
     test "can be used with dot syntax" do
       inp = %Container{a: Nx.tensor(1), b: 2}
-      assert dot_container(inp) == Nx.tensor(2)
+      assert_equal(dot_container(inp), Nx.tensor(2))
     end
 
     test "can be used with nested collections" do
       inp = %Container{a: {Nx.tensor(1), Nx.tensor(2)}, b: %{a: Nx.tensor(3), b: Nx.tensor(4)}}
-      assert container_with_map_tuple(inp) == Nx.tensor(24)
+      assert_equal(container_with_map_tuple(inp), Nx.tensor(24))
     end
   end
 
@@ -91,31 +68,23 @@ defmodule EXLA.Defn.APITest do
 
     test "immediately done" do
       stream = EXLA.stream(&defn_sum/2, [0, 0])
-      assert Nx.Stream.done(stream) == Nx.tensor(0)
+      assert %Nx.Tensor{data: %EXLA.Backend{}} = done = Nx.Stream.done(stream)
+      assert_equal(Nx.backend_transfer(done), Nx.tensor(0))
 
       stream = EXLA.stream(&defn_sum/2, [1, 2])
-      assert Nx.Stream.done(stream) == Nx.tensor(2)
-    end
-
-    test "immediately done with keep_on_device" do
-      stream = EXLA.stream(&defn_sum/2, [0, 0], run_options: [keep_on_device: true])
       assert %Nx.Tensor{data: %EXLA.Backend{}} = done = Nx.Stream.done(stream)
-      assert Nx.backend_transfer(done) == Nx.tensor(0)
-
-      stream = EXLA.stream(&defn_sum/2, [1, 2], run_options: [keep_on_device: true])
-      assert %Nx.Tensor{data: %EXLA.Backend{}} = done = Nx.Stream.done(stream)
-      assert Nx.backend_transfer(done) == Nx.tensor(2)
+      assert_equal(Nx.backend_transfer(done), Nx.tensor(2))
     end
 
     test "send/recv" do
       %_{} = stream = EXLA.stream(&defn_sum/2, [0, 0])
       assert Nx.Stream.send(stream, 1) == :ok
-      assert Nx.Stream.recv(stream) == Nx.tensor(0)
+      assert_equal(Nx.Stream.recv(stream), Nx.tensor(0))
 
       assert Nx.Stream.send(stream, 2) == :ok
-      assert Nx.Stream.recv(stream) == Nx.tensor(1)
+      assert_equal(Nx.Stream.recv(stream), Nx.tensor(1))
 
-      assert Nx.Stream.done(stream) == Nx.tensor(3)
+      assert_equal(Nx.Stream.done(stream), Nx.tensor(3))
     end
 
     test "send x2/recv x2" do
@@ -123,10 +92,10 @@ defmodule EXLA.Defn.APITest do
       assert Nx.Stream.send(stream, 1) == :ok
       assert Nx.Stream.send(stream, 2) == :ok
 
-      assert Nx.Stream.recv(stream) == Nx.tensor(0)
-      assert Nx.Stream.recv(stream) == Nx.tensor(1)
+      assert_equal(Nx.Stream.recv(stream), Nx.tensor(0))
+      assert_equal(Nx.Stream.recv(stream), Nx.tensor(1))
 
-      assert Nx.Stream.done(stream) == Nx.tensor(3)
+      assert_equal(Nx.Stream.done(stream), Nx.tensor(3))
     end
 
     defn stream_composite(i, {a, {b, c}}) do
@@ -139,12 +108,12 @@ defmodule EXLA.Defn.APITest do
     test "send/recv with composite types" do
       %_{} = stream = EXLA.stream(&stream_composite/2, [0, {0, {1, 2}}])
       assert Nx.Stream.send(stream, 1) == :ok
-      assert Nx.Stream.recv(stream) == {{Nx.tensor(1), Nx.tensor(1)}, Nx.tensor(2)}
+      assert_equal(Nx.Stream.recv(stream), {{Nx.tensor(1), Nx.tensor(1)}, Nx.tensor(2)})
 
       assert Nx.Stream.send(stream, 2) == :ok
-      assert Nx.Stream.recv(stream) == {{Nx.tensor(3), Nx.tensor(2)}, Nx.tensor(4)}
+      assert_equal(Nx.Stream.recv(stream), {{Nx.tensor(3), Nx.tensor(2)}, Nx.tensor(4)})
 
-      assert Nx.Stream.done(stream) == {Nx.tensor(3), {Nx.tensor(2), Nx.tensor(4)}}
+      assert_equal(Nx.Stream.done(stream), {Nx.tensor(3), {Nx.tensor(2), Nx.tensor(4)}})
     end
 
     defn stream_empty_outfeed(i, t), do: {{}, i + t}
@@ -157,7 +126,7 @@ defmodule EXLA.Defn.APITest do
       assert Nx.Stream.send(stream, 2) == :ok
       assert Nx.Stream.recv(stream) == {}
 
-      assert Nx.Stream.done(stream) == Nx.tensor(3)
+      assert_equal(Nx.Stream.done(stream), Nx.tensor(3))
     end
 
     defn stream_empty_acc(i, {}), do: {i * i, {}}
@@ -165,10 +134,10 @@ defmodule EXLA.Defn.APITest do
     test "send/recv with empty acc" do
       %_{} = stream = EXLA.stream(&stream_empty_acc/2, [0, {}])
       assert Nx.Stream.send(stream, 1) == :ok
-      assert Nx.Stream.recv(stream) == Nx.tensor(1)
+      assert_equal(Nx.Stream.recv(stream), Nx.tensor(1))
 
       assert Nx.Stream.send(stream, 2) == :ok
-      assert Nx.Stream.recv(stream) == Nx.tensor(4)
+      assert_equal(Nx.Stream.recv(stream), Nx.tensor(4))
 
       assert Nx.Stream.done(stream) == {}
     end
@@ -179,8 +148,8 @@ defmodule EXLA.Defn.APITest do
 
       %_{} = stream = EXLA.stream(&defn_sum/2, [0, 0])
       assert Nx.Stream.send(stream, 1) == :ok
-      assert Nx.Stream.recv(stream) == Nx.tensor(0)
-      assert Nx.Stream.done(stream) == Nx.tensor(1)
+      assert_equal(Nx.Stream.recv(stream), Nx.tensor(0))
+      assert_equal(Nx.Stream.done(stream), Nx.tensor(1))
     end
 
     test "handles failure after writing" do
@@ -194,8 +163,8 @@ defmodule EXLA.Defn.APITest do
 
       %_{} = stream = EXLA.stream(&defn_sum/2, [0, 0])
       assert Nx.Stream.send(stream, 1) == :ok
-      assert Nx.Stream.recv(stream) == Nx.tensor(0)
-      assert Nx.Stream.done(stream) == Nx.tensor(1)
+      assert_equal(Nx.Stream.recv(stream), Nx.tensor(0))
+      assert_equal(Nx.Stream.done(stream), Nx.tensor(1))
     end
 
     test "raises if recv is pending on done" do
@@ -209,7 +178,7 @@ defmodule EXLA.Defn.APITest do
 
     test "raises if stream is done when recving" do
       %_{} = stream = EXLA.stream(&defn_sum/2, [0, 0])
-      assert Nx.Stream.done(stream) == Nx.tensor(0)
+      assert_equal(Nx.Stream.done(stream), Nx.tensor(0))
 
       assert_raise RuntimeError,
                    "cannot recv from stream because it has been terminated",
@@ -225,12 +194,14 @@ defmodule EXLA.Defn.APITest do
       %_{} = stream = EXLA.stream(&container_stream/2, args)
 
       assert Nx.Stream.send(stream, %Container{a: 1, b: -1}) == :ok
-      assert Nx.Stream.recv(stream) == %Container{a: Nx.tensor(1), b: Nx.tensor(-1), d: :elem}
+
+      assert_equal(Nx.Stream.recv(stream), %Container{a: Nx.tensor(1), b: Nx.tensor(-1), d: :elem})
 
       assert Nx.Stream.send(stream, %Container{a: 2, b: -2}) == :ok
-      assert Nx.Stream.recv(stream) == %Container{a: Nx.tensor(3), b: Nx.tensor(-2), d: :elem}
 
-      assert Nx.Stream.done(stream) == %Container{a: Nx.tensor(0), b: Nx.tensor(3), d: :acc}
+      assert_equal(Nx.Stream.recv(stream), %Container{a: Nx.tensor(3), b: Nx.tensor(-2), d: :elem})
+
+      assert_equal(Nx.Stream.done(stream), %Container{a: Nx.tensor(0), b: Nx.tensor(3), d: :acc})
     end
   end
 
@@ -257,11 +228,13 @@ defmodule EXLA.Defn.APITest do
     end
 
     test "executes hook with callback" do
-      assert EXLA.jit(&hook_default/2, [2, 3], hooks: %{default: send_to_self(:tag)}) ==
-               Nx.tensor(5)
+      assert_equal(
+        EXLA.jit(&hook_default/2, [2, 3], hooks: %{default: send_to_self(:tag)}),
+        Nx.tensor(5)
+      )
 
       assert_receive {:tag, tensor}
-      assert tensor == Nx.tensor(5)
+      assert_equal(tensor, Nx.tensor(5))
     end
 
     defn hook_optional(a, b) do
@@ -269,13 +242,15 @@ defmodule EXLA.Defn.APITest do
     end
 
     test "executes optional hook" do
-      assert hook_optional(2, 3) == Nx.tensor(5)
+      assert_equal(hook_optional(2, 3), Nx.tensor(5))
 
-      assert EXLA.jit(&hook_optional/2, [2, 3], hooks: %{optional: send_to_self(:tag)}) ==
-               Nx.tensor(5)
+      assert_equal(
+        EXLA.jit(&hook_optional/2, [2, 3], hooks: %{optional: send_to_self(:tag)}),
+        Nx.tensor(5)
+      )
 
       assert_receive {:tag, tensor}
-      assert tensor == Nx.tensor(5)
+      assert_equal(tensor, Nx.tensor(5))
     end
 
     defn hook_factorial(x) do
@@ -288,8 +263,10 @@ defmodule EXLA.Defn.APITest do
     end
 
     test "executes hook within while" do
-      assert EXLA.jit(&hook_factorial/1, [5], hooks: %{factorial: send_to_self(:tag)}) ==
-               Nx.tensor(120.0)
+      assert_equal(
+        EXLA.jit(&hook_factorial/1, [5], hooks: %{factorial: send_to_self(:tag)}),
+        Nx.tensor(120.0)
+      )
 
       assert_received {:tag, tuple}
       assert tuple == {Nx.tensor(5.0), Nx.tensor(4)}
@@ -310,23 +287,29 @@ defmodule EXLA.Defn.APITest do
     end
 
     test "executes hook within cond" do
-      assert EXLA.jit(&hook_cond/2, [1, 4], hooks: %{cond: send_to_self(:tag)}) ==
-               Nx.tensor(2.0)
+      assert_equal(
+        EXLA.jit(&hook_cond/2, [1, 4], hooks: %{cond: send_to_self(:tag)}),
+        Nx.tensor(2.0)
+      )
 
       assert_received {:tag, tensor}
-      assert tensor == Nx.tensor(2.0)
+      assert_equal(tensor, Nx.tensor(2.0))
 
-      assert EXLA.jit(&hook_cond/2, [-1, 4], hooks: %{cond: send_to_self(:tag)}) ==
-               Nx.tensor(8.0)
-
-      assert_received {:tag, tensor}
-      assert tensor == Nx.tensor(8)
-
-      assert EXLA.jit(&hook_cond/2, [0, 4], hooks: %{cond: send_to_self(:tag)}) ==
-               Nx.tensor(16.0)
+      assert_equal(
+        EXLA.jit(&hook_cond/2, [-1, 4], hooks: %{cond: send_to_self(:tag)}),
+        Nx.tensor(8.0)
+      )
 
       assert_received {:tag, tensor}
-      assert tensor == Nx.tensor(16)
+      assert_equal(tensor, Nx.tensor(8))
+
+      assert_equal(
+        EXLA.jit(&hook_cond/2, [0, 4], hooks: %{cond: send_to_self(:tag)}),
+        Nx.tensor(16.0)
+      )
+
+      assert_received {:tag, tensor}
+      assert_equal(tensor, Nx.tensor(16))
     end
 
     defn hook_container(container) do
@@ -338,8 +321,8 @@ defmodule EXLA.Defn.APITest do
       EXLA.jit(&hook_container/1, [container], hooks: %{container: send_to_self(:tag)})
 
       assert_receive {:tag, %Container{a: a, b: b, c: nil, d: :elem}}
-      assert a == Nx.tensor(1)
-      assert b == Nx.tensor(2)
+      assert_equal(a, Nx.tensor(1))
+      assert_equal(b, Nx.tensor(2))
     end
 
     defn hook_stream(entry, acc), do: hook({acc, entry + acc}, :stream)
@@ -347,20 +330,20 @@ defmodule EXLA.Defn.APITest do
     test "executes hook with stream" do
       %_{} = stream = EXLA.stream(&hook_stream/2, [0, 0], hooks: %{stream: send_to_self(:tag)})
       assert Nx.Stream.send(stream, 1) == :ok
-      assert Nx.Stream.recv(stream) == Nx.tensor(0)
+      assert_equal(Nx.Stream.recv(stream), Nx.tensor(0))
       assert_receive {:tag, {previous_acc, new_acc}}
-      assert previous_acc == Nx.tensor(0)
-      assert new_acc == Nx.tensor(1)
+      assert_equal(previous_acc, Nx.tensor(0))
+      assert_equal(new_acc, Nx.tensor(1))
       refute_received _
 
       assert Nx.Stream.send(stream, 2) == :ok
-      assert Nx.Stream.recv(stream) == Nx.tensor(1)
+      assert_equal(Nx.Stream.recv(stream), Nx.tensor(1))
       assert_receive {:tag, {previous_acc, new_acc}}
-      assert previous_acc == Nx.tensor(1)
-      assert new_acc == Nx.tensor(3)
+      assert_equal(previous_acc, Nx.tensor(1))
+      assert_equal(new_acc, Nx.tensor(3))
       refute_received _
 
-      assert Nx.Stream.done(stream) == Nx.tensor(3)
+      assert_equal(Nx.Stream.done(stream), Nx.tensor(3))
       refute_received _
     end
   end

--- a/exla/test/exla/defn/expr_test.exs
+++ b/exla/test/exla/defn/expr_test.exs
@@ -1,5 +1,5 @@
 defmodule EXLA.Defn.ExprTest do
-  use ExUnit.Case, async: true
+  use EXLA.Case, async: true
 
   import Nx.Defn
 
@@ -16,28 +16,34 @@ defmodule EXLA.Defn.ExprTest do
     defn add_subtract_tuple(a, b), do: {a + b, a - b}
 
     test "on results" do
-      assert add_subtract_tuple(2, 3) == {Nx.tensor(5), Nx.tensor(-1)}
+      assert_equal(add_subtract_tuple(2, 3), {Nx.tensor(5), Nx.tensor(-1)})
 
-      assert add_subtract_tuple(Nx.tensor([-1, 0, 1]), 10) ==
-               {Nx.tensor([9, 10, 11]), Nx.tensor([-11, -10, -9])}
+      assert_equal(
+        add_subtract_tuple(Nx.tensor([-1, 0, 1]), 10),
+        {Nx.tensor([9, 10, 11]), Nx.tensor([-11, -10, -9])}
+      )
     end
 
     defn pattern_tuple({a, b}), do: a + b
 
     test "on patterns" do
-      assert pattern_tuple({2, 3}) == Nx.tensor(5)
+      assert_equal(pattern_tuple({2, 3}), Nx.tensor(5))
 
-      assert pattern_tuple({Nx.tensor([1, 2]), Nx.tensor([[3], [4]])}) ==
-               Nx.tensor([[4, 5], [5, 6]])
+      assert_equal(
+        pattern_tuple({Nx.tensor([1, 2]), Nx.tensor([[3], [4]])}),
+        Nx.tensor([[4, 5], [5, 6]])
+      )
     end
 
     defn calls_pattern_tuple(a, b), do: pattern_tuple({a, b})
 
     test "on inlined tuples" do
-      assert calls_pattern_tuple(2, 3) == Nx.tensor(5)
+      assert_equal(calls_pattern_tuple(2, 3), Nx.tensor(5))
 
-      assert calls_pattern_tuple(Nx.tensor([1, 2]), Nx.tensor([[3], [4]])) ==
-               Nx.tensor([[4, 5], [5, 6]])
+      assert_equal(
+        calls_pattern_tuple(Nx.tensor([1, 2]), Nx.tensor([[3], [4]])),
+        Nx.tensor([[4, 5], [5, 6]])
+      )
     end
   end
 
@@ -50,17 +56,17 @@ defmodule EXLA.Defn.ExprTest do
     defn add_2x2_attribute(t), do: t + @two_per_two
 
     test "handles tensors as constants" do
-      assert constants() == Nx.tensor(2)
+      assert_equal(constants(), Nx.tensor(2))
     end
 
     test "expands module attributes to scalars" do
-      assert add_two_attribute(1) == Nx.tensor(3)
-      assert add_two_attribute(Nx.tensor([1, 2, 3])) == Nx.tensor([3, 4, 5])
+      assert_equal(add_two_attribute(1), Nx.tensor(3))
+      assert_equal(add_two_attribute(Nx.tensor([1, 2, 3])), Nx.tensor([3, 4, 5]))
     end
 
     test "expands module attributes to tensors" do
-      assert add_2x2_attribute(1) == Nx.tensor([[2, 3], [4, 5]])
-      assert add_2x2_attribute(Nx.tensor([1, 2])) == Nx.tensor([[2, 4], [4, 6]])
+      assert_equal(add_2x2_attribute(1), Nx.tensor([[2, 3], [4, 5]]))
+      assert_equal(add_2x2_attribute(Nx.tensor([1, 2])), Nx.tensor([[2, 4], [4, 6]]))
     end
   end
 
@@ -68,7 +74,7 @@ defmodule EXLA.Defn.ExprTest do
     defn return_float, do: Nx.tensor(1, type: {:f, 16})
 
     test "supports float16 return types" do
-      assert return_float() == Nx.tensor(1, type: {:f, 16})
+      assert_equal(return_float(), Nx.tensor(1, type: {:f, 16}))
     end
   end
 
@@ -77,8 +83,8 @@ defmodule EXLA.Defn.ExprTest do
     defn return_complex_tensor, do: Nx.broadcast(Nx.complex(1, 2), {3, 3, 3})
 
     test "supports complex return types" do
-      assert return_complex() == Nx.tensor(Complex.new(1, 2))
-      assert return_complex_tensor() == Nx.broadcast(Complex.new(1, 2), {3, 3, 3})
+      assert_equal(return_complex(), Nx.tensor(Complex.new(1, 2)))
+      assert_equal(return_complex_tensor(), Nx.broadcast(Complex.new(1, 2), {3, 3, 3}))
     end
   end
 
@@ -86,12 +92,14 @@ defmodule EXLA.Defn.ExprTest do
     defn conjugate(x), do: Nx.conjugate(x)
 
     test "correctly returns complex conjugate" do
-      assert conjugate(Nx.tensor(Complex.new(1, 2))) == Nx.tensor(Complex.new(1, -2))
+      assert_equal(conjugate(Nx.tensor(Complex.new(1, 2))), Nx.tensor(Complex.new(1, -2)))
       # This differs from the Nx doctest, which I believe should also return -0
-      assert conjugate(Nx.tensor(1)) == Nx.tensor(Complex.new(1, -0.0))
+      assert_equal(conjugate(Nx.tensor(1)), Nx.tensor(Complex.new(1, -0.0)))
 
-      assert conjugate(Nx.tensor([Complex.new(1, 2), Complex.new(2, -4)])) ==
-               Nx.tensor([Complex.new(1, -2), Complex.new(2, 4)])
+      assert_equal(
+        conjugate(Nx.tensor([Complex.new(1, 2), Complex.new(2, -4)])),
+        Nx.tensor([Complex.new(1, -2), Complex.new(2, 4)])
+      )
     end
   end
 
@@ -99,9 +107,13 @@ defmodule EXLA.Defn.ExprTest do
     defn real(x), do: Nx.real(x)
 
     test "correctly returns real part of complex" do
-      assert real(Nx.tensor(Complex.new(1, 2))) == Nx.tensor(1.0)
-      assert real(Nx.tensor(1)) == Nx.tensor(1.0)
-      assert real(Nx.tensor([Complex.new(1, 2), Complex.new(2, -4)])) == Nx.tensor([1.0, 2.0])
+      assert_equal(real(Nx.tensor(Complex.new(1, 2))), Nx.tensor(1.0))
+      assert_equal(real(Nx.tensor(1)), Nx.tensor(1.0))
+
+      assert_equal(
+        real(Nx.tensor([Complex.new(1, 2), Complex.new(2, -4)])),
+        Nx.tensor([1.0, 2.0])
+      )
     end
   end
 
@@ -109,9 +121,13 @@ defmodule EXLA.Defn.ExprTest do
     defn imag(x), do: Nx.imag(x)
 
     test "correctly returns imaginary part of complex" do
-      assert imag(Nx.tensor(Complex.new(1, 2))) == Nx.tensor(2.0)
-      assert imag(Nx.tensor(1)) == Nx.tensor(0.0)
-      assert imag(Nx.tensor([Complex.new(1, 2), Complex.new(2, -4)])) == Nx.tensor([2.0, -4.0])
+      assert_equal(imag(Nx.tensor(Complex.new(1, 2))), Nx.tensor(2.0))
+      assert_equal(imag(Nx.tensor(1)), Nx.tensor(0.0))
+
+      assert_equal(
+        imag(Nx.tensor([Complex.new(1, 2), Complex.new(2, -4)])),
+        Nx.tensor([2.0, -4.0])
+      )
     end
   end
 
@@ -119,11 +135,11 @@ defmodule EXLA.Defn.ExprTest do
     defn add_two(a, b), do: a + b
 
     test "same shape and type" do
-      assert add_two(1.0, 2.0) == Nx.tensor(3.0)
-      assert add_two(1, 2) == Nx.tensor(3)
+      assert_equal(add_two(1.0, 2.0), Nx.tensor(3.0))
+      assert_equal(add_two(1, 2), Nx.tensor(3))
 
-      assert add_two(Nx.tensor([1, 2]), Nx.tensor([3, 4])) == Nx.tensor([4, 6])
-      assert add_two(Nx.tensor([1.0, 2.0]), Nx.tensor([3.0, 4.0])) == Nx.tensor([4.0, 6.0])
+      assert_equal(add_two(Nx.tensor([1, 2]), Nx.tensor([3, 4])), Nx.tensor([4, 6]))
+      assert_equal(add_two(Nx.tensor([1.0, 2.0]), Nx.tensor([3.0, 4.0])), Nx.tensor([4.0, 6.0]))
     end
 
     test "different types" do
@@ -149,8 +165,8 @@ defmodule EXLA.Defn.ExprTest do
       ]
 
       for {left, right} <- tensors do
-        compare_tensors!(add_two(left, right), evaluate(&add_two/2, [left, right]))
-        compare_tensors!(add_two(right, left), evaluate(&add_two/2, [right, left]))
+        assert_all_close(add_two(left, right), evaluate(&add_two/2, [left, right]))
+        assert_all_close(add_two(right, left), evaluate(&add_two/2, [right, left]))
       end
     end
 
@@ -169,8 +185,8 @@ defmodule EXLA.Defn.ExprTest do
       ]
 
       for t <- tensors do
-        assert add_two_int(t) == Nx.add(t, 2)
-        assert add_two_float(t) == Nx.add(t, 2.0)
+        assert_equal(add_two_int(t), Nx.add(t, 2))
+        assert_equal(add_two_float(t), Nx.add(t, 2.0))
       end
     end
 
@@ -192,8 +208,8 @@ defmodule EXLA.Defn.ExprTest do
       ]
 
       for {left, right} <- tensors do
-        compare_tensors!(add_two(left, right), evaluate(&add_two/2, [left, right]))
-        compare_tensors!(add_two(right, left), evaluate(&add_two/2, [right, left]))
+        assert_all_close(add_two(left, right), evaluate(&add_two/2, [left, right]))
+        assert_all_close(add_two(right, left), evaluate(&add_two/2, [right, left]))
       end
     end
 
@@ -218,8 +234,8 @@ defmodule EXLA.Defn.ExprTest do
       ]
 
       for {left, right} <- tensors do
-        compare_tensors!(divide_two(left, right), Nx.divide(left, right))
-        compare_tensors!(divide_two(right, left), Nx.divide(right, left))
+        assert_all_close(divide_two(left, right), Nx.divide(left, right))
+        assert_all_close(divide_two(right, left), Nx.divide(right, left))
       end
     end
 
@@ -238,8 +254,8 @@ defmodule EXLA.Defn.ExprTest do
       ]
 
       for t <- tensors do
-        compare_tensors!(divide_two_int(t), Nx.divide(t, 2))
-        compare_tensors!(divide_two_float(t), Nx.divide(t, 2.0))
+        assert_all_close(divide_two_int(t), Nx.divide(t, 2))
+        assert_all_close(divide_two_float(t), Nx.divide(t, 2.0))
       end
     end
   end
@@ -251,14 +267,14 @@ defmodule EXLA.Defn.ExprTest do
       left = Nx.tensor([-1023, 1023])
       right = Nx.tensor([[-4], [4]])
       assert Nx.shape(remainder(left, right)) == {2, 2}
-      compare_tensors!(remainder(left, right), Nx.remainder(left, right))
+      assert_all_close(remainder(left, right), Nx.remainder(left, right))
     end
 
     test "floats" do
       left = Nx.tensor([-8.3, -8.4, -8.5, 8.3, 8.4, 8.5])
       right = Nx.tensor([[-4.2], [-4.1], [-4.0], [4.0], [4.1], [4.2]])
       assert Nx.shape(remainder(left, right)) == {6, 6}
-      compare_tensors!(remainder(left, right), Nx.remainder(left, right))
+      assert_all_close(remainder(left, right), Nx.remainder(left, right))
     end
   end
 
@@ -276,8 +292,8 @@ defmodule EXLA.Defn.ExprTest do
 
     test "-" do
       for {left, right} <- @tensors do
-        compare_tensors!(subtract_two(left, right), Nx.subtract(left, right))
-        compare_tensors!(subtract_two(right, left), Nx.subtract(right, left))
+        assert_all_close(subtract_two(left, right), Nx.subtract(left, right))
+        assert_all_close(subtract_two(right, left), Nx.subtract(right, left))
       end
     end
 
@@ -285,8 +301,8 @@ defmodule EXLA.Defn.ExprTest do
 
     test "*" do
       for {left, right} <- @tensors do
-        compare_tensors!(multiply_two(left, right), Nx.multiply(left, right))
-        compare_tensors!(multiply_two(right, left), Nx.multiply(right, left))
+        assert_all_close(multiply_two(left, right), Nx.multiply(left, right))
+        assert_all_close(multiply_two(right, left), Nx.multiply(right, left))
       end
     end
 
@@ -298,7 +314,7 @@ defmodule EXLA.Defn.ExprTest do
             Nx.tensor([-1, 0, 1]),
             Nx.tensor([-1.0, 1.0])
           ] do
-        assert unary_minus(t) == Nx.negate(t)
+        assert_equal(unary_minus(t), Nx.negate(t))
       end
     end
 
@@ -306,8 +322,8 @@ defmodule EXLA.Defn.ExprTest do
 
     test "max" do
       for {left, right} <- @tensors do
-        compare_tensors!(max_two(left, right), Nx.max(left, right))
-        compare_tensors!(max_two(right, left), Nx.max(right, left))
+        assert_all_close(max_two(left, right), Nx.max(left, right))
+        assert_all_close(max_two(right, left), Nx.max(right, left))
       end
     end
 
@@ -315,8 +331,8 @@ defmodule EXLA.Defn.ExprTest do
 
     test "min" do
       for {left, right} <- @tensors do
-        compare_tensors!(min_two(left, right), Nx.min(left, right))
-        compare_tensors!(min_two(right, left), Nx.min(right, left))
+        assert_all_close(min_two(left, right), Nx.min(left, right))
+        assert_all_close(min_two(right, left), Nx.min(right, left))
       end
     end
 
@@ -324,8 +340,8 @@ defmodule EXLA.Defn.ExprTest do
 
     test "power" do
       for {left, right} <- @tensors do
-        compare_tensors!(power_two(left, right), Nx.power(left, right))
-        compare_tensors!(power_two(right, left), Nx.power(right, left))
+        assert_all_close(power_two(left, right), Nx.power(left, right))
+        assert_all_close(power_two(right, left), Nx.power(right, left))
       end
     end
 
@@ -336,8 +352,8 @@ defmodule EXLA.Defn.ExprTest do
       left = Nx.tensor([-1.0, neg_zero, 0.0, 1.0])
       right = Nx.tensor([[-1.0], [neg_zero], [0.0], [1.0]])
 
-      compare_tensors!(atan2_two(left, right), Nx.atan2(left, right))
-      compare_tensors!(atan2_two(right, left), Nx.atan2(right, left))
+      assert_all_close(atan2_two(left, right), Nx.atan2(left, right))
+      assert_all_close(atan2_two(right, left), Nx.atan2(right, left))
     end
 
     defn quotient_two(a, b), do: Nx.quotient(a, b)
@@ -353,8 +369,8 @@ defmodule EXLA.Defn.ExprTest do
       ]
 
       for {left, right} <- int_tensors do
-        compare_tensors!(quotient_two(left, right), Nx.quotient(left, right))
-        compare_tensors!(quotient_two(right, left), Nx.quotient(right, left))
+        assert_all_close(quotient_two(left, right), Nx.quotient(left, right))
+        assert_all_close(quotient_two(right, left), Nx.quotient(right, left))
       end
     end
   end
@@ -367,35 +383,35 @@ defmodule EXLA.Defn.ExprTest do
 
     test "bitwise_and" do
       assert Nx.shape(bitwise_and(@left, @right)) == {5, 5}
-      assert bitwise_and(@left, @right) == Nx.bitwise_and(@left, @right)
+      assert_equal(bitwise_and(@left, @right), Nx.bitwise_and(@left, @right))
     end
 
     defn bitwise_or(a, b), do: a ||| b
 
     test "bitwise_or" do
       assert Nx.shape(bitwise_or(@left, @right)) == {5, 5}
-      assert bitwise_or(@left, @right) == Nx.bitwise_or(@left, @right)
+      assert_equal(bitwise_or(@left, @right), Nx.bitwise_or(@left, @right))
     end
 
     defn bitwise_not(a), do: ~~~a
 
     test "bitwise_not" do
       assert Nx.shape(bitwise_not(@left)) == {5}
-      assert bitwise_not(@left) == Nx.bitwise_not(@left)
+      assert_equal(bitwise_not(@left), Nx.bitwise_not(@left))
     end
 
     defn bitwise_pc(a), do: Nx.population_count(a)
 
     test "population_count" do
       assert Nx.shape(bitwise_pc(@left)) == {5}
-      assert bitwise_pc(@left) == Nx.population_count(@left)
+      assert_equal(bitwise_pc(@left), Nx.population_count(@left))
     end
 
     defn bitwise_clz(a), do: Nx.count_leading_zeros(a)
 
     test "count_leading_zeros" do
       assert Nx.shape(bitwise_clz(@left)) == {5}
-      assert bitwise_clz(@left) == Nx.count_leading_zeros(@left)
+      assert_equal(bitwise_clz(@left), Nx.count_leading_zeros(@left))
     end
 
     @left Nx.tensor([-2, -1, 0, 1, 2])
@@ -405,7 +421,7 @@ defmodule EXLA.Defn.ExprTest do
 
     test "left_shift" do
       assert Nx.shape(left_shift(@left, @right)) == {5, 5}
-      assert left_shift(@left, @right) == Nx.left_shift(@left, @right)
+      assert_equal(left_shift(@left, @right), Nx.left_shift(@left, @right))
     end
 
     @left_signed Nx.tensor([-128, -127, -2, -1, 0, 1, 2, 126, 127], type: {:s, 8})
@@ -419,13 +435,17 @@ defmodule EXLA.Defn.ExprTest do
     test "right_shift" do
       assert Nx.shape(right_shift(@left_signed, @right_signed)) == {9, 9}
 
-      assert right_shift(@left_signed, @right_signed) ==
-               Nx.right_shift(@left_signed, @right_signed)
+      assert_equal(
+        right_shift(@left_signed, @right_signed),
+        Nx.right_shift(@left_signed, @right_signed)
+      )
 
       assert Nx.shape(right_shift(@left_unsigned, @right_unsigned)) == {6, 6}
 
-      assert right_shift(@left_unsigned, @right_unsigned) ==
-               Nx.right_shift(@left_unsigned, @right_unsigned)
+      assert_equal(
+        right_shift(@left_unsigned, @right_unsigned),
+        Nx.right_shift(@left_unsigned, @right_unsigned)
+      )
     end
   end
 
@@ -433,30 +453,30 @@ defmodule EXLA.Defn.ExprTest do
     defn exp(t), do: Nx.exp(t)
 
     test "computes the exp across types" do
-      assert compare_tensors!(
-               Nx.tensor([1, 2, 3]) |> exp(),
-               Nx.tensor([2.718281828459045, 7.38905609893065, 20.085536923187668])
-             )
+      assert_all_close(
+        Nx.tensor([1, 2, 3]) |> exp(),
+        Nx.tensor([2.718281828459045, 7.38905609893065, 20.085536923187668])
+      )
 
-      assert compare_tensors!(
-               Nx.tensor([1, 2, 3], type: {:s, 8}) |> exp(),
-               Nx.tensor([2.718281828459045, 7.38905609893065, 20.085536923187668], type: {:f, 32})
-             )
+      assert_all_close(
+        Nx.tensor([1, 2, 3], type: {:s, 8}) |> exp(),
+        Nx.tensor([2.718281828459045, 7.38905609893065, 20.085536923187668], type: {:f, 32})
+      )
 
-      assert compare_tensors!(
-               Nx.tensor([1, 2, 3], type: {:u, 8}) |> exp(),
-               Nx.tensor([2.718281828459045, 7.38905609893065, 20.085536923187668], type: {:f, 32})
-             )
+      assert_all_close(
+        Nx.tensor([1, 2, 3], type: {:u, 8}) |> exp(),
+        Nx.tensor([2.718281828459045, 7.38905609893065, 20.085536923187668], type: {:f, 32})
+      )
 
-      assert compare_tensors!(
-               Nx.tensor([1.0, 2.0, 3.0]) |> exp(),
-               Nx.tensor([2.718281828459045, 7.38905609893065, 20.085536923187668])
-             )
+      assert_all_close(
+        Nx.tensor([1.0, 2.0, 3.0]) |> exp(),
+        Nx.tensor([2.718281828459045, 7.38905609893065, 20.085536923187668])
+      )
 
-      assert compare_tensors!(
-               Nx.tensor([1.0, 2.0, 3.0], type: {:f, 32}) |> exp(),
-               Nx.tensor([2.718281828459045, 7.38905609893065, 20.085536923187668], type: {:f, 32})
-             )
+      assert_all_close(
+        Nx.tensor([1.0, 2.0, 3.0], type: {:f, 32}) |> exp(),
+        Nx.tensor([2.718281828459045, 7.38905609893065, 20.085536923187668], type: {:f, 32})
+      )
     end
   end
 
@@ -464,16 +484,18 @@ defmodule EXLA.Defn.ExprTest do
     defn equal(a, b), do: Nx.equal(a, b)
 
     test "computes equality of scalars" do
-      assert equal(Nx.tensor(1), Nx.tensor(2)) == Nx.tensor(0, type: {:u, 8})
+      assert_equal(equal(Nx.tensor(1), Nx.tensor(2)), Nx.tensor(0, type: {:u, 8}))
     end
 
     test "computes equality with broadcasting" do
-      assert equal(Nx.tensor(1), Nx.tensor([1, 2, 3])) == Nx.tensor([1, 0, 0], type: {:u, 8})
+      assert_equal(equal(Nx.tensor(1), Nx.tensor([1, 2, 3])), Nx.tensor([1, 0, 0], type: {:u, 8}))
     end
 
     test "computes equality with mixed types" do
-      assert equal(Nx.tensor([1, 2, 3]), Nx.tensor([1.0, 2.0, 3.0])) ==
-               Nx.tensor([1, 1, 1], type: {:u, 8})
+      assert_equal(
+        equal(Nx.tensor([1, 2, 3]), Nx.tensor([1.0, 2.0, 3.0])),
+        Nx.tensor([1, 1, 1], type: {:u, 8})
+      )
     end
 
     defn successive_compare(y_true, y_pred) do
@@ -483,7 +505,7 @@ defmodule EXLA.Defn.ExprTest do
     end
 
     test "computes successive comparisons" do
-      assert successive_compare(Nx.tensor(1), Nx.tensor(1)) == Nx.tensor(1, type: {:u, 8})
+      assert_equal(successive_compare(Nx.tensor(1), Nx.tensor(1)), Nx.tensor(1, type: {:u, 8}))
     end
   end
 
@@ -491,16 +513,21 @@ defmodule EXLA.Defn.ExprTest do
     defn not_equal(a, b), do: Nx.not_equal(a, b)
 
     test "computes equality of scalars" do
-      assert not_equal(Nx.tensor(1), Nx.tensor(2)) == Nx.tensor(1, type: {:u, 8})
+      assert_equal(not_equal(Nx.tensor(1), Nx.tensor(2)), Nx.tensor(1, type: {:u, 8}))
     end
 
     test "computes equality with broadcasting" do
-      assert not_equal(Nx.tensor(1), Nx.tensor([1, 2, 3])) == Nx.tensor([0, 1, 1], type: {:u, 8})
+      assert_equal(
+        not_equal(Nx.tensor(1), Nx.tensor([1, 2, 3])),
+        Nx.tensor([0, 1, 1], type: {:u, 8})
+      )
     end
 
     test "computes equality with mixed types" do
-      assert not_equal(Nx.tensor([1, 2, 3]), Nx.tensor([1.0, 2.0, 3.0])) ==
-               Nx.tensor([0, 0, 0], type: {:u, 8})
+      assert_equal(
+        not_equal(Nx.tensor([1, 2, 3]), Nx.tensor([1.0, 2.0, 3.0])),
+        Nx.tensor([0, 0, 0], type: {:u, 8})
+      )
     end
   end
 
@@ -508,16 +535,18 @@ defmodule EXLA.Defn.ExprTest do
     defn less(a, b), do: Nx.less(a, b)
 
     test "compares scalars" do
-      assert less(Nx.tensor(1), Nx.tensor(2)) == Nx.tensor(1, type: {:u, 8})
+      assert_equal(less(Nx.tensor(1), Nx.tensor(2)), Nx.tensor(1, type: {:u, 8}))
     end
 
     test "compares with broadcasting" do
-      assert less(Nx.tensor(1), Nx.tensor([1, 2, 3])) == Nx.tensor([0, 1, 1], type: {:u, 8})
+      assert_equal(less(Nx.tensor(1), Nx.tensor([1, 2, 3])), Nx.tensor([0, 1, 1], type: {:u, 8}))
     end
 
     test "compares with mixed types" do
-      assert less(Nx.tensor([1, 2, 3]), Nx.tensor([1.0, 2.0, 3.0])) ==
-               Nx.tensor([0, 0, 0], type: {:u, 8})
+      assert_equal(
+        less(Nx.tensor([1, 2, 3]), Nx.tensor([1.0, 2.0, 3.0])),
+        Nx.tensor([0, 0, 0], type: {:u, 8})
+      )
     end
   end
 
@@ -525,16 +554,21 @@ defmodule EXLA.Defn.ExprTest do
     defn greater(a, b), do: Nx.greater(a, b)
 
     test "compares scalars" do
-      assert greater(Nx.tensor(1), Nx.tensor(2)) == Nx.tensor(0, type: {:u, 8})
+      assert_equal(greater(Nx.tensor(1), Nx.tensor(2)), Nx.tensor(0, type: {:u, 8}))
     end
 
     test "compares with broadcasting" do
-      assert greater(Nx.tensor(1), Nx.tensor([1, 2, 3])) == Nx.tensor([0, 0, 0], type: {:u, 8})
+      assert_equal(
+        greater(Nx.tensor(1), Nx.tensor([1, 2, 3])),
+        Nx.tensor([0, 0, 0], type: {:u, 8})
+      )
     end
 
     test "compares with mixed types" do
-      assert greater(Nx.tensor([1, 2, 3]), Nx.tensor([1.0, 2.0, 3.0])) ==
-               Nx.tensor([0, 0, 0], type: {:u, 8})
+      assert_equal(
+        greater(Nx.tensor([1, 2, 3]), Nx.tensor([1.0, 2.0, 3.0])),
+        Nx.tensor([0, 0, 0], type: {:u, 8})
+      )
     end
   end
 
@@ -542,16 +576,21 @@ defmodule EXLA.Defn.ExprTest do
     defn less_equal(a, b), do: Nx.less_equal(a, b)
 
     test "compares scalars" do
-      assert less_equal(Nx.tensor(1), Nx.tensor(2)) == Nx.tensor(1, type: {:u, 8})
+      assert_equal(less_equal(Nx.tensor(1), Nx.tensor(2)), Nx.tensor(1, type: {:u, 8}))
     end
 
     test "compares with broadcasting" do
-      assert less_equal(Nx.tensor(1), Nx.tensor([1, 2, 3])) == Nx.tensor([1, 1, 1], type: {:u, 8})
+      assert_equal(
+        less_equal(Nx.tensor(1), Nx.tensor([1, 2, 3])),
+        Nx.tensor([1, 1, 1], type: {:u, 8})
+      )
     end
 
     test "compares with mixed types" do
-      assert less_equal(Nx.tensor([1, 2, 3]), Nx.tensor([1.0, 2.0, 3.0])) ==
-               Nx.tensor([1, 1, 1], type: {:u, 8})
+      assert_equal(
+        less_equal(Nx.tensor([1, 2, 3]), Nx.tensor([1.0, 2.0, 3.0])),
+        Nx.tensor([1, 1, 1], type: {:u, 8})
+      )
     end
   end
 
@@ -559,17 +598,21 @@ defmodule EXLA.Defn.ExprTest do
     defn greater_equal(a, b), do: Nx.greater_equal(a, b)
 
     test "compares scalars" do
-      assert greater_equal(Nx.tensor(1), Nx.tensor(2)) == Nx.tensor(0, type: {:u, 8})
+      assert_equal(greater_equal(Nx.tensor(1), Nx.tensor(2)), Nx.tensor(0, type: {:u, 8}))
     end
 
     test "compares with broadcasting" do
-      assert greater_equal(Nx.tensor(1), Nx.tensor([1, 2, 3])) ==
-               Nx.tensor([1, 0, 0], type: {:u, 8})
+      assert_equal(
+        greater_equal(Nx.tensor(1), Nx.tensor([1, 2, 3])),
+        Nx.tensor([1, 0, 0], type: {:u, 8})
+      )
     end
 
     test "compares with mixed types" do
-      assert greater_equal(Nx.tensor([1, 2, 3]), Nx.tensor([1.0, 2.0, 3.0])) ==
-               Nx.tensor([1, 1, 1], type: {:u, 8})
+      assert_equal(
+        greater_equal(Nx.tensor([1, 2, 3]), Nx.tensor([1.0, 2.0, 3.0])),
+        Nx.tensor([1, 1, 1], type: {:u, 8})
+      )
     end
   end
 
@@ -577,80 +620,94 @@ defmodule EXLA.Defn.ExprTest do
     defn logical_and(a, b), do: Nx.logical_and(a, b)
 
     test "and" do
-      assert logical_and(Nx.tensor([-1, 0, 1]), Nx.tensor([[-1], [0], [1]])) ==
-               Nx.tensor(
-                 [
-                   [1, 0, 1],
-                   [0, 0, 0],
-                   [1, 0, 1]
-                 ],
-                 type: {:u, 8}
-               )
+      assert_equal(
+        logical_and(Nx.tensor([-1, 0, 1]), Nx.tensor([[-1], [0], [1]])),
+        Nx.tensor(
+          [
+            [1, 0, 1],
+            [0, 0, 0],
+            [1, 0, 1]
+          ],
+          type: {:u, 8}
+        )
+      )
 
-      assert logical_and(Nx.tensor([-1.0, 0.0, 1.0]), Nx.tensor([[-1], [0], [1]])) ==
-               Nx.tensor(
-                 [
-                   [1, 0, 1],
-                   [0, 0, 0],
-                   [1, 0, 1]
-                 ],
-                 type: {:u, 8}
-               )
+      assert_equal(
+        logical_and(Nx.tensor([-1.0, 0.0, 1.0]), Nx.tensor([[-1], [0], [1]])),
+        Nx.tensor(
+          [
+            [1, 0, 1],
+            [0, 0, 0],
+            [1, 0, 1]
+          ],
+          type: {:u, 8}
+        )
+      )
     end
 
     defn logical_or(a, b), do: Nx.logical_or(a, b)
 
     test "or" do
-      assert logical_or(Nx.tensor([-1, 0, 1]), Nx.tensor([[-1], [0], [1]])) ==
-               Nx.tensor(
-                 [
-                   [1, 1, 1],
-                   [1, 0, 1],
-                   [1, 1, 1]
-                 ],
-                 type: {:u, 8}
-               )
+      assert_equal(
+        logical_or(Nx.tensor([-1, 0, 1]), Nx.tensor([[-1], [0], [1]])),
+        Nx.tensor(
+          [
+            [1, 1, 1],
+            [1, 0, 1],
+            [1, 1, 1]
+          ],
+          type: {:u, 8}
+        )
+      )
 
-      assert logical_or(Nx.tensor([-1.0, 0.0, 1.0]), Nx.tensor([[-1], [0], [1]])) ==
-               Nx.tensor(
-                 [
-                   [1, 1, 1],
-                   [1, 0, 1],
-                   [1, 1, 1]
-                 ],
-                 type: {:u, 8}
-               )
+      assert_equal(
+        logical_or(Nx.tensor([-1.0, 0.0, 1.0]), Nx.tensor([[-1], [0], [1]])),
+        Nx.tensor(
+          [
+            [1, 1, 1],
+            [1, 0, 1],
+            [1, 1, 1]
+          ],
+          type: {:u, 8}
+        )
+      )
     end
 
     defn logical_xor(a, b), do: Nx.logical_xor(a, b)
 
     test "xor" do
-      assert logical_xor(Nx.tensor([-1, 0, 1]), Nx.tensor([[-1], [0], [1]])) ==
-               Nx.tensor(
-                 [
-                   [0, 1, 0],
-                   [1, 0, 1],
-                   [0, 1, 0]
-                 ],
-                 type: {:u, 8}
-               )
+      assert_equal(
+        logical_xor(Nx.tensor([-1, 0, 1]), Nx.tensor([[-1], [0], [1]])),
+        Nx.tensor(
+          [
+            [0, 1, 0],
+            [1, 0, 1],
+            [0, 1, 0]
+          ],
+          type: {:u, 8}
+        )
+      )
 
-      assert logical_xor(Nx.tensor([-1.0, 0.0, 1.0]), Nx.tensor([[-1], [0], [1]])) ==
-               Nx.tensor(
-                 [
-                   [0, 1, 0],
-                   [1, 0, 1],
-                   [0, 1, 0]
-                 ],
-                 type: {:u, 8}
-               )
+      assert_equal(
+        logical_xor(Nx.tensor([-1.0, 0.0, 1.0]), Nx.tensor([[-1], [0], [1]])),
+        Nx.tensor(
+          [
+            [0, 1, 0],
+            [1, 0, 1],
+            [0, 1, 0]
+          ],
+          type: {:u, 8}
+        )
+      )
     end
 
     defn logical_not(a), do: Nx.logical_not(a)
 
     test "not" do
-      assert logical_not(Nx.tensor([-2, -1, 0, 1, 2])) ==
-               Nx.tensor([0, 0, 1, 0, 0], type: {:u, 8})
+      assert_equal(
+        logical_not(Nx.tensor([-2, -1, 0, 1, 2])),
+        Nx.tensor([0, 0, 1, 0, 0], type: {:u, 8})
+      )
     end
   end
 
@@ -658,32 +715,42 @@ defmodule EXLA.Defn.ExprTest do
     defn select(pred, x, y), do: Nx.select(pred, x, y)
 
     test "selects one or the other with a scalar" do
-      assert select(Nx.tensor(1), Nx.tensor([1, 2, 3]), Nx.tensor([4, 5, 6])) ==
-               Nx.tensor([1, 2, 3])
+      assert_equal(
+        select(Nx.tensor(1), Nx.tensor([1, 2, 3]), Nx.tensor([4, 5, 6])),
+        Nx.tensor([1, 2, 3])
+      )
     end
 
     test "selects with type" do
-      assert select(
-               Nx.tensor(1),
-               Nx.tensor([1, 2, 3], type: {:u, 8}),
-               Nx.tensor([4, 5, 6], type: {:u, 8})
-             ) ==
-               Nx.tensor([1, 2, 3], type: {:u, 8})
+      assert_equal(
+        select(
+          Nx.tensor(1),
+          Nx.tensor([1, 2, 3], type: {:u, 8}),
+          Nx.tensor([4, 5, 6], type: {:u, 8})
+        ),
+        Nx.tensor([1, 2, 3], type: {:u, 8})
+      )
 
-      assert select(
-               Nx.tensor(1),
-               Nx.tensor([1, 2, 3], type: {:u, 8}),
-               Nx.tensor([4, 5, 6], type: {:f, 32})
-             ) ==
-               Nx.tensor([1, 2, 3], type: {:f, 32})
+      assert_equal(
+        select(
+          Nx.tensor(1),
+          Nx.tensor([1, 2, 3], type: {:u, 8}),
+          Nx.tensor([4, 5, 6], type: {:f, 32})
+        ),
+        Nx.tensor([1, 2, 3], type: {:f, 32})
+      )
     end
 
     test "selects with broadcasting" do
-      assert select(Nx.tensor([1, 0, 1, 0, 1]), Nx.tensor([10]), Nx.tensor([1, 2, 3, 4, 5])) ==
-               Nx.tensor([10, 2, 10, 4, 10])
+      assert_equal(
+        select(Nx.tensor([1, 0, 1, 0, 1]), Nx.tensor([10]), Nx.tensor([1, 2, 3, 4, 5])),
+        Nx.tensor([10, 2, 10, 4, 10])
+      )
 
-      assert select(Nx.tensor([-2, -1, 0, 1, 2]), Nx.tensor([10]), Nx.tensor([1, 2, 3, 4, 5])) ==
-               Nx.tensor([10, 10, 3, 10, 10])
+      assert_equal(
+        select(Nx.tensor([-2, -1, 0, 1, 2]), Nx.tensor([10]), Nx.tensor([1, 2, 3, 4, 5])),
+        Nx.tensor([10, 10, 3, 10, 10])
+      )
     end
   end
 
@@ -699,12 +766,12 @@ defmodule EXLA.Defn.ExprTest do
       defn unquote(defn_fun)(t), do: Nx.unquote(fun)(t)
 
       test "#{fun}" do
-        compare_tensors!(
+        assert_all_close(
           unquote(defn_fun)(@float_tensor),
           evaluate(&(unquote(defn_var) / 1), [@float_tensor])
         )
 
-        compare_tensors!(
+        assert_all_close(
           unquote(defn_fun)(@int_tensor),
           evaluate(&(unquote(defn_var) / 1), [@int_tensor])
         )
@@ -722,12 +789,12 @@ defmodule EXLA.Defn.ExprTest do
       defn unquote(defn_fun)(t), do: Nx.unquote(fun)(t)
 
       test "#{fun}" do
-        compare_tensors!(
+        assert_all_close(
           unquote(defn_fun)(@float_tensor),
           evaluate(&(unquote(defn_var) / 1), [@float_tensor])
         )
 
-        compare_tensors!(
+        assert_all_close(
           unquote(defn_fun)(@int_tensor),
           evaluate(&(unquote(defn_var) / 1), [@int_tensor])
         )
@@ -748,17 +815,17 @@ defmodule EXLA.Defn.ExprTest do
       defn unquote(defn_fun)(t), do: Nx.unquote(fun)(t)
 
       test "#{fun}" do
-        compare_tensors!(
+        assert_all_close(
           unquote(defn_fun)(@uint_tensor),
           evaluate(&(unquote(defn_var) / 1), [@uint_tensor])
         )
 
-        compare_tensors!(
+        assert_all_close(
           unquote(defn_fun)(@sint_tensor),
           evaluate(&(unquote(defn_var) / 1), [@sint_tensor])
         )
 
-        compare_tensors!(
+        assert_all_close(
           unquote(defn_fun)(@float_tensor),
           evaluate(&(unquote(defn_var) / 1), [@float_tensor])
         )
@@ -770,7 +837,7 @@ defmodule EXLA.Defn.ExprTest do
     defn to_float(t), do: Nx.as_type(t, {:f, 32})
 
     test "converts tensor type" do
-      assert to_float(Nx.tensor([1, 2, 3])) == Nx.tensor([1.0, 2.0, 3.0], type: {:f, 32})
+      assert_equal(to_float(Nx.tensor([1, 2, 3])), Nx.tensor([1.0, 2.0, 3.0], type: {:f, 32}))
     end
 
     defn generic_as_type(t, template), do: Nx.as_type(t, template.type)
@@ -779,11 +846,15 @@ defmodule EXLA.Defn.ExprTest do
       non_finite =
         Nx.tensor([Nx.Constants.infinity(), Nx.Constants.nan(), Nx.Constants.neg_infinity()])
 
-      assert generic_as_type(non_finite, Nx.template({}, {:u, 8})) ==
-               Nx.tensor([255, 0, 0], type: {:u, 8})
+      assert_equal(
+        generic_as_type(non_finite, Nx.template({}, {:u, 8})),
+        Nx.tensor([255, 0, 0], type: {:u, 8})
+      )
 
-      assert generic_as_type(non_finite, Nx.template({}, {:s, 16})) ==
-               Nx.tensor([32767, 0, -32768], type: {:s, 16})
+      assert_equal(
+        generic_as_type(non_finite, Nx.template({}, {:s, 16})),
+        Nx.tensor([32767, 0, -32768], type: {:s, 16})
+      )
     end
   end
 
@@ -791,7 +862,10 @@ defmodule EXLA.Defn.ExprTest do
     defn bitcast_to_float(t), do: Nx.bitcast(t, {:f, 32})
 
     test "converts tensor type" do
-      assert bitcast_to_float(Nx.tensor([0, 0, 0], type: {:s, 32})) == Nx.tensor([0.0, 0.0, 0.0])
+      assert_equal(
+        bitcast_to_float(Nx.tensor([0, 0, 0], type: {:s, 32})),
+        Nx.tensor([0.0, 0.0, 0.0])
+      )
     end
   end
 
@@ -799,27 +873,37 @@ defmodule EXLA.Defn.ExprTest do
     defn if3(a, b, c), do: if(a, do: b, else: c)
 
     test "one param per branch" do
-      assert if3(Nx.tensor(0), Nx.tensor(1, type: {:s, 16}), Nx.tensor(2, type: {:f, 32})) ==
-               Nx.tensor(2, type: {:f, 32})
+      assert_equal(
+        if3(Nx.tensor(0), Nx.tensor(1, type: {:s, 16}), Nx.tensor(2, type: {:f, 32})),
+        Nx.tensor(2, type: {:f, 32})
+      )
 
-      assert if3(Nx.tensor(1), Nx.tensor(1, type: {:s, 16}), Nx.tensor(2, type: {:f, 32})) ==
-               Nx.tensor(1, type: {:f, 32})
+      assert_equal(
+        if3(Nx.tensor(1), Nx.tensor(1, type: {:s, 16}), Nx.tensor(2, type: {:f, 32})),
+        Nx.tensor(1, type: {:f, 32})
+      )
 
-      assert if3(Nx.tensor(2), Nx.tensor(1, type: {:s, 16}), Nx.tensor(2, type: {:f, 32})) ==
-               Nx.tensor(1, type: {:f, 32})
+      assert_equal(
+        if3(Nx.tensor(2), Nx.tensor(1, type: {:s, 16}), Nx.tensor(2, type: {:f, 32})),
+        Nx.tensor(1, type: {:f, 32})
+      )
 
-      assert if3(Nx.tensor(0), Nx.tensor([1, 2]), Nx.tensor([[3], [4]])) ==
-               Nx.tensor([[3, 3], [4, 4]])
+      assert_equal(
+        if3(Nx.tensor(0), Nx.tensor([1, 2]), Nx.tensor([[3], [4]])),
+        Nx.tensor([[3, 3], [4, 4]])
+      )
 
-      assert if3(Nx.tensor(1), Nx.tensor([1, 2]), Nx.tensor([[3], [4]])) ==
-               Nx.tensor([[1, 2], [1, 2]])
+      assert_equal(
+        if3(Nx.tensor(1), Nx.tensor([1, 2]), Nx.tensor([[3], [4]])),
+        Nx.tensor([[1, 2], [1, 2]])
+      )
     end
 
     defn if_params(a, b, c), do: if(a, do: b + c, else: b - c)
 
     test "two params per branch" do
-      assert if_params(Nx.tensor(0), Nx.tensor(1), Nx.tensor(2)) == Nx.tensor(-1)
-      assert if_params(Nx.tensor(1), Nx.tensor(1), Nx.tensor(2)) == Nx.tensor(3)
+      assert_equal(if_params(Nx.tensor(0), Nx.tensor(1), Nx.tensor(2)), Nx.tensor(-1))
+      assert_equal(if_params(Nx.tensor(1), Nx.tensor(1), Nx.tensor(2)), Nx.tensor(3))
     end
 
     defn if_shared(a, b, c) do
@@ -828,24 +912,32 @@ defmodule EXLA.Defn.ExprTest do
     end
 
     test "shared params between pred+branch and no params" do
-      assert if_shared(Nx.tensor(0), Nx.tensor(1), Nx.tensor(2)) == Nx.tensor(-1)
-      assert if_shared(Nx.tensor(2), Nx.tensor(1), Nx.tensor(2)) == Nx.tensor(12)
+      assert_equal(if_shared(Nx.tensor(0), Nx.tensor(1), Nx.tensor(2)), Nx.tensor(-1))
+      assert_equal(if_shared(Nx.tensor(2), Nx.tensor(1), Nx.tensor(2)), Nx.tensor(12))
     end
 
     defn if_tuple(a, b, c), do: if(a, do: {{a, b}, c}, else: {{c, b}, a})
 
     test "with tuples" do
-      assert if_tuple(Nx.tensor(0), Nx.tensor(10), Nx.tensor(20)) ==
-               {{Nx.tensor(20), Nx.tensor(10)}, Nx.tensor(0)}
+      assert_equal(
+        if_tuple(Nx.tensor(0), Nx.tensor(10), Nx.tensor(20)),
+        {{Nx.tensor(20), Nx.tensor(10)}, Nx.tensor(0)}
+      )
 
-      assert if_tuple(Nx.tensor(1), Nx.tensor(10), Nx.tensor(20)) ==
-               {{Nx.tensor(1), Nx.tensor(10)}, Nx.tensor(20)}
+      assert_equal(
+        if_tuple(Nx.tensor(1), Nx.tensor(10), Nx.tensor(20)),
+        {{Nx.tensor(1), Nx.tensor(10)}, Nx.tensor(20)}
+      )
 
-      assert if_tuple(Nx.tensor(0), Nx.tensor(10), Nx.tensor([20, 30])) ==
-               {{Nx.tensor([20, 30]), Nx.tensor(10)}, Nx.tensor([0, 0])}
+      assert_equal(
+        if_tuple(Nx.tensor(0), Nx.tensor(10), Nx.tensor([20, 30])),
+        {{Nx.tensor([20, 30]), Nx.tensor(10)}, Nx.tensor([0, 0])}
+      )
 
-      assert if_tuple(Nx.tensor(1), Nx.tensor(10), Nx.tensor([20, 30])) ==
-               {{Nx.tensor([1, 1]), Nx.tensor(10)}, Nx.tensor([20, 30])}
+      assert_equal(
+        if_tuple(Nx.tensor(1), Nx.tensor(10), Nx.tensor([20, 30])),
+        {{Nx.tensor([1, 1]), Nx.tensor(10)}, Nx.tensor([20, 30])}
+      )
     end
 
     defn if_tuple_match(a, b, c) do
@@ -854,8 +946,8 @@ defmodule EXLA.Defn.ExprTest do
     end
 
     test "with matched tuples" do
-      assert if_tuple_match(Nx.tensor(0), Nx.tensor(10), Nx.tensor(20)) == Nx.tensor(200)
-      assert if_tuple_match(Nx.tensor(1), Nx.tensor(10), Nx.tensor(20)) == Nx.tensor(-10)
+      assert_equal(if_tuple_match(Nx.tensor(0), Nx.tensor(10), Nx.tensor(20)), Nx.tensor(200))
+      assert_equal(if_tuple_match(Nx.tensor(1), Nx.tensor(10), Nx.tensor(20)), Nx.tensor(-10))
     end
 
     defn if_tuple_return(a, b, c) do
@@ -864,27 +956,39 @@ defmodule EXLA.Defn.ExprTest do
     end
 
     test "with return tuple" do
-      assert if_tuple_return(Nx.tensor(0), Nx.tensor(10), Nx.tensor(20)) ==
-               {Nx.tensor(20), Nx.tensor(10)}
+      assert_equal(
+        if_tuple_return(Nx.tensor(0), Nx.tensor(10), Nx.tensor(20)),
+        {Nx.tensor(20), Nx.tensor(10)}
+      )
 
-      assert if_tuple_return(Nx.tensor(1), Nx.tensor(10), Nx.tensor(20)) ==
-               {Nx.tensor(1), Nx.tensor(10)}
+      assert_equal(
+        if_tuple_return(Nx.tensor(1), Nx.tensor(10), Nx.tensor(20)),
+        {Nx.tensor(1), Nx.tensor(10)}
+      )
     end
 
     defn if_map(a, b, c), do: if(a, do: {%{a: a, b: b, c: 1}, c}, else: {%{a: c, b: b, c: 2}, a})
 
     test "with map" do
-      assert if_map(Nx.tensor(0), Nx.tensor(10), Nx.tensor(20)) ==
-               {%{a: Nx.tensor(20), b: Nx.tensor(10), c: Nx.tensor(2)}, Nx.tensor(0)}
+      assert_equal(
+        if_map(Nx.tensor(0), Nx.tensor(10), Nx.tensor(20)),
+        {%{a: Nx.tensor(20), b: Nx.tensor(10), c: Nx.tensor(2)}, Nx.tensor(0)}
+      )
 
-      assert if_map(Nx.tensor(1), Nx.tensor(10), Nx.tensor(20)) ==
-               {%{a: Nx.tensor(1), b: Nx.tensor(10), c: Nx.tensor(1)}, Nx.tensor(20)}
+      assert_equal(
+        if_map(Nx.tensor(1), Nx.tensor(10), Nx.tensor(20)),
+        {%{a: Nx.tensor(1), b: Nx.tensor(10), c: Nx.tensor(1)}, Nx.tensor(20)}
+      )
 
-      assert if_map(Nx.tensor(0), Nx.tensor(10), Nx.tensor([20, 30])) ==
-               {%{a: Nx.tensor([20, 30]), b: Nx.tensor(10), c: Nx.tensor(2)}, Nx.tensor([0, 0])}
+      assert_equal(
+        if_map(Nx.tensor(0), Nx.tensor(10), Nx.tensor([20, 30])),
+        {%{a: Nx.tensor([20, 30]), b: Nx.tensor(10), c: Nx.tensor(2)}, Nx.tensor([0, 0])}
+      )
 
-      assert if_map(Nx.tensor(1), Nx.tensor(10), Nx.tensor([20, 30])) ==
-               {%{a: Nx.tensor([1, 1]), b: Nx.tensor(10), c: Nx.tensor(1)}, Nx.tensor([20, 30])}
+      assert_equal(
+        if_map(Nx.tensor(1), Nx.tensor(10), Nx.tensor([20, 30])),
+        {%{a: Nx.tensor([1, 1]), b: Nx.tensor(10), c: Nx.tensor(1)}, Nx.tensor([20, 30])}
+      )
     end
 
     defn if_map_match(a, b, c) do
@@ -893,8 +997,8 @@ defmodule EXLA.Defn.ExprTest do
     end
 
     test "with matched map" do
-      assert if_map_match(Nx.tensor(0), Nx.tensor(10), Nx.tensor(20)) == Nx.tensor(200)
-      assert if_map_match(Nx.tensor(1), Nx.tensor(10), Nx.tensor(20)) == Nx.tensor(-10)
+      assert_equal(if_map_match(Nx.tensor(0), Nx.tensor(10), Nx.tensor(20)), Nx.tensor(200))
+      assert_equal(if_map_match(Nx.tensor(1), Nx.tensor(10), Nx.tensor(20)), Nx.tensor(-10))
     end
   end
 
@@ -902,7 +1006,7 @@ defmodule EXLA.Defn.ExprTest do
     defn add_with_stop_grad(a, b), do: stop_grad(Nx.add(a, b))
 
     test "ignores metadata nodes" do
-      assert add_with_stop_grad(1, 2) == Nx.tensor(3)
+      assert_equal(add_with_stop_grad(1, 2), Nx.tensor(3))
     end
   end
 
@@ -918,9 +1022,9 @@ defmodule EXLA.Defn.ExprTest do
     end
 
     test "computes cond" do
-      assert cond3(Nx.tensor([-1, 0, 1]), Nx.tensor(2), Nx.tensor(3.0)) == Nx.tensor(-5.0)
-      assert cond3(Nx.tensor([1, 2, 3]), Nx.tensor(2), Nx.tensor(3.0)) == Nx.tensor(36.0)
-      assert cond3(Nx.tensor([-1, -2, -3]), Nx.tensor(2), Nx.tensor(3.0)) == Nx.tensor(-1.0)
+      assert_equal(cond3(Nx.tensor([-1, 0, 1]), Nx.tensor(2), Nx.tensor(3.0)), Nx.tensor(-5.0))
+      assert_equal(cond3(Nx.tensor([1, 2, 3]), Nx.tensor(2), Nx.tensor(3.0)), Nx.tensor(36.0))
+      assert_equal(cond3(Nx.tensor([-1, -2, -3]), Nx.tensor(2), Nx.tensor(3.0)), Nx.tensor(-1.0))
     end
 
     defn cond_unused_and_slice(_result, state) do
@@ -932,9 +1036,14 @@ defmodule EXLA.Defn.ExprTest do
     end
 
     test "computes cond with slice and unused vars" do
-      assert cond_unused_and_slice(Nx.tensor(1), Nx.iota({5})) == Nx.tensor(2)
-      assert cond_unused_and_slice(Nx.tensor(1), Nx.tensor([-1, 1, 0, 1, 2])) == Nx.tensor(-1)
-      assert cond_unused_and_slice(Nx.tensor(1), Nx.tensor([2, 1, 0, -1, 1])) == Nx.tensor(1)
+      assert_equal(cond_unused_and_slice(Nx.tensor(1), Nx.iota({5})), Nx.tensor(2))
+
+      assert_equal(
+        cond_unused_and_slice(Nx.tensor(1), Nx.tensor([-1, 1, 0, 1, 2])),
+        Nx.tensor(-1)
+      )
+
+      assert_equal(cond_unused_and_slice(Nx.tensor(1), Nx.tensor([2, 1, 0, -1, 1])), Nx.tensor(1))
     end
 
     defn nested_cond(i) do
@@ -953,8 +1062,8 @@ defmodule EXLA.Defn.ExprTest do
     end
 
     test "computes cond with cond as parameter" do
-      assert nested_cond(Nx.tensor(10)) == Nx.tensor(1)
-      assert nested_cond(Nx.tensor(-10)) == Nx.tensor(0)
+      assert_equal(nested_cond(Nx.tensor(10)), Nx.tensor(1))
+      assert_equal(nested_cond(Nx.tensor(-10)), Nx.tensor(0))
     end
   end
 
@@ -966,8 +1075,8 @@ defmodule EXLA.Defn.ExprTest do
     end
 
     test "simple" do
-      assert upto10(0) == Nx.tensor(10)
-      assert upto10(5) == Nx.tensor(10)
+      assert_equal(upto10(0), Nx.tensor(10))
+      assert_equal(upto10(5), Nx.tensor(10))
     end
 
     defn factorial_tuple(x) do
@@ -980,8 +1089,8 @@ defmodule EXLA.Defn.ExprTest do
     end
 
     test "factorial" do
-      assert factorial_tuple(5) == Nx.tensor(120.0)
-      assert factorial_tuple(10.0) == Nx.tensor(3_628_800.0)
+      assert_equal(factorial_tuple(5), Nx.tensor(120.0))
+      assert_equal(factorial_tuple(10.0), Nx.tensor(3_628_800.0))
     end
 
     defn factorial_map(x) do
@@ -996,8 +1105,8 @@ defmodule EXLA.Defn.ExprTest do
     end
 
     test "factorial map" do
-      assert factorial_map(5) == Nx.tensor(120)
-      assert factorial_map(10.0) == Nx.tensor(3_628_800.0)
+      assert_equal(factorial_map(5), Nx.tensor(120))
+      assert_equal(factorial_map(10.0), Nx.tensor(3_628_800.0))
     end
 
     defn factorial_map_input(map) do
@@ -1010,8 +1119,8 @@ defmodule EXLA.Defn.ExprTest do
     end
 
     test "factorial map input" do
-      assert factorial_map_input(%{factorial: 1, x: 5}) == Nx.tensor(120)
-      assert factorial_map_input(%{factorial: 1.0, x: 10.0}) == Nx.tensor(3_628_800.0)
+      assert_equal(factorial_map_input(%{factorial: 1, x: 5}), Nx.tensor(120))
+      assert_equal(factorial_map_input(%{factorial: 1.0, x: 10.0}), Nx.tensor(3_628_800.0))
     end
   end
 
@@ -1022,22 +1131,26 @@ defmodule EXLA.Defn.ExprTest do
 
     @tag :unsupported_64_bit_op
     test "maps a function over the tensor" do
-      assert map_plus(Nx.tensor([[1, 2, 3], [4, 5, 6]])) == Nx.tensor([[2, 3, 4], [5, 6, 7]])
+      assert_equal(map_plus(Nx.tensor([[1, 2, 3], [4, 5, 6]])), Nx.tensor([[2, 3, 4], [5, 6, 7]]))
     end
 
     @tag :unsupported_64_bit_op
     test "maps a function with an output type" do
-      assert map_equal(Nx.tensor([[1, 2, 3], [4, 5, 6]])) ==
-               Nx.tensor([[1.0, 0.0, 0.0], [0.0, 0.0, 0.0]], type: {:f, 64})
+      assert_equal(
+        map_equal(Nx.tensor([[1, 2, 3], [4, 5, 6]])),
+        Nx.tensor([[1.0, 0.0, 0.0], [0.0, 0.0, 0.0]], type: {:f, 64})
+      )
 
-      assert map_exp(Nx.tensor([[1, 2, 3], [4, 5, 6]])) ==
-               Nx.tensor(
-                 [
-                   [2.718281828459045, 7.38905609893065, 20.085536923187668],
-                   [54.598150033144236, 148.4131591025766, 403.4287934927351]
-                 ],
-                 type: {:f, 64}
-               )
+      assert_equal(
+        map_exp(Nx.tensor([[1, 2, 3], [4, 5, 6]])),
+        Nx.tensor(
+          [
+            [2.718281828459045, 7.38905609893065, 20.085536923187668],
+            [54.598150033144236, 148.4131591025766, 403.4287934927351]
+          ],
+          type: {:f, 64}
+        )
+      )
     end
   end
 
@@ -1049,20 +1162,22 @@ defmodule EXLA.Defn.ExprTest do
       do: Nx.reduce(t, 1, [keep_axes: true, axes: [0, 2]], fn a, b -> a * b end)
 
     test "computes the reduce" do
-      assert Nx.tensor([1, 2, 3]) |> reduce() == Nx.tensor(6)
-      assert Nx.tensor([1.0, 2.0, 3.0]) |> reduce() == Nx.tensor(6.0)
+      assert_equal(Nx.tensor([1, 2, 3]) |> reduce(), Nx.tensor(6))
+      assert_equal(Nx.tensor([1.0, 2.0, 3.0]) |> reduce(), Nx.tensor(6.0))
 
-      assert Nx.tensor([1, 2, 3], type: {:u, 8}) |> reduce() == Nx.tensor(6, type: {:u, 8})
-      assert Nx.tensor([1, 2, 3], type: {:s, 8}) |> reduce() == Nx.tensor(6, type: {:s, 8})
-      assert Nx.tensor([1, 2, 3], type: {:f, 32}) |> reduce() == Nx.tensor(6, type: {:f, 32})
+      assert_equal(Nx.tensor([1, 2, 3], type: {:u, 8}) |> reduce(), Nx.tensor(6, type: {:u, 8}))
+      assert_equal(Nx.tensor([1, 2, 3], type: {:s, 8}) |> reduce(), Nx.tensor(6, type: {:s, 8}))
+      assert_equal(Nx.tensor([1, 2, 3], type: {:f, 32}) |> reduce(), Nx.tensor(6, type: {:f, 32}))
     end
 
     test "computes the reduce, keeping dimensions" do
-      assert Nx.tensor([1, 2, 3]) |> reduce_keep() == Nx.tensor([6])
-      assert Nx.tensor([1.0, 2.0, 3.0]) |> reduce_keep() == Nx.tensor([6.0])
+      assert_equal(Nx.tensor([1, 2, 3]) |> reduce_keep(), Nx.tensor([6]))
+      assert_equal(Nx.tensor([1.0, 2.0, 3.0]) |> reduce_keep(), Nx.tensor([6.0]))
 
-      assert Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]]) |> reduce_keep_2() ==
-               Nx.tensor([[[36], [14400]]])
+      assert_equal(
+        Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]]) |> reduce_keep_2(),
+        Nx.tensor([[[36], [14400]]])
+      )
     end
   end
 
@@ -1111,78 +1226,94 @@ defmodule EXLA.Defn.ExprTest do
     test "valid padding, no stride" do
       t = Nx.iota({6, 7})
 
-      assert window_reduce_valid_no_stride(t) ==
-               Nx.window_reduce(t, 0, {2, 2}, fn a, b -> a + b end)
+      assert_equal(
+        window_reduce_valid_no_stride(t),
+        Nx.window_reduce(t, 0, {2, 2}, fn a, b -> a + b end)
+      )
     end
 
     test "valid padding, stride" do
       t = Nx.iota({11, 10})
 
-      assert window_reduce_valid_stride(t) ==
-               Nx.window_reduce(t, 0, {2, 2}, [strides: [2, 2]], fn a, b -> a + b end)
+      assert_equal(
+        window_reduce_valid_stride(t),
+        Nx.window_reduce(t, 0, {2, 2}, [strides: [2, 2]], fn a, b -> a + b end)
+      )
     end
 
     test "same padding, no stride" do
       t = Nx.iota({3, 3})
 
-      assert window_reduce_same_no_stride(t) ==
-               Nx.window_reduce(t, 0, {2, 2}, [padding: :same], fn a, b -> a + b end)
+      assert_equal(
+        window_reduce_same_no_stride(t),
+        Nx.window_reduce(t, 0, {2, 2}, [padding: :same], fn a, b -> a + b end)
+      )
     end
 
     test "same padding, stride" do
       t = Nx.iota({8, 8})
 
-      assert window_reduce_same_stride(t) ==
-               Nx.window_reduce(t, 0, {2, 2}, [padding: :same, strides: [2, 1]], fn a, b ->
-                 a + b
-               end)
+      assert_equal(
+        window_reduce_same_stride(t),
+        Nx.window_reduce(t, 0, {2, 2}, [padding: :same, strides: [2, 1]], fn a, b ->
+          a + b
+        end)
+      )
     end
 
     test "general padding, no stride" do
       t = Nx.iota({3, 3})
 
-      assert window_reduce_general_no_stride(t) ==
-               Nx.window_reduce(t, 0, {2, 2}, [padding: [{2, 1}, {1, 2}]], fn a, b -> a + b end)
+      assert_equal(
+        window_reduce_general_no_stride(t),
+        Nx.window_reduce(t, 0, {2, 2}, [padding: [{2, 1}, {1, 2}]], fn a, b -> a + b end)
+      )
     end
 
     test "general padding, stride" do
       t = Nx.iota({7, 7})
 
-      assert window_reduce_general_stride(t) ==
-               Nx.window_reduce(
-                 t,
-                 0,
-                 {2, 2},
-                 [padding: [{1, 2}, {2, 1}], strides: [2, 1]],
-                 fn a, b -> a + b end
-               )
+      assert_equal(
+        window_reduce_general_stride(t),
+        Nx.window_reduce(
+          t,
+          0,
+          {2, 2},
+          [padding: [{1, 2}, {2, 1}], strides: [2, 1]],
+          fn a, b -> a + b end
+        )
+      )
     end
 
     test "n-d reduce window" do
       t = Nx.iota({4, 2, 4, 3, 1, 3})
 
-      assert window_reduce_nd(t) ==
-               Nx.window_reduce(
-                 t,
-                 0,
-                 {1, 2, 1, 2, 1, 2},
-                 [padding: :same, strides: [2, 1, 1, 1, 1, 2]],
-                 fn a, b -> a + b end
-               )
+      assert_equal(
+        window_reduce_nd(t),
+        Nx.window_reduce(
+          t,
+          0,
+          {1, 2, 1, 2, 1, 2},
+          [padding: :same, strides: [2, 1, 1, 1, 1, 2]],
+          fn a, b -> a + b end
+        )
+      )
     end
 
     @tag :unsupported_dilated_window_reduce
     test "computes a dilated reduce window" do
       t = Nx.iota({6, 4, 3})
 
-      assert dilated_window_reduce(t) ==
-               Nx.window_reduce(
-                 t,
-                 0,
-                 {2, 1, 2},
-                 [padding: :same, strides: [1, 2, 1], window_dilations: [2, 1, 1]],
-                 fn a, b -> a + b end
-               )
+      assert_equal(
+        dilated_window_reduce(t),
+        Nx.window_reduce(
+          t,
+          0,
+          {2, 1, 2},
+          [padding: :same, strides: [1, 2, 1], window_dilations: [2, 1, 1]],
+          fn a, b -> a + b end
+        )
+      )
     end
   end
 
@@ -1220,7 +1351,7 @@ defmodule EXLA.Defn.ExprTest do
           strides: [2, 3]
         )
 
-      compare_tensors!(lhs, rhs)
+      assert_all_close(lhs, rhs)
     end
 
     defn window_scatter_min_no_padding(t) do
@@ -1256,7 +1387,7 @@ defmodule EXLA.Defn.ExprTest do
           strides: [2, 3]
         )
 
-      compare_tensors!(lhs, rhs)
+      assert_all_close(lhs, rhs)
     end
   end
 
@@ -1290,18 +1421,21 @@ defmodule EXLA.Defn.ExprTest do
           4
         ])
 
-      assert Nx.tensor([
-               [
-                 [0, 1, 0, 0],
-                 [0, 2, 0, 0],
-                 [0, 0, 0, 0]
-               ],
-               [
-                 [0, 0, 0, 4],
-                 [0, 0, 0, 0],
-                 [0, 0, -1, 3]
-               ]
-             ]) == indexed_add(target, indices, updates)
+      assert_equal(
+        Nx.tensor([
+          [
+            [0, 1, 0, 0],
+            [0, 2, 0, 0],
+            [0, 0, 0, 0]
+          ],
+          [
+            [0, 0, 0, 4],
+            [0, 0, 0, 0],
+            [0, 0, -1, 3]
+          ]
+        ]),
+        indexed_add(target, indices, updates)
+      )
     end
 
     test "indexed_add handles different input types" do
@@ -1309,25 +1443,25 @@ defmodule EXLA.Defn.ExprTest do
       indices = Nx.tensor([[0]])
       updates = Nx.tensor([1])
 
-      assert Nx.tensor([1], type: {:s, 64}) == indexed_add(target, indices, updates)
+      assert_equal(indexed_add(target, indices, updates), Nx.tensor([1], type: {:s, 64}))
 
       target = Nx.tensor([0])
       indices = Nx.tensor([[0]])
       updates = Nx.tensor([1.0])
 
-      assert Nx.tensor([1.0], type: {:f, 32}) == indexed_add(target, indices, updates)
+      assert_equal(indexed_add(target, indices, updates), Nx.tensor([1.0], type: {:f, 32}))
 
       target = Nx.tensor([0.0])
       indices = Nx.tensor([[0]])
       updates = Nx.tensor([1])
 
-      assert Nx.tensor([1.0], type: {:f, 32}) == indexed_add(target, indices, updates)
+      assert_equal(indexed_add(target, indices, updates), Nx.tensor([1.0], type: {:f, 32}))
 
       target = Nx.tensor([0.0], type: {:f, 64})
       indices = Nx.tensor([[0]])
       updates = Nx.tensor([1.0], type: {:f, 32})
 
-      assert Nx.tensor([1.0], type: {:f, 64}) == indexed_add(target, indices, updates)
+      assert_equal(indexed_add(target, indices, updates), Nx.tensor([1.0], type: {:f, 64}))
     end
   end
 
@@ -1337,16 +1471,21 @@ defmodule EXLA.Defn.ExprTest do
     defn all_axis_1(t), do: Nx.all(t, axes: [1])
 
     test "computes the bitwise and across types" do
-      assert all(Nx.tensor([1, 2, 3])) == Nx.tensor(1, type: {:u, 8})
-      assert all(Nx.tensor([0, 1, 2])) == Nx.tensor(0, type: {:u, 8})
-      assert all(Nx.tensor([0.0, 1.0, 2.0])) == Nx.tensor(0, type: {:u, 8})
+      assert_equal(all(Nx.tensor([1, 2, 3])), Nx.tensor(1, type: {:u, 8}))
+      assert_equal(all(Nx.tensor([0, 1, 2])), Nx.tensor(0, type: {:u, 8}))
+      assert_equal(all(Nx.tensor([0.0, 1.0, 2.0])), Nx.tensor(0, type: {:u, 8}))
     end
 
     test "computes the bitwise and on given axes" do
-      assert all_axis_0(Nx.tensor([[-1, 0, 1], [2, 3, 4]])) ==
-               Nx.tensor([1, 0, 1], type: {:u, 8})
+      assert_equal(
+        all_axis_0(Nx.tensor([[-1, 0, 1], [2, 3, 4]])),
+        Nx.tensor([1, 0, 1], type: {:u, 8})
+      )
 
-      assert all_axis_1(Nx.tensor([[-1, 0, 1], [2, 3, 4]])) == Nx.tensor([0, 1], type: {:u, 8})
+      assert_equal(
+        all_axis_1(Nx.tensor([[-1, 0, 1], [2, 3, 4]])),
+        Nx.tensor([0, 1], type: {:u, 8})
+      )
     end
   end
 
@@ -1356,14 +1495,21 @@ defmodule EXLA.Defn.ExprTest do
     defn any_axis_1(t), do: Nx.any(t, axes: [1])
 
     test "computes the bitwise and across types" do
-      assert any(Nx.tensor([-1, 0, 1])) == Nx.tensor(1, type: {:u, 8})
-      assert any(Nx.tensor([0, 0, 0])) == Nx.tensor(0, type: {:u, 8})
-      assert any(Nx.tensor([-1.0, 0.0, 1.0])) == Nx.tensor(1, type: {:u, 8})
+      assert_equal(any(Nx.tensor([-1, 0, 1])), Nx.tensor(1, type: {:u, 8}))
+      assert_equal(any(Nx.tensor([0, 0, 0])), Nx.tensor(0, type: {:u, 8}))
+      assert_equal(any(Nx.tensor([-1.0, 0.0, 1.0])), Nx.tensor(1, type: {:u, 8}))
     end
 
     test "computes the bitwise and on given axes" do
-      assert any_axis_0(Nx.tensor([[0, 1, 0], [0, 1, 2]])) == Nx.tensor([0, 1, 1], type: {:u, 8})
-      assert any_axis_1(Nx.tensor([[0, 1, 0], [0, 1, 2]])) == Nx.tensor([1, 1], type: {:u, 8})
+      assert_equal(
+        any_axis_0(Nx.tensor([[0, 1, 0], [0, 1, 2]])),
+        Nx.tensor([0, 1, 1], type: {:u, 8})
+      )
+
+      assert_equal(
+        any_axis_1(Nx.tensor([[0, 1, 0], [0, 1, 2]])),
+        Nx.tensor([1, 1], type: {:u, 8})
+      )
     end
   end
 
@@ -1371,11 +1517,15 @@ defmodule EXLA.Defn.ExprTest do
     defn sum(t), do: Nx.sum(t)
 
     test "computes the sum across types" do
-      assert Nx.tensor([1, 2, 3]) |> sum() == Nx.tensor(6)
-      assert Nx.tensor([1, 2, 3], type: {:s, 8}) |> sum() == Nx.tensor(6)
-      assert Nx.tensor([1, 2, 3], type: {:u, 8}) |> sum() == Nx.tensor(6, type: {:u, 64})
-      assert Nx.tensor([1.0, 2.0, 3.0]) |> sum() == Nx.tensor(6.0)
-      assert Nx.tensor([1.0, 2.0, 3.0], type: {:f, 32}) |> sum() == Nx.tensor(6, type: {:f, 32})
+      assert_equal(Nx.tensor([1, 2, 3]) |> sum(), Nx.tensor(6))
+      assert_equal(Nx.tensor([1, 2, 3], type: {:s, 8}) |> sum(), Nx.tensor(6))
+      assert_equal(Nx.tensor([1, 2, 3], type: {:u, 8}) |> sum(), Nx.tensor(6, type: {:u, 64}))
+      assert_equal(Nx.tensor([1.0, 2.0, 3.0]) |> sum(), Nx.tensor(6.0))
+
+      assert_equal(
+        Nx.tensor([1.0, 2.0, 3.0], type: {:f, 32}) |> sum(),
+        Nx.tensor(6, type: {:f, 32})
+      )
     end
 
     defn sum_pos_axis(t), do: Nx.sum(t, axes: [1])
@@ -1384,28 +1534,30 @@ defmodule EXLA.Defn.ExprTest do
 
     test "computes the sum on a given axis" do
       t = Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]])
-      assert sum_pos_axis(t) == Nx.sum(t, axes: [1])
-      assert sum_neg_axis(t) == Nx.sum(t, axes: [-3])
-      assert sum_pos_neg_axis(t) == Nx.sum(t, axes: [1, -3])
+      assert_equal(sum_pos_axis(t), Nx.sum(t, axes: [1]))
+      assert_equal(sum_neg_axis(t), Nx.sum(t, axes: [-3]))
+      assert_equal(sum_pos_neg_axis(t), Nx.sum(t, axes: [1, -3]))
     end
 
     defn sum_equal(t), do: Nx.sum(Nx.equal(t, 1.0))
 
     test "does not overflow" do
-      assert sum_equal(Nx.tensor(1)) == Nx.tensor(1, type: {:u, 64})
-      assert sum_equal(Nx.tensor([1, 1, 1])) == Nx.tensor(3, type: {:u, 64})
-      assert sum_equal(Nx.tensor([1, 2, 3])) == Nx.tensor(1, type: {:u, 64})
+      assert_equal(sum_equal(Nx.tensor(1)), Nx.tensor(1, type: {:u, 64}))
+      assert_equal(sum_equal(Nx.tensor([1, 1, 1])), Nx.tensor(3, type: {:u, 64}))
+      assert_equal(sum_equal(Nx.tensor([1, 2, 3])), Nx.tensor(1, type: {:u, 64}))
     end
 
     defn sum_keep(t), do: Nx.sum(t, keep_axes: true)
     defn sum_keep_2(t), do: Nx.sum(t, axes: [0, 2], keep_axes: true)
 
     test "keeps dimensions if keep_axes" do
-      assert Nx.tensor([1, 2, 3]) |> sum_keep() == Nx.tensor([6])
-      assert Nx.tensor([1.0, 2.0, 3.0]) |> sum_keep() == Nx.tensor([6.0])
+      assert_equal(Nx.tensor([1, 2, 3]) |> sum_keep(), Nx.tensor([6]))
+      assert_equal(Nx.tensor([1.0, 2.0, 3.0]) |> sum_keep(), Nx.tensor([6.0]))
 
-      assert Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]]) |> sum_keep_2() ==
-               Nx.tensor([[[12], [30]]])
+      assert_equal(
+        Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]]) |> sum_keep_2(),
+        Nx.tensor([[[12], [30]]])
+      )
     end
   end
 
@@ -1413,13 +1565,15 @@ defmodule EXLA.Defn.ExprTest do
     defn product(t), do: Nx.product(t)
 
     test "computes the product across types" do
-      assert Nx.tensor([1, 2, 3]) |> product() == Nx.tensor(6)
-      assert Nx.tensor([1, 2, 3], type: {:s, 8}) |> product() == Nx.tensor(6)
-      assert Nx.tensor([1, 2, 3], type: {:u, 8}) |> product() == Nx.tensor(6, type: {:u, 64})
-      assert Nx.tensor([1.0, 2.0, 3.0]) |> product() == Nx.tensor(6.0)
+      assert_equal(Nx.tensor([1, 2, 3]) |> product(), Nx.tensor(6))
+      assert_equal(Nx.tensor([1, 2, 3], type: {:s, 8}) |> product(), Nx.tensor(6))
+      assert_equal(Nx.tensor([1, 2, 3], type: {:u, 8}) |> product(), Nx.tensor(6, type: {:u, 64}))
+      assert_equal(Nx.tensor([1.0, 2.0, 3.0]) |> product(), Nx.tensor(6.0))
 
-      assert Nx.tensor([1.0, 2.0, 3.0], type: {:f, 32}) |> product() ==
-               Nx.tensor(6, type: {:f, 32})
+      assert_equal(
+        Nx.tensor([1.0, 2.0, 3.0], type: {:f, 32}) |> product(),
+        Nx.tensor(6, type: {:f, 32})
+      )
     end
 
     defn product_pos_axis(t), do: Nx.product(t, axes: [1])
@@ -1428,28 +1582,30 @@ defmodule EXLA.Defn.ExprTest do
 
     test "computes the sum on a given axis" do
       t = Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]])
-      assert product_pos_axis(t) == Nx.product(t, axes: [1])
-      assert product_neg_axis(t) == Nx.product(t, axes: [-3])
-      assert product_pos_neg_axis(t) == Nx.product(t, axes: [1, -3])
+      assert_equal(product_pos_axis(t), Nx.product(t, axes: [1]))
+      assert_equal(product_neg_axis(t), Nx.product(t, axes: [-3]))
+      assert_equal(product_pos_neg_axis(t), Nx.product(t, axes: [1, -3]))
     end
 
     defn product_equal(t), do: Nx.product(Nx.equal(t, 1.0))
 
     test "does not overflow" do
-      assert product_equal(Nx.tensor(1)) == Nx.tensor(1, type: {:u, 64})
-      assert product_equal(Nx.tensor([1, 1, 1])) == Nx.tensor(1, type: {:u, 64})
-      assert product_equal(Nx.tensor([1, 2, 3])) == Nx.tensor(0, type: {:u, 64})
+      assert_equal(product_equal(Nx.tensor(1)), Nx.tensor(1, type: {:u, 64}))
+      assert_equal(product_equal(Nx.tensor([1, 1, 1])), Nx.tensor(1, type: {:u, 64}))
+      assert_equal(product_equal(Nx.tensor([1, 2, 3])), Nx.tensor(0, type: {:u, 64}))
     end
 
     defn product_keep(t), do: Nx.product(t, keep_axes: true)
     defn product_keep_2(t), do: Nx.product(t, axes: [0, 2], keep_axes: true)
 
     test "keeps dimensions if keep_axes" do
-      assert Nx.tensor([1, 2, 3]) |> product_keep() == Nx.tensor([6])
-      assert Nx.tensor([1.0, 2.0, 3.0]) |> product_keep() == Nx.tensor([6.0])
+      assert_equal(Nx.tensor([1, 2, 3]) |> product_keep(), Nx.tensor([6]))
+      assert_equal(Nx.tensor([1.0, 2.0, 3.0]) |> product_keep(), Nx.tensor([6.0]))
 
-      assert Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]]) |> product_keep_2() ==
-               Nx.tensor([[[36], [14400]]])
+      assert_equal(
+        Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]]) |> product_keep_2(),
+        Nx.tensor([[[36], [14400]]])
+      )
     end
   end
 
@@ -1457,56 +1613,62 @@ defmodule EXLA.Defn.ExprTest do
     defn mean(t), do: Nx.mean(t)
 
     test "computes mean without axis" do
-      assert mean(Nx.tensor(42)) == Nx.tensor(42.0)
-      assert mean(Nx.tensor([1, 2, 3])) == Nx.tensor(2.0)
-      assert mean(Nx.tensor([1, 2, 3], type: {:u, 8})) == Nx.tensor(2.0, type: {:f, 32})
+      assert_equal(mean(Nx.tensor(42)), Nx.tensor(42.0))
+      assert_equal(mean(Nx.tensor([1, 2, 3])), Nx.tensor(2.0))
+      assert_equal(mean(Nx.tensor([1, 2, 3], type: {:u, 8})), Nx.tensor(2.0, type: {:f, 32}))
     end
 
     defn mean_over_single_axis(t), do: Nx.mean(t, axes: [0])
 
     test "computes mean over a single axis" do
-      assert mean_over_single_axis(Nx.tensor([1, 2, 3])) == Nx.tensor(2.0)
+      assert_equal(mean_over_single_axis(Nx.tensor([1, 2, 3])), Nx.tensor(2.0))
 
-      assert mean_over_single_axis(Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]])) ==
-               Nx.tensor([
-                 [4.0, 5.0, 6.0],
-                 [7.0, 8.0, 9.0]
-               ])
+      assert_equal(
+        mean_over_single_axis(Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]])),
+        Nx.tensor([
+          [4.0, 5.0, 6.0],
+          [7.0, 8.0, 9.0]
+        ])
+      )
     end
 
     defn mean_over_multiple_axes(t), do: Nx.mean(t, axes: [0, 2])
 
     test "computes mean over multiple axes" do
-      assert mean_over_multiple_axes(
-               Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]])
-             ) == Nx.tensor([5.0, 8.0])
+      assert_equal(
+        mean_over_multiple_axes(Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]])),
+        Nx.tensor([5.0, 8.0])
+      )
     end
 
     defn mean_over_negative_axis(t), do: Nx.mean(t, axes: [-1])
 
     test "computes mean over negative axes" do
-      assert mean_over_negative_axis(
-               Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]])
-             ) == Nx.tensor([[2.0, 5.0], [8.0, 11.0]])
+      assert_equal(
+        mean_over_negative_axis(Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]])),
+        Nx.tensor([[2.0, 5.0], [8.0, 11.0]])
+      )
     end
 
     defn mean_equal(t), do: Nx.mean(Nx.equal(t, 1.0))
 
     test "does not overflow" do
-      assert mean_equal(Nx.tensor(1)) == Nx.tensor(1.0)
-      assert mean_equal(Nx.tensor([1, 1, 1])) == Nx.tensor(1.0)
-      assert mean_equal(Nx.tensor([1, 2, 3])) == Nx.tensor(0.3333333333333333)
+      assert_equal(mean_equal(Nx.tensor(1)), Nx.tensor(1.0))
+      assert_equal(mean_equal(Nx.tensor([1, 1, 1])), Nx.tensor(1.0))
+      assert_equal(mean_equal(Nx.tensor([1, 2, 3])), Nx.tensor(0.3333333333333333))
     end
 
     defn mean_keep(t), do: Nx.mean(t, keep_axes: true)
     defn mean_keep_2(t), do: Nx.mean(t, axes: [0, 2], keep_axes: true)
 
     test "keeps dimensions if keep_axes" do
-      assert Nx.tensor([1, 2, 3]) |> mean_keep() == Nx.tensor([2.0])
-      assert Nx.tensor([1.0, 2.0, 3.0]) |> mean_keep() == Nx.tensor([2.0])
+      assert_equal(Nx.tensor([1, 2, 3]) |> mean_keep(), Nx.tensor([2.0]))
+      assert_equal(Nx.tensor([1.0, 2.0, 3.0]) |> mean_keep(), Nx.tensor([2.0]))
 
-      assert Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]]) |> mean_keep_2() ==
-               Nx.tensor([[[2.0], [5.0]]])
+      assert_equal(
+        Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]]) |> mean_keep_2(),
+        Nx.tensor([[[2.0], [5.0]]])
+      )
     end
   end
 
@@ -1514,13 +1676,24 @@ defmodule EXLA.Defn.ExprTest do
     defn reduce_max(t), do: Nx.reduce_max(t)
 
     test "computes the maximum across types" do
-      assert Nx.tensor([1, 2, 3]) |> reduce_max() == Nx.tensor(3)
-      assert Nx.tensor([1, 2, 3], type: {:s, 8}) |> reduce_max() == Nx.tensor(3, type: {:s, 8})
-      assert Nx.tensor([1, 2, 3], type: {:u, 8}) |> reduce_max() == Nx.tensor(3, type: {:u, 8})
-      assert Nx.tensor([1.0, 2.0, 3.0]) |> reduce_max() == Nx.tensor(3.0)
+      assert_equal(Nx.tensor([1, 2, 3]) |> reduce_max(), Nx.tensor(3))
 
-      assert Nx.tensor([1.0, 2.0, 3.0], type: {:f, 32}) |> reduce_max() ==
-               Nx.tensor(3, type: {:f, 32})
+      assert_equal(
+        Nx.tensor([1, 2, 3], type: {:s, 8}) |> reduce_max(),
+        Nx.tensor(3, type: {:s, 8})
+      )
+
+      assert_equal(
+        Nx.tensor([1, 2, 3], type: {:u, 8}) |> reduce_max(),
+        Nx.tensor(3, type: {:u, 8})
+      )
+
+      assert_equal(Nx.tensor([1.0, 2.0, 3.0]) |> reduce_max(), Nx.tensor(3.0))
+
+      assert_equal(
+        Nx.tensor([1.0, 2.0, 3.0], type: {:f, 32}) |> reduce_max(),
+        Nx.tensor(3, type: {:f, 32})
+      )
     end
 
     defn reduce_max_pos_axis(t), do: Nx.reduce_max(t, axes: [1])
@@ -1529,20 +1702,22 @@ defmodule EXLA.Defn.ExprTest do
 
     test "computes the max on a given axis" do
       t = Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]])
-      assert reduce_max_pos_axis(t) == Nx.reduce_max(t, axes: [1])
-      assert reduce_max_neg_axis(t) == Nx.reduce_max(t, axes: [-3])
-      assert reduce_max_pos_neg_axis(t) == Nx.reduce_max(t, axes: [1, -3])
+      assert_equal(reduce_max_pos_axis(t), Nx.reduce_max(t, axes: [1]))
+      assert_equal(reduce_max_neg_axis(t), Nx.reduce_max(t, axes: [-3]))
+      assert_equal(reduce_max_pos_neg_axis(t), Nx.reduce_max(t, axes: [1, -3]))
     end
 
     defn reduce_max_keep(t), do: Nx.reduce_max(t, keep_axes: true)
     defn reduce_max_keep_2(t), do: Nx.reduce_max(t, axes: [0, 2], keep_axes: true)
 
     test "keeps dimensions if keep_axes" do
-      assert Nx.tensor([1, 2, 3]) |> reduce_max_keep() == Nx.tensor([3])
-      assert Nx.tensor([1.0, 2.0, 3.0]) |> reduce_max_keep() == Nx.tensor([3.0])
+      assert_equal(Nx.tensor([1, 2, 3]) |> reduce_max_keep(), Nx.tensor([3]))
+      assert_equal(Nx.tensor([1.0, 2.0, 3.0]) |> reduce_max_keep(), Nx.tensor([3.0]))
 
-      assert Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]]) |> reduce_max_keep_2() ==
-               Nx.tensor([[[3], [6]]])
+      assert_equal(
+        Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]]) |> reduce_max_keep_2(),
+        Nx.tensor([[[3], [6]]])
+      )
     end
   end
 
@@ -1550,13 +1725,24 @@ defmodule EXLA.Defn.ExprTest do
     defn reduce_min(t), do: Nx.reduce_min(t)
 
     test "computes the minimum across types" do
-      assert Nx.tensor([1, 2, 3]) |> reduce_min() == Nx.tensor(1)
-      assert Nx.tensor([1, 2, 3], type: {:s, 8}) |> reduce_min() == Nx.tensor(1, type: {:s, 8})
-      assert Nx.tensor([1, 2, 3], type: {:u, 8}) |> reduce_min() == Nx.tensor(1, type: {:u, 8})
-      assert Nx.tensor([1.0, 2.0, 3.0]) |> reduce_min() == Nx.tensor(1.0)
+      assert_equal(Nx.tensor([1, 2, 3]) |> reduce_min(), Nx.tensor(1))
 
-      assert Nx.tensor([1.0, 2.0, 3.0], type: {:f, 32}) |> reduce_min() ==
-               Nx.tensor(1, type: {:f, 32})
+      assert_equal(
+        Nx.tensor([1, 2, 3], type: {:s, 8}) |> reduce_min(),
+        Nx.tensor(1, type: {:s, 8})
+      )
+
+      assert_equal(
+        Nx.tensor([1, 2, 3], type: {:u, 8}) |> reduce_min(),
+        Nx.tensor(1, type: {:u, 8})
+      )
+
+      assert_equal(Nx.tensor([1.0, 2.0, 3.0]) |> reduce_min(), Nx.tensor(1.0))
+
+      assert_equal(
+        Nx.tensor([1.0, 2.0, 3.0], type: {:f, 32}) |> reduce_min(),
+        Nx.tensor(1, type: {:f, 32})
+      )
     end
 
     defn reduce_min_pos_axis(t), do: Nx.reduce_min(t, axes: [1])
@@ -1565,20 +1751,22 @@ defmodule EXLA.Defn.ExprTest do
 
     test "computes the min on a given axis" do
       t = Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]])
-      assert reduce_min_pos_axis(t) == Nx.reduce_min(t, axes: [1])
-      assert reduce_min_neg_axis(t) == Nx.reduce_min(t, axes: [-3])
-      assert reduce_min_pos_neg_axis(t) == Nx.reduce_min(t, axes: [1, -3])
+      assert_equal(reduce_min_pos_axis(t), Nx.reduce_min(t, axes: [1]))
+      assert_equal(reduce_min_neg_axis(t), Nx.reduce_min(t, axes: [-3]))
+      assert_equal(reduce_min_pos_neg_axis(t), Nx.reduce_min(t, axes: [1, -3]))
     end
 
     defn reduce_min_keep(t), do: Nx.reduce_min(t, keep_axes: true)
     defn reduce_min_keep_2(t), do: Nx.reduce_min(t, axes: [0, 2], keep_axes: true)
 
     test "keeps dimensions if keep_axes" do
-      assert Nx.tensor([1, 2, 3]) |> reduce_min_keep() == Nx.tensor([1])
-      assert Nx.tensor([1.0, 2.0, 3.0]) |> reduce_min_keep() == Nx.tensor([1.0])
+      assert_equal(Nx.tensor([1, 2, 3]) |> reduce_min_keep(), Nx.tensor([1]))
+      assert_equal(Nx.tensor([1.0, 2.0, 3.0]) |> reduce_min_keep(), Nx.tensor([1.0]))
 
-      assert Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]]) |> reduce_min_keep_2() ==
-               Nx.tensor([[[1], [4]]])
+      assert_equal(
+        Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]]) |> reduce_min_keep_2(),
+        Nx.tensor([[[1], [4]]])
+      )
     end
   end
 
@@ -1593,54 +1781,62 @@ defmodule EXLA.Defn.ExprTest do
     defn argmin_keep_axis(t), do: Nx.argmin(t, axis: 1, keep_axis: true)
 
     test "computes the argmax across types" do
-      assert argmax(Nx.tensor([1, 2, 3])) == Nx.tensor(2)
-      assert argmax(Nx.tensor([1, 2, 3], type: {:s, 8})) == Nx.tensor(2)
-      assert argmax(Nx.tensor([1, 2, 3], type: {:u, 8})) == Nx.tensor(2)
-      assert argmax(Nx.tensor([1.0, 2.0, 3.0])) == Nx.tensor(2)
-      assert argmax(Nx.tensor([1.0, 2.0, 3.0], type: {:f, 32})) == Nx.tensor(2)
-      assert argmax(Nx.tensor([1.0, 2.0, 3.0], type: {:bf, 16})) == Nx.tensor(2)
-      assert argmax(Nx.tensor([[1, 2, 3], [4, 5, 6]])) == Nx.tensor(5)
+      assert_equal(argmax(Nx.tensor([1, 2, 3])), Nx.tensor(2))
+      assert_equal(argmax(Nx.tensor([1, 2, 3], type: {:s, 8})), Nx.tensor(2))
+      assert_equal(argmax(Nx.tensor([1, 2, 3], type: {:u, 8})), Nx.tensor(2))
+      assert_equal(argmax(Nx.tensor([1.0, 2.0, 3.0])), Nx.tensor(2))
+      assert_equal(argmax(Nx.tensor([1.0, 2.0, 3.0], type: {:f, 32})), Nx.tensor(2))
+      assert_equal(argmax(Nx.tensor([1.0, 2.0, 3.0], type: {:bf, 16})), Nx.tensor(2))
+      assert_equal(argmax(Nx.tensor([[1, 2, 3], [4, 5, 6]])), Nx.tensor(5))
     end
 
     test "computes the argmin across types" do
-      assert argmin(Nx.tensor([1, 2, 3])) == Nx.tensor(0)
-      assert argmin(Nx.tensor([1, 2, 3], type: {:s, 8})) == Nx.tensor(0)
-      assert argmin(Nx.tensor([1, 2, 3], type: {:u, 8})) == Nx.tensor(0)
-      assert argmin(Nx.tensor([1.0, 2.0, 3.0])) == Nx.tensor(0)
-      assert argmin(Nx.tensor([1.0, 2.0, 3.0], type: {:f, 32})) == Nx.tensor(0)
-      assert argmin(Nx.tensor([1.0, 2.0, 3.0], type: {:bf, 16})) == Nx.tensor(0)
-      assert argmin(Nx.tensor([[1, 2, 3], [4, 5, 6]])) == Nx.tensor(0)
+      assert_equal(argmin(Nx.tensor([1, 2, 3])), Nx.tensor(0))
+      assert_equal(argmin(Nx.tensor([1, 2, 3], type: {:s, 8})), Nx.tensor(0))
+      assert_equal(argmin(Nx.tensor([1, 2, 3], type: {:u, 8})), Nx.tensor(0))
+      assert_equal(argmin(Nx.tensor([1.0, 2.0, 3.0])), Nx.tensor(0))
+      assert_equal(argmin(Nx.tensor([1.0, 2.0, 3.0], type: {:f, 32})), Nx.tensor(0))
+      assert_equal(argmin(Nx.tensor([1.0, 2.0, 3.0], type: {:bf, 16})), Nx.tensor(0))
+      assert_equal(argmin(Nx.tensor([[1, 2, 3], [4, 5, 6]])), Nx.tensor(0))
     end
 
     test "computes the argmax on an axis" do
-      assert argmax_axis(Nx.tensor([[[1, 1, 1], [1, 1, 3]], [[6, 2, 3], [2, 8, 3]]])) ==
-               Nx.tensor([[0, 0, 1], [0, 1, 0]])
+      assert_equal(
+        argmax_axis(Nx.tensor([[[1, 1, 1], [1, 1, 3]], [[6, 2, 3], [2, 8, 3]]])),
+        Nx.tensor([[0, 0, 1], [0, 1, 0]])
+      )
     end
 
     test "computes the argmin on an axis" do
-      assert argmin_axis(Nx.tensor([[[4, 2, 3], [1, -5, 3]], [[6, 2, 3], [4, 8, 3]]])) ==
-               Nx.tensor([[1, 1, 0], [1, 0, 0]])
+      assert_equal(
+        argmin_axis(Nx.tensor([[[4, 2, 3], [1, -5, 3]], [[6, 2, 3], [4, 8, 3]]])),
+        Nx.tensor([[1, 1, 0], [1, 0, 0]])
+      )
     end
 
     test "computes argmax with tie_break: :high" do
-      assert argmax_axis(Nx.tensor([[1, 2, 2], [1, 2, 2]])) == Nx.tensor([1, 1])
-      assert argmax_high(Nx.tensor([[1, 2, 2], [1, 2, 2]])) == Nx.tensor([2, 2])
+      assert_equal(argmax_axis(Nx.tensor([[1, 2, 2], [1, 2, 2]])), Nx.tensor([1, 1]))
+      assert_equal(argmax_high(Nx.tensor([[1, 2, 2], [1, 2, 2]])), Nx.tensor([2, 2]))
     end
 
     test "computes argmax with keep_axis: true" do
-      assert argmax_keep_axis(Nx.tensor([[[4, 2, 3], [1, -5, 3]], [[6, 2, 3], [4, 8, 3]]])) ==
-               Nx.tensor([
-                 [[0, 0, 0]],
-                 [[0, 1, 0]]
-               ])
+      assert_equal(
+        argmax_keep_axis(Nx.tensor([[[4, 2, 3], [1, -5, 3]], [[6, 2, 3], [4, 8, 3]]])),
+        Nx.tensor([
+          [[0, 0, 0]],
+          [[0, 1, 0]]
+        ])
+      )
     end
 
     test "computes argmin with keep_axis: true" do
-      assert argmin_keep_axis(Nx.tensor([[[4, 2, 3], [1, -5, 3]], [[6, 2, 3], [4, 8, 3]]])) ==
-               Nx.tensor([
-                 [[1, 1, 0]],
-                 [[1, 0, 0]]
-               ])
+      assert_equal(
+        argmin_keep_axis(Nx.tensor([[[4, 2, 3], [1, -5, 3]], [[6, 2, 3], [4, 8, 3]]])),
+        Nx.tensor([
+          [[1, 1, 0]],
+          [[1, 0, 0]]
+        ])
+      )
     end
   end
 
@@ -1658,31 +1854,39 @@ defmodule EXLA.Defn.ExprTest do
     end
 
     test "computes the sum of a window" do
-      assert window_sum1(Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]])) ==
-               Nx.tensor([[[5, 7, 9]], [[5, 7, 9]]])
+      assert_equal(
+        window_sum1(Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]])),
+        Nx.tensor([[[5, 7, 9]], [[5, 7, 9]]])
+      )
 
-      assert window_sum2(Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]])) ==
-               Nx.tensor([[[0, 0], [0, 18]], [[0, 0], [0, 9]]])
+      assert_equal(
+        window_sum2(Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]])),
+        Nx.tensor([[[0, 0], [0, 18]], [[0, 0], [0, 9]]])
+      )
 
-      assert window_sum3(
-               Nx.tensor([[[4.0, 2.0, 3.0], [2.0, 5.0, 6.5]], [[1.2, 2.2, 3.2], [4.0, 5.0, 6.2]]])
-             ) ==
-               Nx.tensor([
-                 [[0.0, 4.0, 2.0, 3.0, 0.0], [0.0, 2.0, 5.0, 6.5, 0.0]],
-                 [[0.0, 1.2, 2.2, 3.2, 0.0], [0.0, 4.0, 5.0, 6.2, 0.0]]
-               ])
+      assert_equal(
+        window_sum3(
+          Nx.tensor([[[4.0, 2.0, 3.0], [2.0, 5.0, 6.5]], [[1.2, 2.2, 3.2], [4.0, 5.0, 6.2]]])
+        ),
+        Nx.tensor([
+          [[0.0, 4.0, 2.0, 3.0, 0.0], [0.0, 2.0, 5.0, 6.5, 0.0]],
+          [[0.0, 1.2, 2.2, 3.2, 0.0], [0.0, 4.0, 5.0, 6.2, 0.0]]
+        ])
+      )
     end
 
     @tag :unsupported_dilated_window_reduce
     test "computes the sum of a dilated window" do
       t = Nx.iota({8, 10, 12})
 
-      assert dilated_window_sum(t) ==
-               Nx.window_sum(t, {3, 2, 1},
-                 strides: [1, 1, 1],
-                 padding: :same,
-                 window_dilations: [1, 2, 2]
-               )
+      assert_equal(
+        dilated_window_sum(t),
+        Nx.window_sum(t, {3, 2, 1},
+          strides: [1, 1, 1],
+          padding: :same,
+          window_dilations: [1, 2, 2]
+        )
+      )
     end
   end
 
@@ -1700,19 +1904,25 @@ defmodule EXLA.Defn.ExprTest do
     end
 
     test "computes the mean of a window" do
-      assert window_mean1(Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]])) ==
-               Nx.tensor([[[2.5, 3.5, 4.5]], [[2.5, 3.5, 4.5]]])
+      assert_equal(
+        window_mean1(Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]])),
+        Nx.tensor([[[2.5, 3.5, 4.5]], [[2.5, 3.5, 4.5]]])
+      )
 
-      assert window_mean2(Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]])) ==
-               Nx.tensor([[[0, 0], [0, 4.5]], [[0, 0], [0, 2.25]]])
+      assert_equal(
+        window_mean2(Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]])),
+        Nx.tensor([[[0, 0], [0, 4.5]], [[0, 0], [0, 2.25]]])
+      )
 
-      assert window_mean3(
-               Nx.tensor([[[4.0, 2.0, 3.0], [2.0, 5.0, 6.5]], [[1.2, 2.2, 3.2], [4.0, 5.0, 6.2]]])
-             ) ==
-               Nx.tensor([
-                 [[0.0, 2.0, 1.0, 1.5, 0.0], [0.0, 1.0, 2.5, 3.25, 0.0]],
-                 [[0.0, 0.6, 1.1, 1.6, 0.0], [0.0, 2.0, 2.5, 3.1, 0.0]]
-               ])
+      assert_equal(
+        window_mean3(
+          Nx.tensor([[[4.0, 2.0, 3.0], [2.0, 5.0, 6.5]], [[1.2, 2.2, 3.2], [4.0, 5.0, 6.2]]])
+        ),
+        Nx.tensor([
+          [[0.0, 2.0, 1.0, 1.5, 0.0], [0.0, 1.0, 2.5, 3.25, 0.0]],
+          [[0.0, 0.6, 1.1, 1.6, 0.0], [0.0, 2.0, 2.5, 3.1, 0.0]]
+        ])
+      )
     end
 
     @tag :unsupported_dilated_window_reduce
@@ -1727,7 +1937,7 @@ defmodule EXLA.Defn.ExprTest do
           window_dilations: [1, 2, 2]
         )
 
-      compare_tensors!(lhs, rhs)
+      assert_all_close(lhs, rhs)
     end
   end
 
@@ -1745,46 +1955,54 @@ defmodule EXLA.Defn.ExprTest do
     end
 
     test "computes the max of a window" do
-      assert window_max1(Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]])) ==
-               Nx.tensor([[[4, 5, 6]], [[4, 5, 6]]])
+      assert_equal(
+        window_max1(Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]])),
+        Nx.tensor([[[4, 5, 6]], [[4, 5, 6]]])
+      )
 
-      assert window_max2(Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]])) ==
-               Nx.tensor([
-                 [
-                   [-9_223_372_036_854_775_808, -9_223_372_036_854_775_808],
-                   [-9_223_372_036_854_775_808, 6]
-                 ],
-                 [
-                   [-9_223_372_036_854_775_808, -9_223_372_036_854_775_808],
-                   [-9_223_372_036_854_775_808, 6]
-                 ]
-               ])
+      assert_equal(
+        window_max2(Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]])),
+        Nx.tensor([
+          [
+            [-9_223_372_036_854_775_808, -9_223_372_036_854_775_808],
+            [-9_223_372_036_854_775_808, 6]
+          ],
+          [
+            [-9_223_372_036_854_775_808, -9_223_372_036_854_775_808],
+            [-9_223_372_036_854_775_808, 6]
+          ]
+        ])
+      )
 
-      assert window_max3(
-               Nx.tensor([[[4.0, 2.0, 3.0], [2.0, 5.0, 6.5]], [[1.2, 2.2, 3.2], [4.0, 5.0, 6.2]]])
-             ) ==
-               Nx.tensor([
-                 [
-                   [-3.4028234663852886e38, 4.0, 2.0, 3.0, -3.4028234663852886e38],
-                   [-3.4028234663852886e38, 2.0, 5.0, 6.5, -3.4028234663852886e38]
-                 ],
-                 [
-                   [-3.4028234663852886e38, 1.2, 2.2, 3.2, -3.4028234663852886e38],
-                   [-3.4028234663852886e38, 4.0, 5.0, 6.2, -3.4028234663852886e38]
-                 ]
-               ])
+      assert_equal(
+        window_max3(
+          Nx.tensor([[[4.0, 2.0, 3.0], [2.0, 5.0, 6.5]], [[1.2, 2.2, 3.2], [4.0, 5.0, 6.2]]])
+        ),
+        Nx.tensor([
+          [
+            [-3.4028234663852886e38, 4.0, 2.0, 3.0, -3.4028234663852886e38],
+            [-3.4028234663852886e38, 2.0, 5.0, 6.5, -3.4028234663852886e38]
+          ],
+          [
+            [-3.4028234663852886e38, 1.2, 2.2, 3.2, -3.4028234663852886e38],
+            [-3.4028234663852886e38, 4.0, 5.0, 6.2, -3.4028234663852886e38]
+          ]
+        ])
+      )
     end
 
     @tag :unsupported_dilated_window_reduce
     test "computes the max of a dilated window" do
       t = Nx.iota({8, 10, 12}, type: {:f, 64})
 
-      assert dilated_window_max(t) ==
-               Nx.window_max(t, {3, 2, 1},
-                 strides: [1, 1, 1],
-                 padding: :same,
-                 window_dilations: [1, 2, 2]
-               )
+      assert_equal(
+        dilated_window_max(t),
+        Nx.window_max(t, {3, 2, 1},
+          strides: [1, 1, 1],
+          padding: :same,
+          window_dilations: [1, 2, 2]
+        )
+      )
     end
   end
 
@@ -1802,46 +2020,54 @@ defmodule EXLA.Defn.ExprTest do
     end
 
     test "computes the min of a window" do
-      assert window_min1(Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]])) ==
-               Nx.tensor([[[1, 2, 3]], [[1, 2, 3]]])
+      assert_equal(
+        window_min1(Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]])),
+        Nx.tensor([[[1, 2, 3]], [[1, 2, 3]]])
+      )
 
-      assert window_min2(Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]])) ==
-               Nx.tensor([
-                 [
-                   [9_223_372_036_854_775_807, 9_223_372_036_854_775_807],
-                   [9_223_372_036_854_775_807, 3]
-                 ],
-                 [
-                   [9_223_372_036_854_775_807, 9_223_372_036_854_775_807],
-                   [9_223_372_036_854_775_807, 3]
-                 ]
-               ])
+      assert_equal(
+        window_min2(Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]])),
+        Nx.tensor([
+          [
+            [9_223_372_036_854_775_807, 9_223_372_036_854_775_807],
+            [9_223_372_036_854_775_807, 3]
+          ],
+          [
+            [9_223_372_036_854_775_807, 9_223_372_036_854_775_807],
+            [9_223_372_036_854_775_807, 3]
+          ]
+        ])
+      )
 
-      assert window_min3(
-               Nx.tensor([[[4.0, 2.0, 3.0], [2.0, 5.0, 6.5]], [[1.2, 2.2, 3.2], [4.0, 5.0, 6.2]]])
-             ) ==
-               Nx.tensor([
-                 [
-                   [3.4028234663852886e38, 4.0, 2.0, 3.0, 3.4028234663852886e38],
-                   [3.4028234663852886e38, 2.0, 5.0, 6.5, 3.4028234663852886e38]
-                 ],
-                 [
-                   [3.4028234663852886e38, 1.2, 2.2, 3.2, 3.4028234663852886e38],
-                   [3.4028234663852886e38, 4.0, 5.0, 6.2, 3.4028234663852886e38]
-                 ]
-               ])
+      assert_equal(
+        window_min3(
+          Nx.tensor([[[4.0, 2.0, 3.0], [2.0, 5.0, 6.5]], [[1.2, 2.2, 3.2], [4.0, 5.0, 6.2]]])
+        ),
+        Nx.tensor([
+          [
+            [3.4028234663852886e38, 4.0, 2.0, 3.0, 3.4028234663852886e38],
+            [3.4028234663852886e38, 2.0, 5.0, 6.5, 3.4028234663852886e38]
+          ],
+          [
+            [3.4028234663852886e38, 1.2, 2.2, 3.2, 3.4028234663852886e38],
+            [3.4028234663852886e38, 4.0, 5.0, 6.2, 3.4028234663852886e38]
+          ]
+        ])
+      )
     end
 
     @tag :unsupported_dilated_window_reduce
     test "computes the min of a dilated window" do
       t = Nx.iota({8, 10, 12})
 
-      assert dilated_window_min(t) ==
-               Nx.window_min(t, {3, 2, 1},
-                 strides: [1, 1, 1],
-                 padding: :same,
-                 window_dilations: [1, 2, 2]
-               )
+      assert_equal(
+        dilated_window_min(t),
+        Nx.window_min(t, {3, 2, 1},
+          strides: [1, 1, 1],
+          padding: :same,
+          window_dilations: [1, 2, 2]
+        )
+      )
     end
   end
 
@@ -1863,31 +2089,39 @@ defmodule EXLA.Defn.ExprTest do
     end
 
     test "computes the product of a window" do
-      assert window_product1(Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]])) ==
-               Nx.tensor([[[4, 10, 18]], [[4, 10, 18]]])
+      assert_equal(
+        window_product1(Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]])),
+        Nx.tensor([[[4, 10, 18]], [[4, 10, 18]]])
+      )
 
-      assert window_product2(Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]])) ==
-               Nx.tensor([[[1, 1], [1, 324]], [[1, 1], [1, 18]]])
+      assert_equal(
+        window_product2(Nx.tensor([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]])),
+        Nx.tensor([[[1, 1], [1, 324]], [[1, 1], [1, 18]]])
+      )
 
-      assert window_product3(
-               Nx.tensor([[[4.0, 2.0, 3.0], [2.0, 5.0, 6.5]], [[1.2, 2.2, 3.2], [4.0, 5.0, 6.2]]])
-             ) ==
-               Nx.tensor([
-                 [[1.0, 4.0, 2.0, 3.0, 1.0], [1.0, 2.0, 5.0, 6.5, 1.0]],
-                 [[1.0, 1.2, 2.2, 3.2, 1.0], [1.0, 4.0, 5.0, 6.2, 1.0]]
-               ])
+      assert_equal(
+        window_product3(
+          Nx.tensor([[[4.0, 2.0, 3.0], [2.0, 5.0, 6.5]], [[1.2, 2.2, 3.2], [4.0, 5.0, 6.2]]])
+        ),
+        Nx.tensor([
+          [[1.0, 4.0, 2.0, 3.0, 1.0], [1.0, 2.0, 5.0, 6.5, 1.0]],
+          [[1.0, 1.2, 2.2, 3.2, 1.0], [1.0, 4.0, 5.0, 6.2, 1.0]]
+        ])
+      )
     end
 
     @tag :unsupported_dilated_window_reduce
     test "computes the product of a dilated window" do
       t = Nx.iota({8, 10, 12})
 
-      assert dilated_window_product(t) ==
-               Nx.window_product(t, {3, 2, 1},
-                 strides: [1, 1, 1],
-                 padding: :same,
-                 window_dilations: [1, 2, 2]
-               )
+      assert_equal(
+        dilated_window_product(t),
+        Nx.window_product(t, {3, 2, 1},
+          strides: [1, 1, 1],
+          padding: :same,
+          window_dilations: [1, 2, 2]
+        )
+      )
     end
   end
 
@@ -1895,75 +2129,93 @@ defmodule EXLA.Defn.ExprTest do
     defn dot(a, b), do: Nx.dot(a, b)
 
     test "computes the dot product of scalars" do
-      assert dot(Nx.tensor(2), Nx.tensor(2)) == Nx.tensor(4)
-      assert dot(Nx.tensor(2.0), Nx.tensor(2.0)) == Nx.tensor(4.0)
-      assert dot(Nx.tensor(-2.0), Nx.tensor(-2)) == Nx.tensor(4.0)
+      assert_equal(dot(Nx.tensor(2), Nx.tensor(2)), Nx.tensor(4))
+      assert_equal(dot(Nx.tensor(2.0), Nx.tensor(2.0)), Nx.tensor(4.0))
+      assert_equal(dot(Nx.tensor(-2.0), Nx.tensor(-2)), Nx.tensor(4.0))
     end
 
     test "computes the dot product of vectors" do
-      assert dot(Nx.tensor([1, 2, 3], type: {:s, 32}), Nx.tensor([4, 5, 6], type: {:s, 32})) ==
-               Nx.tensor(32, type: {:s, 32})
+      assert_equal(
+        dot(Nx.tensor([1, 2, 3], type: {:s, 32}), Nx.tensor([4, 5, 6], type: {:s, 32})),
+        Nx.tensor(32, type: {:s, 32})
+      )
 
-      assert dot(Nx.tensor([1.0, 2.0, 3.0], type: {:f, 32}), Nx.tensor([4, 5, 6])) ==
-               Nx.tensor(32.0)
+      assert_equal(
+        dot(Nx.tensor([1.0, 2.0, 3.0], type: {:f, 32}), Nx.tensor([4, 5, 6])),
+        Nx.tensor(32.0)
+      )
 
-      assert dot(Nx.tensor([1.0, 2.0, 3.0]), Nx.tensor([4.0, 5.0, 6.0])) == Nx.tensor(32.0)
+      assert_equal(dot(Nx.tensor([1.0, 2.0, 3.0]), Nx.tensor([4.0, 5.0, 6.0])), Nx.tensor(32.0))
     end
 
     test "computes the dot product of matrices" do
-      assert dot(
-               Nx.tensor([[1, 2, 3], [4, 5, 6]], type: {:s, 32}),
-               Nx.tensor([[7, 8], [9, 10], [11, 12]], type: {:s, 32})
-             ) ==
-               Nx.tensor([[58, 64], [139, 154]], type: {:s, 32})
+      assert_equal(
+        dot(
+          Nx.tensor([[1, 2, 3], [4, 5, 6]], type: {:s, 32}),
+          Nx.tensor([[7, 8], [9, 10], [11, 12]], type: {:s, 32})
+        ),
+        Nx.tensor([[58, 64], [139, 154]], type: {:s, 32})
+      )
 
-      assert dot(
-               Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
-               Nx.tensor([[7.0, 8.0], [9.0, 10.0], [11.0, 12.0]])
-             ) == Nx.tensor([[58.0, 64.0], [139.0, 154.0]])
+      assert_equal(
+        dot(
+          Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
+          Nx.tensor([[7.0, 8.0], [9.0, 10.0], [11.0, 12.0]])
+        ),
+        Nx.tensor([[58.0, 64.0], [139.0, 154.0]])
+      )
 
-      assert dot(
-               Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
-               Nx.tensor([[7, 8], [9, 10], [11, 12]])
-             ) == Nx.tensor([[58.0, 64.0], [139.0, 154.0]])
+      assert_equal(
+        dot(
+          Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
+          Nx.tensor([[7, 8], [9, 10], [11, 12]])
+        ),
+        Nx.tensor([[58.0, 64.0], [139.0, 154.0]])
+      )
     end
 
     test "computes the dot product of tensors" do
-      assert dot(
-               Nx.tensor(
-                 [[[1, 2, 3], [4, 5, 6], [7, 8, 9]], [[1, 2, 3], [4, 5, 6], [7, 8, 9]]],
-                 type: {:s, 32}
-               ),
-               Nx.tensor(
-                 [[[1, 2, 3], [3, 4, 5], [5, 6, 7]]],
-                 type: {:s, 32}
-               )
-             ) ==
-               Nx.tensor(
-                 [
-                   [[[22, 28, 34]], [[49, 64, 79]], [[76, 100, 124]]],
-                   [[[22, 28, 34]], [[49, 64, 79]], [[76, 100, 124]]]
-                 ],
-                 type: {:s, 32}
-               )
+      assert_equal(
+        dot(
+          Nx.tensor(
+            [[[1, 2, 3], [4, 5, 6], [7, 8, 9]], [[1, 2, 3], [4, 5, 6], [7, 8, 9]]],
+            type: {:s, 32}
+          ),
+          Nx.tensor(
+            [[[1, 2, 3], [3, 4, 5], [5, 6, 7]]],
+            type: {:s, 32}
+          )
+        ),
+        Nx.tensor(
+          [
+            [[[22, 28, 34]], [[49, 64, 79]], [[76, 100, 124]]],
+            [[[22, 28, 34]], [[49, 64, 79]], [[76, 100, 124]]]
+          ],
+          type: {:s, 32}
+        )
+      )
     end
 
     defn batched_dot(t1, t2), do: Nx.dot(t1, [1], [0], t2, [1], [0])
 
     test "computes a batched dot product" do
-      assert batched_dot(Nx.iota({3, 2, 3}, type: {:f, 32}), Nx.iota({3, 2, 2}, type: {:f, 32})) ==
-               Nx.tensor([
-                 [[6.0, 9.0], [8.0, 13.0], [10.0, 17.0]],
-                 [[78.0, 93.0], [88.0, 105.0], [98.0, 117.0]],
-                 [[246.0, 273.0], [264.0, 293.0], [282.0, 313.0]]
-               ])
+      assert_equal(
+        batched_dot(Nx.iota({3, 2, 3}, type: {:f, 32}), Nx.iota({3, 2, 2}, type: {:f, 32})),
+        Nx.tensor([
+          [[6.0, 9.0], [8.0, 13.0], [10.0, 17.0]],
+          [[78.0, 93.0], [88.0, 105.0], [98.0, 117.0]],
+          [[246.0, 273.0], [264.0, 293.0], [282.0, 313.0]]
+        ])
+      )
     end
 
     defn general_dot(t1, t2), do: Nx.dot(t1, [0, 1], [], t2, [1, 2], [])
 
     test "computes a general dot product" do
-      assert general_dot(Nx.iota({4, 5, 2}, type: {:f, 32}), Nx.iota({2, 4, 5}, type: {:f, 32})) ==
-               Nx.tensor([[4940.0, 12540.0], [5130.0, 13130.0]])
+      assert_equal(
+        general_dot(Nx.iota({4, 5, 2}, type: {:f, 32}), Nx.iota({2, 4, 5}, type: {:f, 32})),
+        Nx.tensor([[4940.0, 12540.0], [5130.0, 13130.0]])
+      )
     end
   end
 
@@ -2053,7 +2305,7 @@ defmodule EXLA.Defn.ExprTest do
           output_permutation: [:batch, :channels, :height, :width]
         )
 
-      compare_tensors!(lhs, rhs)
+      assert_all_close(lhs, rhs)
       assert %{names: [:batch, :height, :width, :channels], shape: {8, 11, 11, 6}} = lhs
     end
 
@@ -2072,7 +2324,7 @@ defmodule EXLA.Defn.ExprTest do
           output_permutation: [2, 3, 0, 1]
         )
 
-      compare_tensors!(lhs, rhs)
+      assert_all_close(lhs, rhs)
       assert %{shape: {6, 12, 4, 32}} = lhs
     end
 
@@ -2088,7 +2340,7 @@ defmodule EXLA.Defn.ExprTest do
           input_permutation: [:batch, :channels, :height, :width]
         )
 
-      compare_tensors!(lhs, rhs)
+      assert_all_close(lhs, rhs)
       assert %{names: [:batch, :channels, :height, :width]} = lhs
     end
 
@@ -2099,7 +2351,7 @@ defmodule EXLA.Defn.ExprTest do
 
       lhs = conv_valid_no_stride(img, kernel)
       rhs = Nx.conv(img, kernel, strides: [1, 1])
-      compare_tensors!(lhs, rhs)
+      assert_all_close(lhs, rhs)
     end
 
     @tag :unsupported_64_bit_op
@@ -2109,7 +2361,7 @@ defmodule EXLA.Defn.ExprTest do
 
       lhs = conv_valid_stride(img, kernel)
       rhs = Nx.conv(img, kernel, strides: [2, 2], padding: :valid)
-      compare_tensors!(lhs, rhs)
+      assert_all_close(lhs, rhs)
     end
 
     @tag :unsupported_64_bit_op
@@ -2119,7 +2371,7 @@ defmodule EXLA.Defn.ExprTest do
 
       lhs = conv_same_no_stride(img, kernel)
       rhs = Nx.conv(img, kernel, strides: [1, 1], padding: :same)
-      compare_tensors!(lhs, rhs)
+      assert_all_close(lhs, rhs)
     end
 
     @tag :unsupported_64_bit_op
@@ -2129,7 +2381,7 @@ defmodule EXLA.Defn.ExprTest do
 
       lhs = conv_same_stride(img, kernel)
       rhs = Nx.conv(img, kernel, strides: [3, 3], padding: :same)
-      compare_tensors!(lhs, rhs)
+      assert_all_close(lhs, rhs)
     end
 
     @tag :unsupported_64_bit_op
@@ -2140,7 +2392,7 @@ defmodule EXLA.Defn.ExprTest do
       lhs = conv_general_no_stride(img, kernel)
       rhs = Nx.conv(img, kernel, strides: [1, 1], padding: [{-1, 2}, {3, -1}])
 
-      compare_tensors!(lhs, rhs)
+      assert_all_close(lhs, rhs)
     end
 
     @tag :unsupported_64_bit_op
@@ -2151,7 +2403,7 @@ defmodule EXLA.Defn.ExprTest do
       lhs = conv_general_stride(img, kernel)
       rhs = Nx.conv(img, kernel, strides: [2, 1], padding: [{2, 2}, {-2, 4}])
 
-      compare_tensors!(lhs, rhs)
+      assert_all_close(lhs, rhs)
     end
 
     @tag :unsupported_64_bit_op
@@ -2162,7 +2414,7 @@ defmodule EXLA.Defn.ExprTest do
       lhs = conv_3d(img, kernel)
       rhs = Nx.conv(img, kernel, strides: [1, 2, 1], padding: :same)
 
-      compare_tensors!(lhs, rhs)
+      assert_all_close(lhs, rhs)
     end
 
     test "computes a convolution with mixed types" do
@@ -2172,7 +2424,7 @@ defmodule EXLA.Defn.ExprTest do
       lhs = conv_valid_no_stride(img, kernel)
       rhs = Nx.conv(img, kernel, strides: [1, 1], padding: :valid)
 
-      compare_tensors!(lhs, rhs)
+      assert_all_close(lhs, rhs)
     end
 
     @tag :unsupported_64_bit_op
@@ -2183,7 +2435,7 @@ defmodule EXLA.Defn.ExprTest do
       lhs = dilated_conv(img, kernel)
       rhs = Nx.conv(img, kernel, strides: [1, 1], padding: :same, kernel_dilation: [1, 2])
 
-      compare_tensors!(lhs, rhs)
+      assert_all_close(lhs, rhs)
     end
 
     test "computes an input dilated convolution" do
@@ -2193,7 +2445,7 @@ defmodule EXLA.Defn.ExprTest do
       lhs = dilated_input_conv(img, kernel)
       rhs = Nx.conv(img, kernel, strides: [1, 1], padding: :same, input_dilation: [2, 1])
 
-      compare_tensors!(lhs, rhs)
+      assert_all_close(lhs, rhs)
     end
 
     test "computes a conv with both dilations" do
@@ -2210,7 +2462,7 @@ defmodule EXLA.Defn.ExprTest do
           kernel_dilation: [2, 1]
         )
 
-      compare_tensors!(lhs, rhs)
+      assert_all_close(lhs, rhs)
     end
 
     test "computes a grouped convolution with valid padding, no stride" do
@@ -2219,7 +2471,7 @@ defmodule EXLA.Defn.ExprTest do
       lhs = grouped_conv_valid_no_stride(img, kernel)
       rhs = Nx.conv(img, kernel, strides: 1, padding: :valid, feature_group_size: 2)
 
-      compare_tensors!(lhs, rhs)
+      assert_all_close(lhs, rhs)
     end
 
     test "computes a grouped convolution with same padding, stride, 3-d" do
@@ -2229,7 +2481,7 @@ defmodule EXLA.Defn.ExprTest do
       lhs = grouped_conv_same_stride(img, kernel)
       rhs = Nx.conv(img, kernel, strides: [2, 1, 2], padding: :same, feature_group_size: 4)
 
-      compare_tensors!(lhs, rhs)
+      assert_all_close(lhs, rhs)
     end
 
     test "computes a batch grouped convolution" do
@@ -2239,7 +2491,7 @@ defmodule EXLA.Defn.ExprTest do
       lhs = batch_grouped_conv(img, kernel)
       rhs = Nx.conv(img, kernel, batch_group_size: 2)
 
-      compare_tensors!(lhs, rhs)
+      assert_all_close(lhs, rhs)
     end
 
     test "computes a batch grouped convolution with general padding, input dilation" do
@@ -2255,7 +2507,7 @@ defmodule EXLA.Defn.ExprTest do
           input_dilation: [2, 1]
         )
 
-      compare_tensors!(lhs, rhs)
+      assert_all_close(lhs, rhs)
     end
   end
 
@@ -2267,51 +2519,59 @@ defmodule EXLA.Defn.ExprTest do
     defn transpose_perm3(t), do: Nx.transpose(t, axes: [0, 2, 1])
 
     test "transposes without axes" do
-      assert transpose(Nx.tensor(1)) == Nx.tensor(1)
+      assert_equal(transpose(Nx.tensor(1)), Nx.tensor(1))
 
-      assert transpose(Nx.iota({2, 3, 4})) ==
-               Nx.tensor([
-                 [[0, 12], [4, 16], [8, 20]],
-                 [[1, 13], [5, 17], [9, 21]],
-                 [[2, 14], [6, 18], [10, 22]],
-                 [[3, 15], [7, 19], [11, 23]]
-               ])
+      assert_equal(
+        transpose(Nx.iota({2, 3, 4})),
+        Nx.tensor([
+          [[0, 12], [4, 16], [8, 20]],
+          [[1, 13], [5, 17], [9, 21]],
+          [[2, 14], [6, 18], [10, 22]],
+          [[3, 15], [7, 19], [11, 23]]
+        ])
+      )
     end
 
     test "transposes with axes" do
-      assert transpose_scalar(Nx.tensor(1)) == Nx.tensor(1)
+      assert_equal(transpose_scalar(Nx.tensor(1)), Nx.tensor(1))
 
-      assert transpose_perm1(Nx.iota({2, 3, 4})) ==
-               Nx.tensor([
-                 [[0, 12], [4, 16], [8, 20]],
-                 [[1, 13], [5, 17], [9, 21]],
-                 [[2, 14], [6, 18], [10, 22]],
-                 [[3, 15], [7, 19], [11, 23]]
-               ])
+      assert_equal(
+        transpose_perm1(Nx.iota({2, 3, 4})),
+        Nx.tensor([
+          [[0, 12], [4, 16], [8, 20]],
+          [[1, 13], [5, 17], [9, 21]],
+          [[2, 14], [6, 18], [10, 22]],
+          [[3, 15], [7, 19], [11, 23]]
+        ])
+      )
 
-      assert transpose_perm2(Nx.iota({2, 3, 4})) ==
-               Nx.tensor([
-                 [[0, 4, 8], [12, 16, 20]],
-                 [[1, 5, 9], [13, 17, 21]],
-                 [[2, 6, 10], [14, 18, 22]],
-                 [[3, 7, 11], [15, 19, 23]]
-               ])
+      assert_equal(
+        transpose_perm2(Nx.iota({2, 3, 4})),
+        Nx.tensor([
+          [[0, 4, 8], [12, 16, 20]],
+          [[1, 5, 9], [13, 17, 21]],
+          [[2, 6, 10], [14, 18, 22]],
+          [[3, 7, 11], [15, 19, 23]]
+        ])
+      )
 
-      assert transpose_perm3(Nx.iota({2, 3, 4})) ==
-               Nx.tensor([
-                 [
-                   [0, 4, 8],
-                   [1, 5, 9],
-                   [2, 6, 10],
-                   [3, 7, 11]
-                 ],
-                 [
-                   [12, 16, 20],
-                   [13, 17, 21],
-                   [14, 18, 22],
-                   [15, 19, 23]
-                 ]
-               ])
+      assert_equal(
+        transpose_perm3(Nx.iota({2, 3, 4})),
+        Nx.tensor([
+          [
+            [0, 4, 8],
+            [1, 5, 9],
+            [2, 6, 10],
+            [3, 7, 11]
+          ],
+          [
+            [12, 16, 20],
+            [13, 17, 21],
+            [14, 18, 22],
+            [15, 19, 23]
+          ]
+        ])
+      )
     end
   end
 
@@ -2319,15 +2579,15 @@ defmodule EXLA.Defn.ExprTest do
     defn softmax(t), do: Nx.exp(t) / Nx.sum(Nx.exp(t))
 
     test "computes softmax" do
-      assert compare_tensors!(
-               softmax(Nx.tensor([1.0, 2.0, 3.0, 4.0])),
-               Nx.tensor([
-                 0.03205860328008499,
-                 0.08714431874203257,
-                 0.23688281808991013,
-                 0.6439142598879722
-               ])
-             )
+      assert_all_close(
+        softmax(Nx.tensor([1.0, 2.0, 3.0, 4.0])),
+        Nx.tensor([
+          0.03205860328008499,
+          0.08714431874203257,
+          0.23688281808991013,
+          0.6439142598879722
+        ])
+      )
     end
   end
 
@@ -2335,17 +2595,21 @@ defmodule EXLA.Defn.ExprTest do
     defn reshape_with_shape(t), do: Nx.reshape(t, {2, 2})
 
     test "with shape" do
-      assert reshape_with_shape(Nx.tensor([1, 2, 3, 4])) == Nx.tensor([[1, 2], [3, 4]])
+      assert_equal(reshape_with_shape(Nx.tensor([1, 2, 3, 4])), Nx.tensor([[1, 2], [3, 4]]))
     end
 
     defn reshape_with_tensor(t, shape), do: Nx.reshape(t, shape)
 
     test "with tensor" do
-      assert reshape_with_tensor(Nx.tensor([1, 2, 3, 4]), Nx.tensor([[0, 0], [0, 0]])) ==
-               Nx.tensor([[1, 2], [3, 4]])
+      assert_equal(
+        reshape_with_tensor(Nx.tensor([1, 2, 3, 4]), Nx.tensor([[0, 0], [0, 0]])),
+        Nx.tensor([[1, 2], [3, 4]])
+      )
 
-      assert reshape_with_tensor(Nx.tensor([1, 2, 3, 4]), Nx.tensor([[0], [0], [0], [0]])) ==
-               Nx.tensor([[1], [2], [3], [4]])
+      assert_equal(
+        reshape_with_tensor(Nx.tensor([1, 2, 3, 4]), Nx.tensor([[0], [0], [0], [0]])),
+        Nx.tensor([[1], [2], [3], [4]])
+      )
     end
   end
 
@@ -2359,16 +2623,18 @@ defmodule EXLA.Defn.ExprTest do
     defn pad_tensor_negative_value(t), do: Nx.pad(t, 0, [{-1, 0, 0}, {-1, -1, 0}, {0, -1, 0}])
 
     test "with scalar" do
-      assert pad_scalar(Nx.tensor(1)) == Nx.tensor(1)
+      assert_equal(pad_scalar(Nx.tensor(1)), Nx.tensor(1))
     end
 
     test "with vector" do
-      assert pad_vector(Nx.tensor([1, 2, 3])) == Nx.tensor([0, 1, 2, 3, 0])
+      assert_equal(pad_vector(Nx.tensor([1, 2, 3])), Nx.tensor([0, 1, 2, 3, 0]))
     end
 
     test "with matrix" do
-      assert pad_matrix(Nx.tensor([[1, 2, 3], [4, 5, 6]])) ==
-               Nx.tensor([[0, 0, 0, 0, 0], [0, 1, 2, 3, 0], [0, 4, 5, 6, 0], [0, 0, 0, 0, 0]])
+      assert_equal(
+        pad_matrix(Nx.tensor([[1, 2, 3], [4, 5, 6]])),
+        Nx.tensor([[0, 0, 0, 0, 0], [0, 1, 2, 3, 0], [0, 4, 5, 6, 0], [0, 0, 0, 0, 0]])
+      )
     end
 
     test "with tensor" do
@@ -2401,25 +2667,35 @@ defmodule EXLA.Defn.ExprTest do
           ]
         ])
 
-      assert pad_tensor(Nx.tensor([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])) == result
-      assert pad_tensor(Nx.tensor([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]])) == result
+      assert_equal(pad_tensor(Nx.tensor([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])), result)
+
+      assert_equal(
+        pad_tensor(Nx.tensor([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]])),
+        result
+      )
     end
 
     test "with negative value" do
-      assert pad_vector_negative_value(Nx.tensor([1.0, 1.0, 2.0, 3.0, 0.0])) ==
-               Nx.tensor([1.0, 2.0, 3.0])
+      assert_equal(
+        pad_vector_negative_value(Nx.tensor([1.0, 1.0, 2.0, 3.0, 0.0])),
+        Nx.tensor([1.0, 2.0, 3.0])
+      )
 
-      assert pad_matrix_negative_value(Nx.tensor([[0, 1, 2, 3], [0, 4, 5, 6]])) ==
-               Nx.tensor([[1, 2, 3, 0], [4, 5, 6, 0]])
+      assert_equal(
+        pad_matrix_negative_value(Nx.tensor([[0, 1, 2, 3], [0, 4, 5, 6]])),
+        Nx.tensor([[1, 2, 3, 0], [4, 5, 6, 0]])
+      )
 
-      assert pad_tensor_negative_value(
-               Nx.tensor([
-                 [[0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0]],
-                 [[0, 0, 0], [1, 2, 0], [3, 4, 0], [0, 0, 0]],
-                 [[0, 0, 0], [5, 6, 0], [7, 8, 0], [0, 0, 0]]
-               ])
-             ) ==
-               Nx.tensor([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])
+      assert_equal(
+        pad_tensor_negative_value(
+          Nx.tensor([
+            [[0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0]],
+            [[0, 0, 0], [1, 2, 0], [3, 4, 0], [0, 0, 0]],
+            [[0, 0, 0], [5, 6, 0], [7, 8, 0], [0, 0, 0]]
+          ])
+        ),
+        Nx.tensor([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])
+      )
     end
   end
 
@@ -2427,9 +2703,9 @@ defmodule EXLA.Defn.ExprTest do
     defn broadcast_with_shape(t), do: Nx.broadcast(t, {2, 2})
 
     test "with shape" do
-      assert broadcast_with_shape(Nx.tensor([1, 2])) == Nx.tensor([[1, 2], [1, 2]])
-      assert broadcast_with_shape(Nx.tensor([[1, 2]])) == Nx.tensor([[1, 2], [1, 2]])
-      assert broadcast_with_shape(Nx.tensor([[1], [2]])) == Nx.tensor([[1, 1], [2, 2]])
+      assert_equal(broadcast_with_shape(Nx.tensor([1, 2])), Nx.tensor([[1, 2], [1, 2]]))
+      assert_equal(broadcast_with_shape(Nx.tensor([[1, 2]])), Nx.tensor([[1, 2], [1, 2]]))
+      assert_equal(broadcast_with_shape(Nx.tensor([[1], [2]])), Nx.tensor([[1, 1], [2, 2]]))
     end
 
     defn broadcast_with_tensor(t, shape), do: Nx.broadcast(t, shape)
@@ -2441,7 +2717,7 @@ defmodule EXLA.Defn.ExprTest do
       ]
 
       for {left, right} <- tensors do
-        assert Nx.broadcast(left, right) == broadcast_with_tensor(left, right)
+        assert_equal(Nx.broadcast(left, right), broadcast_with_tensor(left, right))
       end
     end
 
@@ -2449,10 +2725,15 @@ defmodule EXLA.Defn.ExprTest do
     defn broadcast_with_axes_3(t), do: Nx.broadcast(t, {2, 3, 2}, axes: [1])
 
     test "with axes" do
-      assert broadcast_with_axes_2(Nx.tensor([1, 2, 3])) == Nx.tensor([[1, 1], [2, 2], [3, 3]])
+      assert_equal(
+        broadcast_with_axes_2(Nx.tensor([1, 2, 3])),
+        Nx.tensor([[1, 1], [2, 2], [3, 3]])
+      )
 
-      assert broadcast_with_axes_3(Nx.tensor([1, 2, 3])) ==
-               Nx.tensor([[[1, 1], [2, 2], [3, 3]], [[1, 1], [2, 2], [3, 3]]])
+      assert_equal(
+        broadcast_with_axes_3(Nx.tensor([1, 2, 3])),
+        Nx.tensor([[[1, 1], [2, 2], [3, 3]], [[1, 1], [2, 2], [3, 3]]])
+      )
     end
   end
 
@@ -2461,13 +2742,13 @@ defmodule EXLA.Defn.ExprTest do
     defn squeeze2(t), do: Nx.squeeze(t, axes: [0, 1])
 
     test "with scalar" do
-      assert squeeze(Nx.tensor(1)) == Nx.tensor(1)
+      assert_equal(squeeze(Nx.tensor(1)), Nx.tensor(1))
     end
 
     test "with tensors" do
-      assert squeeze(Nx.tensor([[1, 2, 3]])) == Nx.tensor([1, 2, 3])
-      assert squeeze(Nx.tensor([[[[[1]]]]])) == Nx.tensor(1)
-      assert squeeze2(Nx.tensor([[[[[1]]]]])) == Nx.tensor([[[1]]])
+      assert_equal(squeeze(Nx.tensor([[1, 2, 3]])), Nx.tensor([1, 2, 3]))
+      assert_equal(squeeze(Nx.tensor([[[[[1]]]]])), Nx.tensor(1))
+      assert_equal(squeeze2(Nx.tensor([[[[[1]]]]])), Nx.tensor([[[1]]]))
     end
   end
 
@@ -2575,25 +2856,25 @@ defmodule EXLA.Defn.ExprTest do
     defn iota_with_shape, do: Nx.iota({3, 4, 2, 3}, axis: 2)
 
     test "generates with shape" do
-      assert iota_with_shape() == Nx.iota({3, 4, 2, 3}, axis: 2)
+      assert_equal(iota_with_shape(), Nx.iota({3, 4, 2, 3}, axis: 2))
     end
 
     defn iota_with_type, do: Nx.iota({1, 2, 3}, axis: 1, type: {:f, 32})
 
     test "generates with type" do
-      assert iota_with_type() == Nx.iota({1, 2, 3}, axis: 1, type: {:f, 32})
+      assert_equal(iota_with_type(), Nx.iota({1, 2, 3}, axis: 1, type: {:f, 32}))
     end
 
     defn iota_no_axis, do: Nx.iota({2, 2, 2})
 
     test "generates without axis" do
-      assert iota_no_axis() == Nx.iota({2, 2, 2})
+      assert_equal(iota_no_axis(), Nx.iota({2, 2, 2}))
     end
 
     defn iota_neg_axis, do: Nx.iota({2, 2, 2}, axis: -2)
 
     test "generates with negative axis" do
-      assert iota_neg_axis() == Nx.iota({2, 2, 2}, axis: -2)
+      assert_equal(iota_neg_axis(), Nx.iota({2, 2, 2}, axis: -2))
     end
   end
 
@@ -2601,13 +2882,13 @@ defmodule EXLA.Defn.ExprTest do
     defn eye, do: Nx.eye(2)
 
     test "generates with shape" do
-      assert eye() == Nx.tensor([[1, 0], [0, 1]])
+      assert_equal(eye(), Nx.tensor([[1, 0], [0, 1]]))
     end
 
     defn eye_with_type, do: Nx.eye(1, type: {:f, 32})
 
     test "generates with type" do
-      assert eye_with_type() == Nx.tensor([[1]], type: {:f, 32})
+      assert_equal(eye_with_type(), Nx.tensor([[1]], type: {:f, 32}))
     end
   end
 
@@ -2617,28 +2898,39 @@ defmodule EXLA.Defn.ExprTest do
     defn clip_with_tensor(value), do: Nx.clip(value, Nx.tensor(2.0), Nx.max(1.0, 3.0))
 
     test "works with both set" do
-      assert clip_both(Nx.tensor([[1, 2, 3], [4, 5, 6]])) == Nx.tensor([[2, 2, 3], [4, 4, 4]])
+      assert_equal(
+        clip_both(Nx.tensor([[1, 2, 3], [4, 5, 6]])),
+        Nx.tensor([[2, 2, 3], [4, 4, 4]])
+      )
     end
 
     test "works with mxied types" do
-      assert clip_mixed_types(Nx.tensor([[1, 2, 3], [4, 5, 6]])) ==
-               Nx.tensor([[2.0, 2.0, 3.0], [3.0, 3.0, 3.0]])
+      assert_equal(
+        clip_mixed_types(Nx.tensor([[1, 2, 3], [4, 5, 6]])),
+        Nx.tensor([[2.0, 2.0, 3.0], [3.0, 3.0, 3.0]])
+      )
     end
 
     test "works with tensor min/max" do
-      assert clip_with_tensor(Nx.tensor([[1, 2, 3], [4, 5, 6]])) ==
-               Nx.tensor([[2.0, 2.0, 3.0], [3.0, 3.0, 3.0]])
+      assert_equal(
+        clip_with_tensor(Nx.tensor([[1, 2, 3], [4, 5, 6]])),
+        Nx.tensor([[2.0, 2.0, 3.0], [3.0, 3.0, 3.0]])
+      )
     end
 
     test "works with floating point" do
-      assert clip_both(Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])) ==
-               Nx.tensor([[2.0, 2.0, 3.0], [4.0, 4.0, 4.0]])
+      assert_equal(
+        clip_both(Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])),
+        Nx.tensor([[2.0, 2.0, 3.0], [4.0, 4.0, 4.0]])
+      )
     end
   end
 
   describe "slicing" do
     defn slice1(t), do: Nx.slice(t, [0, 6, 2], [2, 1, 3])
+
     defn slice1_dynamic(t), do: Nx.slice(t, [Nx.tensor(0), Nx.tensor(6), Nx.tensor(2)], [2, 1, 3])
+
     defn slice2(t), do: Nx.slice(t, [1, 4, 10], [1, 1, 10], strides: [1, 2, 3])
 
     defn slice2_dynamic(t),
@@ -2652,33 +2944,37 @@ defmodule EXLA.Defn.ExprTest do
     test "works without stride" do
       t = Nx.iota({900})
       t = Nx.reshape(t, {2, 15, 30})
-      assert slice1(t) == Nx.tensor([[[182, 183, 184]], [[632, 633, 634]]])
-      assert slice1_dynamic(t) == Nx.tensor([[[182, 183, 184]], [[632, 633, 634]]])
+      assert_equal(slice1(t), Nx.tensor([[[182, 183, 184]], [[632, 633, 634]]]))
+      assert_equal(slice1_dynamic(t), Nx.tensor([[[182, 183, 184]], [[632, 633, 634]]]))
     end
 
     test "works with stride" do
       t = Nx.iota({900})
       t = Nx.reshape(t, {2, 15, 30})
-      assert slice2(t) == Nx.tensor([[[580, 583, 586, 589]]])
-      assert slice2_dynamic(t) == Nx.tensor([[[580, 583, 586, 589]]])
+      assert_equal(slice2(t), Nx.tensor([[[580, 583, 586, 589]]]))
+      assert_equal(slice2_dynamic(t), Nx.tensor([[[580, 583, 586, 589]]]))
 
-      assert slice3(t) ==
-               Nx.tensor([
-                 [
-                   [131, 134, 137],
-                   [161, 164, 167],
-                   [191, 194, 197]
-                 ]
-               ])
+      assert_equal(
+        slice3(t),
+        Nx.tensor([
+          [
+            [131, 134, 137],
+            [161, 164, 167],
+            [191, 194, 197]
+          ]
+        ])
+      )
 
-      assert slice3_dynamic(t) ==
-               Nx.tensor([
-                 [
-                   [131, 134, 137],
-                   [161, 164, 167],
-                   [191, 194, 197]
-                 ]
-               ])
+      assert_equal(
+        slice3_dynamic(t),
+        Nx.tensor([
+          [
+            [131, 134, 137],
+            [161, 164, 167],
+            [191, 194, 197]
+          ]
+        ])
+      )
     end
   end
 
@@ -2689,26 +2985,34 @@ defmodule EXLA.Defn.ExprTest do
     defn put_slice4(t1, t2), do: Nx.put_slice(t1, [Nx.tensor(0), Nx.tensor(2)], t2)
 
     test "works with one dimension" do
-      assert put_slice1(Nx.tensor([0, 1, 2, 3, 4]), Nx.tensor([5, 6])) ==
-               Nx.tensor([0, 1, 5, 6, 4])
+      assert_equal(
+        put_slice1(Nx.tensor([0, 1, 2, 3, 4]), Nx.tensor([5, 6])),
+        Nx.tensor([0, 1, 5, 6, 4])
+      )
     end
 
     test "works with two dimensions" do
-      assert put_slice2(Nx.tensor([[1, 2, 3], [4, 5, 6]]), Nx.tensor([[7, 8], [9, 10]])) ==
-               Nx.tensor([[1, 7, 8], [4, 9, 10]])
+      assert_equal(
+        put_slice2(Nx.tensor([[1, 2, 3], [4, 5, 6]]), Nx.tensor([[7, 8], [9, 10]])),
+        Nx.tensor([[1, 7, 8], [4, 9, 10]])
+      )
     end
 
     test "works with float types" do
-      assert put_slice3(
-               Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
-               Nx.tensor([[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]])
-             ) ==
-               Nx.tensor([[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]])
+      assert_equal(
+        put_slice3(
+          Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
+          Nx.tensor([[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]])
+        ),
+        Nx.tensor([[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]])
+      )
     end
 
     test "works with mixed types" do
-      assert put_slice4(Nx.tensor([[1, 2, 3], [4, 5, 6]]), Nx.tensor([[10.0, 11.0]])) ==
-               Nx.tensor([[1.0, 10.0, 11.0], [4.0, 5.0, 6.0]])
+      assert_equal(
+        put_slice4(Nx.tensor([[1, 2, 3], [4, 5, 6]]), Nx.tensor([[10.0, 11.0]])),
+        Nx.tensor([[1.0, 10.0, 11.0], [4.0, 5.0, 6.0]])
+      )
     end
   end
 
@@ -2717,54 +3021,60 @@ defmodule EXLA.Defn.ExprTest do
     defn take_axis_1(t, idx), do: Nx.take(t, idx, axis: 1)
 
     test "1d indices" do
-      assert take_axis_0(Nx.tensor([[1, 2], [3, 4]]), Nx.tensor([1, 0, 1])) ==
-               Nx.tensor([[3, 4], [1, 2], [3, 4]])
+      assert_equal(
+        take_axis_0(Nx.tensor([[1, 2], [3, 4]]), Nx.tensor([1, 0, 1])),
+        Nx.tensor([[3, 4], [1, 2], [3, 4]])
+      )
 
-      assert take_axis_1(Nx.tensor([[1, 2], [3, 4]]), Nx.tensor([1, 0, 1])) ==
-               Nx.tensor([[2, 1, 2], [4, 3, 4]])
+      assert_equal(
+        take_axis_1(Nx.tensor([[1, 2], [3, 4]]), Nx.tensor([1, 0, 1])),
+        Nx.tensor([[2, 1, 2], [4, 3, 4]])
+      )
     end
 
     test "2d indices" do
-      assert take_axis_1(
-               Nx.tensor([[[1, 2], [11, 12]], [[101, 102], [111, 112]]]),
-               Nx.tensor([[0, 0, 0], [1, 1, 1], [0, 0, 0]])
-             ) ==
-               Nx.tensor([
-                 [
-                   [
-                     [1, 2],
-                     [1, 2],
-                     [1, 2]
-                   ],
-                   [
-                     [11, 12],
-                     [11, 12],
-                     [11, 12]
-                   ],
-                   [
-                     [1, 2],
-                     [1, 2],
-                     [1, 2]
-                   ]
-                 ],
-                 [
-                   [
-                     [101, 102],
-                     [101, 102],
-                     [101, 102]
-                   ],
-                   [
-                     [111, 112],
-                     [111, 112],
-                     [111, 112]
-                   ],
-                   [
-                     [101, 102],
-                     [101, 102],
-                     [101, 102]
-                   ]
-                 ]
-               ])
+      assert_equal(
+        take_axis_1(
+          Nx.tensor([[[1, 2], [11, 12]], [[101, 102], [111, 112]]]),
+          Nx.tensor([[0, 0, 0], [1, 1, 1], [0, 0, 0]])
+        ),
+        Nx.tensor([
+          [
+            [
+              [1, 2],
+              [1, 2],
+              [1, 2]
+            ],
+            [
+              [11, 12],
+              [11, 12],
+              [11, 12]
+            ],
+            [
+              [1, 2],
+              [1, 2],
+              [1, 2]
+            ]
+          ],
+          [
+            [
+              [101, 102],
+              [101, 102],
+              [101, 102]
+            ],
+            [
+              [111, 112],
+              [111, 112],
+              [111, 112]
+            ],
+            [
+              [101, 102],
+              [101, 102],
+              [101, 102]
+            ]
+          ]
+        ])
+      )
     end
   end
 
@@ -2772,22 +3082,30 @@ defmodule EXLA.Defn.ExprTest do
     defn gather(t, idx), do: Nx.gather(t, idx)
 
     test "1d result" do
-      assert gather(Nx.tensor([[1, 2], [3, 4]]), Nx.tensor([[1, 1], [0, 1], [1, 0]])) ==
-               Nx.tensor([4, 2, 3])
+      assert_equal(
+        gather(Nx.tensor([[1, 2], [3, 4]]), Nx.tensor([[1, 1], [0, 1], [1, 0]])),
+        Nx.tensor([4, 2, 3])
+      )
 
-      assert gather(
-               Nx.tensor([[[1, 2], [11, 12]], [[101, 102], [111, 112]]]),
-               Nx.tensor([[0, 0, 0], [0, 1, 1], [1, 1, 1]])
-             ) ==
-               Nx.tensor([1, 12, 112])
+      assert_equal(
+        gather(
+          Nx.tensor([[[1, 2], [11, 12]], [[101, 102], [111, 112]]]),
+          Nx.tensor([[0, 0, 0], [0, 1, 1], [1, 1, 1]])
+        ),
+        Nx.tensor([1, 12, 112])
+      )
 
-      assert gather(Nx.tensor([[1, 2], [3, 4]]), Nx.tensor([[-1, -1], [10, 11], [-1, 10]])) ==
-               Nx.tensor([1, 4, 2])
+      assert_equal(
+        gather(Nx.tensor([[1, 2], [3, 4]]), Nx.tensor([[-1, -1], [10, 11], [-1, 10]])),
+        Nx.tensor([1, 4, 2])
+      )
     end
 
     test "2d result" do
-      assert gather(Nx.tensor([[1, 2], [3, 4]]), Nx.tensor([[[1, 1], [0, 0]], [[1, 0], [0, 1]]])) ==
-               Nx.tensor([[4, 1], [3, 2]])
+      assert_equal(
+        gather(Nx.tensor([[1, 2], [3, 4]]), Nx.tensor([[[1, 1], [0, 0]], [[1, 0], [0, 1]]])),
+        Nx.tensor([[4, 1], [3, 2]])
+      )
     end
   end
 
@@ -2798,79 +3116,87 @@ defmodule EXLA.Defn.ExprTest do
     defn reverse3(t), do: Nx.reverse(t, axes: [1, 2, 4])
 
     test "works on all dims" do
-      assert reverse(Nx.iota({10})) == Nx.tensor([9, 8, 7, 6, 5, 4, 3, 2, 1, 0])
-      assert reverse(Nx.iota({2, 4})) == Nx.tensor([[7, 6, 5, 4], [3, 2, 1, 0]])
+      assert_equal(reverse(Nx.iota({10})), Nx.tensor([9, 8, 7, 6, 5, 4, 3, 2, 1, 0]))
+      assert_equal(reverse(Nx.iota({2, 4})), Nx.tensor([[7, 6, 5, 4], [3, 2, 1, 0]]))
 
-      assert reverse(Nx.iota({3, 3, 3})) ==
-               Nx.tensor([
-                 [[26, 25, 24], [23, 22, 21], [20, 19, 18]],
-                 [[17, 16, 15], [14, 13, 12], [11, 10, 9]],
-                 [[8, 7, 6], [5, 4, 3], [2, 1, 0]]
-               ])
+      assert_equal(
+        reverse(Nx.iota({3, 3, 3})),
+        Nx.tensor([
+          [[26, 25, 24], [23, 22, 21], [20, 19, 18]],
+          [[17, 16, 15], [14, 13, 12], [11, 10, 9]],
+          [[8, 7, 6], [5, 4, 3], [2, 1, 0]]
+        ])
+      )
 
-      assert reverse(Nx.iota({2, 1, 4, 2})) ==
-               Nx.tensor([
-                 [[[15, 14], [13, 12], [11, 10], [9, 8]]],
-                 [[[7, 6], [5, 4], [3, 2], [1, 0]]]
-               ])
+      assert_equal(
+        reverse(Nx.iota({2, 1, 4, 2})),
+        Nx.tensor([
+          [[[15, 14], [13, 12], [11, 10], [9, 8]]],
+          [[[7, 6], [5, 4], [3, 2], [1, 0]]]
+        ])
+      )
     end
 
     test "works with 1 dim" do
-      assert reverse1(Nx.iota({2, 3})) == Nx.tensor([[2, 1, 0], [5, 4, 3]])
+      assert_equal(reverse1(Nx.iota({2, 3})), Nx.tensor([[2, 1, 0], [5, 4, 3]]))
     end
 
     test "works with 2 dims" do
-      assert reverse2(Nx.iota({2, 3, 4})) ==
-               Nx.tensor([
-                 [
-                   [15, 14, 13, 12],
-                   [19, 18, 17, 16],
-                   [23, 22, 21, 20]
-                 ],
-                 [
-                   [3, 2, 1, 0],
-                   [7, 6, 5, 4],
-                   [11, 10, 9, 8]
-                 ]
-               ])
+      assert_equal(
+        reverse2(Nx.iota({2, 3, 4})),
+        Nx.tensor([
+          [
+            [15, 14, 13, 12],
+            [19, 18, 17, 16],
+            [23, 22, 21, 20]
+          ],
+          [
+            [3, 2, 1, 0],
+            [7, 6, 5, 4],
+            [11, 10, 9, 8]
+          ]
+        ])
+      )
     end
 
     test "works with 3 dims" do
-      assert reverse3(Nx.iota({2, 2, 1, 3, 4})) ==
-               Nx.tensor([
-                 [
-                   [
-                     [
-                       [15, 14, 13, 12],
-                       [19, 18, 17, 16],
-                       [23, 22, 21, 20]
-                     ]
-                   ],
-                   [
-                     [
-                       [3, 2, 1, 0],
-                       [7, 6, 5, 4],
-                       [11, 10, 9, 8]
-                     ]
-                   ]
-                 ],
-                 [
-                   [
-                     [
-                       [39, 38, 37, 36],
-                       [43, 42, 41, 40],
-                       [47, 46, 45, 44]
-                     ]
-                   ],
-                   [
-                     [
-                       [27, 26, 25, 24],
-                       [31, 30, 29, 28],
-                       [35, 34, 33, 32]
-                     ]
-                   ]
-                 ]
-               ])
+      assert_equal(
+        reverse3(Nx.iota({2, 2, 1, 3, 4})),
+        Nx.tensor([
+          [
+            [
+              [
+                [15, 14, 13, 12],
+                [19, 18, 17, 16],
+                [23, 22, 21, 20]
+              ]
+            ],
+            [
+              [
+                [3, 2, 1, 0],
+                [7, 6, 5, 4],
+                [11, 10, 9, 8]
+              ]
+            ]
+          ],
+          [
+            [
+              [
+                [39, 38, 37, 36],
+                [43, 42, 41, 40],
+                [47, 46, 45, 44]
+              ]
+            ],
+            [
+              [
+                [27, 26, 25, 24],
+                [31, 30, 29, 28],
+                [35, 34, 33, 32]
+              ]
+            ]
+          ]
+        ])
+      )
     end
   end
 
@@ -2886,25 +3212,27 @@ defmodule EXLA.Defn.ExprTest do
       t2 = Nx.iota({1, 2, 2})
       t3 = Nx.iota({1, 2, 2})
 
-      assert concatenate0(t1, t2, t3) ==
-               Nx.tensor([
-                 [
-                   [0, 1],
-                   [2, 3]
-                 ],
-                 [
-                   [4, 5],
-                   [6, 7]
-                 ],
-                 [
-                   [0, 1],
-                   [2, 3]
-                 ],
-                 [
-                   [0, 1],
-                   [2, 3]
-                 ]
-               ])
+      assert_equal(
+        concatenate0(t1, t2, t3),
+        Nx.tensor([
+          [
+            [0, 1],
+            [2, 3]
+          ],
+          [
+            [4, 5],
+            [6, 7]
+          ],
+          [
+            [0, 1],
+            [2, 3]
+          ],
+          [
+            [0, 1],
+            [2, 3]
+          ]
+        ])
+      )
     end
 
     test "works on 1st axis" do
@@ -2912,41 +3240,45 @@ defmodule EXLA.Defn.ExprTest do
       t2 = Nx.iota({1, 1, 2})
       t3 = Nx.iota({1, 2, 2})
 
-      assert concatenate1(t1, t2, t3) ==
-               Nx.tensor([
-                 [
-                   [0, 1],
-                   [2, 3],
-                   [4, 5],
-                   [0, 1],
-                   [0, 1],
-                   [2, 3]
-                 ]
-               ])
+      assert_equal(
+        concatenate1(t1, t2, t3),
+        Nx.tensor([
+          [
+            [0, 1],
+            [2, 3],
+            [4, 5],
+            [0, 1],
+            [0, 1],
+            [2, 3]
+          ]
+        ])
+      )
 
       t1 = Nx.iota({2, 2, 2})
       t2 = Nx.add(t1, 10)
       t3 = Nx.add(t1, 20)
 
-      assert concatenate1(t1, t2, t3) ==
-               Nx.tensor([
-                 [
-                   [0, 1],
-                   [2, 3],
-                   [10, 11],
-                   [12, 13],
-                   [20, 21],
-                   [22, 23]
-                 ],
-                 [
-                   [4, 5],
-                   [6, 7],
-                   [14, 15],
-                   [16, 17],
-                   [24, 25],
-                   [26, 27]
-                 ]
-               ])
+      assert_equal(
+        concatenate1(t1, t2, t3),
+        Nx.tensor([
+          [
+            [0, 1],
+            [2, 3],
+            [10, 11],
+            [12, 13],
+            [20, 21],
+            [22, 23]
+          ],
+          [
+            [4, 5],
+            [6, 7],
+            [14, 15],
+            [16, 17],
+            [24, 25],
+            [26, 27]
+          ]
+        ])
+      )
     end
 
     test "works on 2nd axis" do
@@ -2954,27 +3286,31 @@ defmodule EXLA.Defn.ExprTest do
       t2 = Nx.iota({2, 1, 1})
       t3 = Nx.iota({2, 1, 3})
 
-      assert concatenate2(t1, t2, t3) ==
-               Nx.tensor([
-                 [
-                   [0, 1, 2, 3, 0, 0, 1, 2]
-                 ],
-                 [
-                   [4, 5, 6, 7, 1, 3, 4, 5]
-                 ]
-               ])
+      assert_equal(
+        concatenate2(t1, t2, t3),
+        Nx.tensor([
+          [
+            [0, 1, 2, 3, 0, 0, 1, 2]
+          ],
+          [
+            [4, 5, 6, 7, 1, 3, 4, 5]
+          ]
+        ])
+      )
     end
 
     test "works with 1 input" do
-      assert concatenate1_inp(Nx.iota({2, 1, 4})) ==
-               Nx.tensor([
-                 [
-                   [0, 1, 2, 3]
-                 ],
-                 [
-                   [4, 5, 6, 7]
-                 ]
-               ])
+      assert_equal(
+        concatenate1_inp(Nx.iota({2, 1, 4})),
+        Nx.tensor([
+          [
+            [0, 1, 2, 3]
+          ],
+          [
+            [4, 5, 6, 7]
+          ]
+        ])
+      )
     end
 
     test "works with mixed types" do
@@ -2982,32 +3318,34 @@ defmodule EXLA.Defn.ExprTest do
       t2 = Nx.iota({1, 2, 2}, type: {:u, 8})
       t3 = Nx.iota({1, 2, 2}, type: {:bf, 16})
 
-      assert concatenate0(t1, t2, t3) ==
-               Nx.tensor(
-                 [
-                   [
-                     [0.0, 1.0],
-                     [2.0, 3.0]
-                   ],
-                   [
-                     [4.0, 5.0],
-                     [6.0, 7.0]
-                   ],
-                   [
-                     [0.0, 1.0],
-                     [2.0, 3.0]
-                   ],
-                   [
-                     [0.0, 1.0],
-                     [2.0, 3.0]
-                   ]
-                 ],
-                 type: {:f, 32}
-               )
+      assert_equal(
+        concatenate0(t1, t2, t3),
+        Nx.tensor(
+          [
+            [
+              [0.0, 1.0],
+              [2.0, 3.0]
+            ],
+            [
+              [4.0, 5.0],
+              [6.0, 7.0]
+            ],
+            [
+              [0.0, 1.0],
+              [2.0, 3.0]
+            ],
+            [
+              [0.0, 1.0],
+              [2.0, 3.0]
+            ]
+          ],
+          type: {:f, 32}
+        )
+      )
     end
 
     test "works with constants" do
-      assert concat_constants() == Nx.tensor([1, 2])
+      assert_equal(concat_constants(), Nx.tensor([1, 2]))
     end
 
     test "works with mixed backends" do
@@ -3018,7 +3356,7 @@ defmodule EXLA.Defn.ExprTest do
         t2 = Nx.tensor([3, 4], opts2)
         t3 = Nx.tensor([5, 6], opts1)
 
-        compare_tensors!(Nx.tensor([1, 2, 3, 4, 5, 6]), Nx.concatenate([t1, t2, t3]))
+        assert_all_close(Nx.tensor([1, 2, 3, 4, 5, 6]), Nx.concatenate([t1, t2, t3]))
       end
     end
   end
@@ -3029,16 +3367,16 @@ defmodule EXLA.Defn.ExprTest do
     test "triangular_solve" do
       a = Nx.tensor([[3, 0, 0, 0], [2, 1, 0, 0], [1, 0, 1, 0], [1, 1, 1, 1]])
       b = Nx.tensor([4, 2, 4, 2])
-      assert compare_tensors!(Nx.dot(a, ts(a, b)), b)
+      assert_all_close(Nx.dot(a, ts(a, b)), b)
 
       a = Nx.tensor([[1, 0, 0], [1, 1, 0], [0, 1, 1]])
       b = Nx.tensor([[1, 2, 3], [2, 2, 4], [2, 0, 1]])
-      assert compare_tensors!(Nx.dot(a, ts(a, b)), b)
+      assert_all_close(Nx.dot(a, ts(a, b)), b)
 
       upper = Nx.transpose(a)
-      assert compare_tensors!(Nx.dot(upper, ts(upper, b, lower: false)), b)
-      assert compare_tensors!(Nx.dot(ts(upper, b, left_side: false, lower: false), upper), b)
-      assert compare_tensors!(Nx.dot(Nx.transpose(a), ts(a, b, transform_a: :transpose)), b)
+      assert_all_close(Nx.dot(upper, ts(upper, b, lower: false)), b)
+      assert_all_close(Nx.dot(ts(upper, b, left_side: false, lower: false), upper), b)
+      assert_all_close(Nx.dot(Nx.transpose(a), ts(a, b, transform_a: :transpose)), b)
     end
 
     defn qr(t), do: Nx.LinAlg.qr(t)
@@ -3051,12 +3389,12 @@ defmodule EXLA.Defn.ExprTest do
       assert {q, r} = qr(input)
       assert q.shape == {3, 2}
       assert r.shape == {2, 2}
-      assert compare_tensors!(Nx.dot(q, r), output)
+      assert_all_close(Nx.dot(q, r), output)
 
       assert {q, r} = qr_complete(Nx.iota({3, 2}))
       assert q.shape == {3, 3}
       assert r.shape == {3, 2}
-      assert compare_tensors!(Nx.dot(q, r), output)
+      assert_all_close(Nx.dot(q, r), output)
     end
 
     defn svd(t), do: Nx.LinAlg.svd(t)
@@ -3071,10 +3409,10 @@ defmodule EXLA.Defn.ExprTest do
       assert vt.shape == {3, 3}
       s_full = Nx.multiply(s, Nx.tensor([[1, 0, 0], [0, 1, 0], [0, 0, 1]]))
 
-      assert compare_tensors!(u |> Nx.dot(s_full) |> Nx.dot(Nx.transpose(vt)), output,
-               atol: 1.0e-5,
-               rtol: 1.0e-2
-             )
+      assert_all_close(u |> Nx.dot(s_full) |> Nx.dot(Nx.transpose(vt)), output,
+        atol: 1.0e-5,
+        rtol: 1.0e-2
+      )
     end
 
     test "svd (tall matrix)" do
@@ -3087,10 +3425,10 @@ defmodule EXLA.Defn.ExprTest do
       assert vt.shape == {2, 2}
       s_full = Nx.multiply(s, Nx.tensor([[1, 0], [0, 1], [0, 0]]))
 
-      assert compare_tensors!(u |> Nx.dot(s_full) |> Nx.dot(Nx.transpose(vt)), output,
-               atol: 1.0e-5,
-               rtol: 1.0e-2
-             )
+      assert_all_close(u |> Nx.dot(s_full) |> Nx.dot(Nx.transpose(vt)), output,
+        atol: 1.0e-5,
+        rtol: 1.0e-2
+      )
     end
 
     test "svd (wide matrix)" do
@@ -3103,10 +3441,10 @@ defmodule EXLA.Defn.ExprTest do
       assert vt.shape == {3, 3}
       s_full = Nx.multiply(Nx.reshape(s, {2, 1}), Nx.tensor([[1, 0, 0], [0, 1, 0]]))
 
-      assert compare_tensors!(u |> Nx.dot(s_full) |> Nx.dot(Nx.transpose(vt)), output,
-               atol: 1.0e-5,
-               rtol: 1.0e-2
-             )
+      assert_all_close(u |> Nx.dot(s_full) |> Nx.dot(Nx.transpose(vt)), output,
+        atol: 1.0e-5,
+        rtol: 1.0e-2
+      )
     end
   end
 
@@ -3117,37 +3455,40 @@ defmodule EXLA.Defn.ExprTest do
     defn sort2(t), do: Nx.sort(t, axis: 2)
 
     test "sorts a 1d tensor" do
-      assert sort0(Nx.tensor([0, 5, 2, 1, 3, 4])) == Nx.tensor([0, 1, 2, 3, 4, 5])
+      assert_equal(sort0(Nx.tensor([0, 5, 2, 1, 3, 4])), Nx.tensor([0, 1, 2, 3, 4, 5]))
     end
 
     test "sorts a 2d tensor along the 0th axis" do
-      assert sort0(Nx.tensor([[3, 1, 7], [2, 5, 4]])) == Nx.tensor([[2, 1, 4], [3, 5, 7]])
+      assert_equal(sort0(Nx.tensor([[3, 1, 7], [2, 5, 4]])), Nx.tensor([[2, 1, 4], [3, 5, 7]]))
     end
 
     test "sorts a 2d tensor along the 1st axis" do
-      assert sort1(Nx.tensor([[3, 1, 7], [2, 5, 4]])) == Nx.tensor([[1, 3, 7], [2, 4, 5]])
+      assert_equal(sort1(Nx.tensor([[3, 1, 7], [2, 5, 4]])), Nx.tensor([[1, 3, 7], [2, 4, 5]]))
     end
 
     test "sorts a 2d tensor along the 1st axis ascending" do
-      assert sort1_asc(Nx.tensor([[3, 1, 7], [2, 5, 4]])) == Nx.tensor([[1, 3, 7], [2, 4, 5]])
+      assert_equal(
+        sort1_asc(Nx.tensor([[3, 1, 7], [2, 5, 4]])),
+        Nx.tensor([[1, 3, 7], [2, 4, 5]])
+      )
     end
 
     test "sorts a 3d tensor along the 2nd axis" do
-      assert sort2(
-               Nx.tensor([[[4, 5, 2], [2, 5, 3], [5, 0, 2]], [[1, 9, 8], [2, 1, 3], [2, 1, 4]]])
-             ) ==
-               Nx.tensor([
-                 [
-                   [2, 4, 5],
-                   [2, 3, 5],
-                   [0, 2, 5]
-                 ],
-                 [
-                   [1, 8, 9],
-                   [1, 2, 3],
-                   [1, 2, 4]
-                 ]
-               ])
+      assert_equal(
+        sort2(Nx.tensor([[[4, 5, 2], [2, 5, 3], [5, 0, 2]], [[1, 9, 8], [2, 1, 3], [2, 1, 4]]])),
+        Nx.tensor([
+          [
+            [2, 4, 5],
+            [2, 3, 5],
+            [0, 2, 5]
+          ],
+          [
+            [1, 8, 9],
+            [1, 2, 3],
+            [1, 2, 4]
+          ]
+        ])
+      )
     end
   end
 
@@ -3158,42 +3499,49 @@ defmodule EXLA.Defn.ExprTest do
     defn argsort2(t), do: Nx.argsort(t, axis: 2)
 
     test "sorts a 1d tensor and returns its indices" do
-      assert argsort0(Nx.tensor([0, 5, 2, 1, 3, 4])) == Nx.tensor([0, 3, 2, 4, 5, 1])
+      assert_equal(argsort0(Nx.tensor([0, 5, 2, 1, 3, 4])), Nx.tensor([0, 3, 2, 4, 5, 1]))
     end
 
     test "sorts a 2d tensor along the 0th axis and returns its indices" do
-      assert argsort0(Nx.tensor([[3, 1, 7], [2, 5, 4]])) == Nx.tensor([[1, 0, 1], [0, 1, 0]])
+      assert_equal(argsort0(Nx.tensor([[3, 1, 7], [2, 5, 4]])), Nx.tensor([[1, 0, 1], [0, 1, 0]]))
     end
 
     test "sorts a 2d tensor along the 1st axis and returns its indices" do
-      assert argsort1(Nx.tensor([[3, 1, 7], [2, 5, 4]])) == Nx.tensor([[1, 0, 2], [0, 2, 1]])
+      assert_equal(argsort1(Nx.tensor([[3, 1, 7], [2, 5, 4]])), Nx.tensor([[1, 0, 2], [0, 2, 1]]))
     end
 
     test "sorts a 2d tensor along the 1st axis ascending and returns its indices" do
-      assert argsort1_asc(Nx.tensor([[3, 1, 7], [2, 5, 4]])) == Nx.tensor([[1, 0, 2], [0, 2, 1]])
+      assert_equal(
+        argsort1_asc(Nx.tensor([[3, 1, 7], [2, 5, 4]])),
+        Nx.tensor([[1, 0, 2], [0, 2, 1]])
+      )
     end
 
     test "sorts a 3d tensor along the 2nd axis and returns its indices" do
-      assert argsort2(
-               Nx.tensor([[[4, 5, 2], [2, 5, 3], [5, 0, 2]], [[1, 9, 8], [2, 1, 3], [2, 1, 4]]])
-             ) ==
-               Nx.tensor([
-                 [
-                   [2, 0, 1],
-                   [0, 2, 1],
-                   [1, 2, 0]
-                 ],
-                 [
-                   [0, 2, 1],
-                   [1, 0, 2],
-                   [1, 0, 2]
-                 ]
-               ])
+      assert_equal(
+        argsort2(
+          Nx.tensor([[[4, 5, 2], [2, 5, 3], [5, 0, 2]], [[1, 9, 8], [2, 1, 3], [2, 1, 4]]])
+        ),
+        Nx.tensor([
+          [
+            [2, 0, 1],
+            [0, 2, 1],
+            [1, 2, 0]
+          ],
+          [
+            [0, 2, 1],
+            [1, 0, 2],
+            [1, 0, 2]
+          ]
+        ])
+      )
     end
 
     test "sorts a floating-point tensor and returns its indices" do
-      assert argsort0(Nx.tensor([42.0, 23.0, 16.0, 15.0, 8.0, 4.0])) ==
-               Nx.tensor([5, 4, 3, 2, 1, 0])
+      assert_equal(
+        argsort0(Nx.tensor([42.0, 23.0, 16.0, 15.0, 8.0, 4.0])),
+        Nx.tensor([5, 4, 3, 2, 1, 0])
+      )
     end
   end
 
@@ -3202,7 +3550,7 @@ defmodule EXLA.Defn.ExprTest do
 
     test "determinant" do
       two_by_two = Nx.tensor([[1, 2], [3, 4]], names: [:x, :y])
-      assert determinant(two_by_two) == Nx.tensor(-2.0)
+      assert_equal(determinant(two_by_two), Nx.tensor(-2.0))
     end
   end
 
@@ -3212,11 +3560,11 @@ defmodule EXLA.Defn.ExprTest do
     test "works on 2x2 matrix" do
       lhs = cholesky(Nx.tensor([[20.0, 17.6], [17.6, 16.0]]))
       rhs = Nx.tensor([[4.47213595499958, 0.0], [3.93547964039963, 0.7155417527999305]])
-      compare_tensors!(lhs, rhs)
+      assert_all_close(lhs, rhs)
 
       lhs = cholesky(Nx.tensor([[1, 2], [2, 5]]))
       rhs = Nx.tensor([[1.0, 0.0], [2.0, 1.0]])
-      compare_tensors!(lhs, rhs)
+      assert_all_close(lhs, rhs)
     end
 
     test "works on a 4x4 matrix" do
@@ -3238,7 +3586,7 @@ defmodule EXLA.Defn.ExprTest do
           [3.2659863237109046, -1.4142135623730956, 1.5877132402714704, 3.1324910215354165]
         ])
 
-      compare_tensors!(lhs, rhs)
+      assert_all_close(lhs, rhs)
     end
 
     test "works on a 50x50 matrix" do
@@ -3247,7 +3595,7 @@ defmodule EXLA.Defn.ExprTest do
       tensor = Nx.add(tensor, Nx.multiply(50, Nx.eye(tensor)))
 
       l = cholesky(tensor)
-      compare_tensors!(Nx.dot(l, Nx.transpose(l)), tensor, atol: 1.0e-4, rtol: 1.0e-2)
+      assert_all_close(Nx.dot(l, Nx.transpose(l)), tensor, atol: 1.0e-4, rtol: 1.0e-2)
     end
   end
 
@@ -3257,7 +3605,7 @@ defmodule EXLA.Defn.ExprTest do
     test "accepts bfloat16 input" do
       lhs = Nx.tensor([1.0, 2.0, 3.0], type: {:bf, 16})
       rhs = Nx.tensor([4.0, 5.0, 6.0], type: {:bf, 16})
-      assert add(lhs, rhs) == Nx.tensor([5.0, 7.0, 9.0], type: {:bf, 16})
+      assert_equal(add(lhs, rhs), Nx.tensor([5.0, 7.0, 9.0], type: {:bf, 16}))
     end
   end
 
@@ -3281,11 +3629,14 @@ defmodule EXLA.Defn.ExprTest do
     end
 
     test "succeeds on good precision" do
-      assert EXLA.jit(
-               &precision/2,
-               [Nx.tensor([1, 2, 3], type: {:bf, 16}), Nx.tensor([1, 2, 3], type: {:bf, 16})],
-               precision: :high
-             ) == Nx.tensor(14, type: {:bf, 16})
+      assert_equal(
+        EXLA.jit(
+          &precision/2,
+          [Nx.tensor([1, 2, 3], type: {:bf, 16}), Nx.tensor([1, 2, 3], type: {:bf, 16})],
+          precision: :high
+        ),
+        Nx.tensor(14, type: {:bf, 16})
+      )
     end
   end
 
@@ -3301,8 +3652,10 @@ defmodule EXLA.Defn.ExprTest do
       t = Nx.tensor([[[1, 2], [3, 4]], [[5, 6], [7, 8]], [[9, 10], [11, 12]]])
       i = Nx.tensor([[[0, 1], [0, 1]], [[0, 1], [0, 1]], [[0, 1], [0, 1]]])
 
-      assert take_along_axis(t, i, 2) ==
-               Nx.tensor([[[1, 2], [3, 4]], [[5, 6], [7, 8]], [[9, 10], [11, 12]]])
+      assert_equal(
+        take_along_axis(t, i, 2),
+        Nx.tensor([[[1, 2], [3, 4]], [[5, 6], [7, 8]], [[9, 10], [11, 12]]])
+      )
     end
 
     test "works for {3, 2, 2} tensor growing along axis = 2" do
@@ -3315,12 +3668,14 @@ defmodule EXLA.Defn.ExprTest do
           [[0, 1, 1, 0], [0, 1, 1, 0]]
         ])
 
-      assert take_along_axis(t, i, 2) ==
-               Nx.tensor([
-                 [[1, 2, 2, 1], [3, 4, 4, 3]],
-                 [[5, 6, 6, 5], [7, 8, 8, 7]],
-                 [[9, 10, 10, 9], [11, 12, 12, 11]]
-               ])
+      assert_equal(
+        take_along_axis(t, i, 2),
+        Nx.tensor([
+          [[1, 2, 2, 1], [3, 4, 4, 3]],
+          [[5, 6, 6, 5], [7, 8, 8, 7]],
+          [[9, 10, 10, 9], [11, 12, 12, 11]]
+        ])
+      )
     end
 
     test "works for {3, 2, 2} tensor growing along axis = 0" do
@@ -3346,32 +3701,24 @@ defmodule EXLA.Defn.ExprTest do
           ]
         ])
 
-      assert take_along_axis(t, i) ==
-               Nx.tensor([
-                 [[1, 2], [3, 4]],
-                 [[5, 6], [7, 8]],
-                 [[9, 10], [11, 12]],
-                 [[9, 6], [7, 4]]
-               ])
+      assert_equal(
+        take_along_axis(t, i),
+        Nx.tensor([
+          [[1, 2], [3, 4]],
+          [[5, 6], [7, 8]],
+          [[9, 10], [11, 12]],
+          [[9, 6], [7, 4]]
+        ])
+      )
     end
 
     test "uses argsort indices properly" do
       t = Nx.tensor([[[1, 2], [3, 4]], [[5, 6], [7, 8]], [[9, 10], [11, 12]]])
 
-      assert sort_with_take_along_axis(t, axis: 1, direction: :desc) ==
-               Nx.sort(t, axis: 1, direction: :desc)
-    end
-  end
-
-  defp compare_tensors!(left, right, opts \\ []) do
-    atol = opts[:atol] || 1.0e-7
-    rtol = opts[:rtol] || 1.0e-4
-
-    try do
-      assert Nx.all_close(left, right, atol: atol, rtol: rtol) == Nx.tensor(1, type: {:u, 8})
-    rescue
-      # So we can see the diff
-      _ -> assert left == right
+      assert_equal(
+        sort_with_take_along_axis(t, axis: 1, direction: :desc),
+        Nx.sort(t, axis: 1, direction: :desc)
+      )
     end
   end
 end

--- a/exla/test/exla/multi_device_test.exs
+++ b/exla/test/exla/multi_device_test.exs
@@ -11,7 +11,7 @@ defmodule EXLA.MultiDeviceTest do
     t2 = BinaryBuffer.from_binary(<<2::32-native>>, Shape.make_shape({:s, 32}, {}))
 
     assert [a = %DeviceBuffer{}, b = %DeviceBuffer{}, c = %DeviceBuffer{}] =
-             run_one([t1, t2], [keep_on_device: true, device_id: 1], fn b, x, y ->
+             run_one([t1, t2], [device_id: 1], fn b, x, y ->
                Op.tuple(b, [x, y, Op.add(x, y)])
              end)
 
@@ -33,8 +33,7 @@ defmodule EXLA.MultiDeviceTest do
 
     assert executable.device_id == -1
 
-    [[a1, a2, a3], [b1, b2, b3]] =
-      Executable.run(executable, [[t1, t2], [t3, t4]], keep_on_device: true)
+    [[a1, a2, a3], [b1, b2, b3]] = Executable.run(executable, [[t1, t2], [t3, t4]])
 
     assert <<1::32-native>> == DeviceBuffer.read(a1)
     assert <<2::32-native>> == DeviceBuffer.read(a2)

--- a/exla/test/support/exla_case.ex
+++ b/exla/test/support/exla_case.ex
@@ -1,0 +1,46 @@
+defmodule EXLA.Case do
+  @moduledoc """
+  Test case for tensor assertions
+  """
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      import EXLA.Case
+    end
+  end
+
+  defmacro assert_equal(left, right) do
+    # Assert against binary backend tensors to show diff on failure
+    quote do
+      assert unquote(left) |> to_binary_backend() == unquote(right) |> to_binary_backend()
+    end
+  end
+
+  def to_binary_backend(tensor) do
+    Nx.backend_copy(tensor, Nx.BinaryBackend)
+  end
+
+  def assert_all_close(left, right, opts \\ []) do
+    atol = opts[:atol] || 1.0e-4
+    rtol = opts[:rtol] || 1.0e-4
+
+    equals =
+      left
+      |> Nx.all_close(right, atol: atol, rtol: rtol)
+      |> Nx.backend_transfer(Nx.BinaryBackend)
+
+    if equals != Nx.tensor(1, type: {:u, 8}, backend: Nx.BinaryBackend) do
+      flunk("""
+      expected
+
+      #{inspect(left)}
+
+      to be within tolerance of
+
+      #{inspect(right)}
+      """)
+    end
+  end
+end


### PR DESCRIPTION
Removes the `:keep_on_device` option and effectively makes it the default behaviour.

Context: the `EXLA.Backend` (#739) allows for using regular Nx operations on a device tensor, so implicit transfer to the CPU doesn't really sense.