### PR TITLE
Add `div/2` to `Nx.Defn.Kernel`

### DIFF
--- a/nx/lib/nx/defn/kernel.ex
+++ b/nx/lib/nx/defn/kernel.ex
@@ -442,6 +442,22 @@ defmodule Nx.Defn.Kernel do
   def left / right, do: Nx.divide(left, right)
 
   @doc """
+  Element-wise quotient operator.
+
+  It delegates to `Nx.quotient/2` (supports broadcasting).
+
+  ## Examples
+
+     defn quotient(a, b) do
+       div(a, b)
+     end
+  """
+  def div(left, right) when Kernel.and(is_number(left), is_number(right)),
+    do: Kernel.div(left, right)
+
+  def div(left, right), do: Nx.quotient(left, right)
+
+  @doc """
   Element-wise remainder operation.
 
   It delegates to `Nx.remainder/2` (supports broadcasting).

--- a/nx/test/nx/defn/kernel_test.exs
+++ b/nx/test/nx/defn/kernel_test.exs
@@ -106,6 +106,10 @@ defmodule Nx.Defn.KernelTest do
       assert Nx.Defn.Kernel.max(0, 1) == 1
     end
 
+    test "div" do
+      assert Nx.Defn.Kernel.div(11, 5) == 2
+    end
+
     test "rem" do
       assert Nx.Defn.Kernel.rem(1, 5) == 1
     end


### PR DESCRIPTION
Adds the `div/2` to function to perform integer division to `Nx.Defn.Kernel`.

Closes #815.