### PR TITLE
Fix while inside cond

### DIFF
--- a/exla/test/exla/defn/expr_test.exs
+++ b/exla/test/exla/defn/expr_test.exs
@@ -3721,4 +3721,21 @@ defmodule EXLA.Defn.ExprTest do
       )
     end
   end
+
+  defn while_in_cond(i) do
+    cond do
+      i < 5 ->
+        while {i}, i < 5 do
+          {i + 1}
+        end
+
+      true ->
+        {i}
+    end
+  end
+
+  test "computes while inside cond" do
+    assert {i} = while_in_cond(0)
+    assert_equal(i, Nx.tensor(5))
+  end
 end


### PR DESCRIPTION
Closes #699.

When inside cond, we transform the branch `expr` here

https://github.com/elixir-nx/nx/blob/ee3ba17d5bc69cb0f782b5713c9055930f004439/exla/lib/exla/defn.ex#L1422-L1423

The transformation shifts the parameters as in [this diff](https://www.diffchecker.com/4C6XHPnE).

(I assume that's expected, but if not, maybe that's the actual issue)

---

Then we call `token_computation` for while pred and body, where we remap parameters from while `args`, such that they point to the while parameter tuple. This remapping ignores the position in existing parameter expressions, so if none of the parameters has position 0 it breaks.