### PR TITLE
fixed Typo in Readme example

### DIFF
--- a/nx/README.md
+++ b/nx/README.md
@@ -97,7 +97,7 @@ using this library:
 
 ```elixir
 iex> t = Nx.tensor([[1, 2], [3, 4]])
-iex> Nx.divide(Nx.exp(t), Nx.sum(Nx.exp(t)))
+iex> Nx.divide(Nx.exp(t), Nx.sum(Nx.exp(t))
 #Nx.Tensor<
   f32[2][2]
   [


### PR DESCRIPTION
there was `)` too much in line 100