### PR TITLE
feat(complex/grad): support cholesky

### DIFF
--- a/nx/lib/nx/defn/grad.ex
+++ b/nx/lib/nx/defn/grad.ex
@@ -555,7 +555,11 @@ defmodule Nx.Defn.Grad do
       |> Nx.LinAlg.triangular_solve(bm, left_side: false)
 
     # If we end up supporting the "make_symmetric" option for Nx.LinAlg.cholesky
-    # we need to apply: dl := (adjoint(dl) + dl)/2 when the option is true
+    # we need to apply: dl := (adjoint(dl) + dl)/2 when the option is true.
+    # If the option is applied as Nx.add(tensor, adjoint(tensor)) |> Nx.divide(2)
+    # on the expression, no modifications are needed here, because
+    # the grad for the transformation is actually the same transformation
+    # applied on the grad
 
     [{input, dl}]
   end

--- a/nx/test/nx/defn/grad_test.exs
+++ b/nx/test/nx/defn/grad_test.exs
@@ -1753,6 +1753,23 @@ defmodule Nx.Defn.GradTest do
       grad(t, fn x -> x |> Nx.exp() |> Nx.LinAlg.cholesky() |> Nx.sum() end)
     end
 
+    test "computes for 2x2 complex matrix" do
+      t = ~M[
+        1 -2i
+        2i 5
+      ]
+
+      assert cholesky_grad(t) == ~M[
+        2.5-1i -1i
+        1+1i 0.5
+      ]
+
+      assert_all_close(cholesky_cos_grad(t), ~M[
+        -5.7305   0.8414i
+        -4.4683i -0.4207
+      ])
+    end
+
     test "computes grad for {2, 2}-tensor" do
       t = Nx.tensor([[1.0, 2.0], [2.0, 5.0]])
       assert cholesky_grad(t) == Nx.tensor([[1.5, -1.0], [0.0, 0.5]])


### PR DESCRIPTION
The main issue which was holding me back on this is that `jax.lax.linalg.cholesky` has a default option of `make_symmetric=True`, which adds a transform `input := (adjoint(input)+ input)/2` both at the beggining of the cholesky algorithm and at the end of the grad calculation (same transform but with the grad result instead).

I've kept a comment regarding this for when we want to support said option, if we end up doing it.