### PR TITLE
Fix cache pathing for intel macs

### DIFF
--- a/exla/Makefile
+++ b/exla/Makefile
@@ -27,7 +27,7 @@ ifeq ($(shell uname -s), Darwin)
 	LDFLAGS += -flat_namespace -undefined suppress
 	POST_INSTALL = install_name_tool \
 		-change bazel-out/darwin_arm64-opt/bin/tensorflow/compiler/xla/extension/libxla_extension.so @loader_path/xla_extension/lib/libxla_extension.so \
-		-change bazel-out/darwin-opt/bin/tensorflow/compiler/xla/extension/libxla_extension.so @loader_path/lib/libxla_extension.so \
+		-change bazel-out/darwin-opt/bin/tensorflow/compiler/xla/extension/libxla_extension.so @loader_path/xla_extension/lib/libxla_extension.so \
 		$(EXLA_CACHE_SO)
 else
 	# Use a relative RPATH, so at runtime libexla.so looks for libxla_extension.so


### PR DESCRIPTION
Add a bazel path for darwin (Intel macs) to point to the correct file.

Closes #745