### PR TITLE
Make `Nx.flatten` an optional callback

### DIFF
--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -2160,7 +2160,17 @@ defmodule Nx do
   """
   @doc type: :shape
   def flatten(tensor) do
-    reshape(tensor, {size(tensor)})
+    tensor = to_tensor(tensor)
+    shape = {size(tensor)}
+
+    output =
+      tensor
+      |> Map.put(:shape, shape)
+      |> Map.put(:names, [nil])
+
+    Nx.Shared.optional(:flatten, [tensor], output, fn tensor ->
+      reshape(tensor, shape)
+    end)
   end
 
   @doc """

--- a/nx/lib/nx/backend.ex
+++ b/nx/lib/nx/backend.ex
@@ -143,6 +143,8 @@ defmodule Nx.Backend do
   @callback cumulative_min(out :: tensor, t :: tensor, axis) :: tensor
   @callback cumulative_max(out :: tensor, t :: tensor, axis) :: tensor
 
+  @callback flatten(out :: tensor, t :: tensor) :: tensor
+
   @optional_callbacks [
     optional: 3,
     solve: 3,
@@ -151,7 +153,8 @@ defmodule Nx.Backend do
     cumulative_sum: 3,
     cumulative_product: 3,
     cumulative_min: 3,
-    cumulative_max: 3
+    cumulative_max: 3,
+    flatten: 2
   ]
 
   ## Inspect implementation

--- a/torchx/c_src/torchx.cpp
+++ b/torchx/c_src/torchx.cpp
@@ -354,6 +354,12 @@ NIF(split)
   TENSOR_LIST(torch::split(*t, batch_size));
 }
 
+NIF(flatten)
+{
+  TENSOR_PARAM(0, t);
+
+  TENSOR(torch::flatten(*t));
+}
 
 NIF(reshape)
 {
@@ -1116,6 +1122,7 @@ static ErlNifFunc nif_functions[] = {
     DF(to_blob, 1),
     DF(to_blob, 2),
     DF(delete_tensor, 1),
+    DF(flatten, 1),
     DF(reshape, 2),
     DF(split, 2),
     DF(to_type, 2),

--- a/torchx/lib/torchx.ex
+++ b/torchx/lib/torchx.ex
@@ -198,6 +198,7 @@ defmodule Torchx do
 
   ## Manipulation
 
+  deftensor flatten(tensor)
   deftensor reshape(tensor, shape)
   deftensor to_type(tensor, type)
   deftensor squeeze(tensor)

--- a/torchx/lib/torchx/backend.ex
+++ b/torchx/lib/torchx/backend.ex
@@ -238,6 +238,9 @@ defmodule Torchx.Backend do
   ## Shape
 
   @impl true
+  def flatten(out, %T{} = t), do: t |> from_nx() |> Torchx.flatten() |> to_nx(out)
+
+  @impl true
   def reshape(%T{shape: shape} = out, %T{} = t),
     do: Torchx.reshape(from_nx(t), shape) |> to_nx(out)
 


### PR DESCRIPTION
- Make `Nx.flatten` an optional callback
- Implement flatten for `Torchx`