### PR TITLE
feat(defn): support booleans

### DIFF
--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -375,7 +375,7 @@ defmodule Nx do
   See also: `t:t/0`
   """
   @doc type: :guards
-  defguard is_tensor(t) when is_number(t) or is_struct(t, T) or is_struct(t, Complex)
+  defguard is_tensor(t) when is_number(t) or is_struct(t, T) or is_struct(t, Complex) or is_boolean(t)
 
   ## Creation API
 
@@ -698,7 +698,7 @@ defmodule Nx do
 
   defp tensor_or_number_to_binary(true, type), do: tensor_or_number_to_binary(1, type)
   defp tensor_or_number_to_binary(false, type), do: tensor_or_number_to_binary(0, type)
-  
+
   defp tensor_or_number_to_binary(%Complex{re: re, im: im}, {:c, size}) do
     number_to_binary(re, {:f, div(size, 2)}) <> number_to_binary(im, {:f, div(size, 2)})
   end
@@ -1638,6 +1638,9 @@ defmodule Nx do
     out = %T{shape: {}, type: {:c, size * 2}, names: []}
     backend.constant(out, number, options)
   end
+
+  def to_tensor(true), do: to_tensor(1)
+  def to_tensor(false), do: to_tensor(0)
 
   def to_tensor(t) do
     raise ArgumentError, "expected a %Nx.Tensor{} or a number, got: #{inspect(t)}"

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -610,10 +610,9 @@ defmodule Nx do
     Enum.reduce(tail, infer_type(head), &Nx.Type.merge(infer_type(&1), &2))
   end
 
-  defp infer_type(value) when is_boolean(value), do: {:u, 8}
-
   defp infer_type(number)
-       when is_number(number) or is_struct(number, Complex) or number in @non_finite do
+       when is_number(number) or is_struct(number, Complex) or number in @non_finite or
+              is_boolean(number) do
     Nx.Type.infer(number)
   end
 
@@ -1640,8 +1639,13 @@ defmodule Nx do
     backend.constant(out, number, options)
   end
 
-  def to_tensor(true), do: to_tensor(1)
-  def to_tensor(false), do: to_tensor(0)
+  def to_tensor(bool) when is_boolean(bool) do
+    {backend, options} = default_backend()
+    type = Nx.Type.infer(bool)
+    out = %T{shape: {}, type: type, names: []}
+    number = if bool == true, do: 1, else: 0
+    backend.constant(out, number, options)
+  end
 
   def to_tensor(t) do
     raise ArgumentError, "expected a %Nx.Tensor{} or a number, got: #{inspect(t)}"

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -435,6 +435,28 @@ defmodule Nx do
         [1.0, 2.0, 3.0]
       >
 
+  Boolean values are also accepted, where `true` is
+  converted to `1` and `false` to `0`, with the type
+  being inferred as `{:u, 8}`
+
+      iex> Nx.tensor(true)
+      #Nx.Tensor<
+        u8
+        1
+      >
+
+      iex> Nx.tensor(false)
+      #Nx.Tensor<
+        u8
+        0
+      >
+
+      iex> Nx.tensor([true, false])
+      #Nx.Tensor<
+        u8[2]
+        [1, 0]
+      >
+
   Multi-dimensional tensors are also possible:
 
       iex> Nx.tensor([[1, 2, 3], [4, 5, 6]])
@@ -587,6 +609,8 @@ defmodule Nx do
     Enum.reduce(tail, infer_type(head), &Nx.Type.merge(infer_type(&1), &2))
   end
 
+  defp infer_type(value) when is_boolean(value), do: {:u, 8}
+
   defp infer_type(number)
        when is_number(number) or is_struct(number, Complex) or number in @non_finite do
     Nx.Type.infer(number)
@@ -595,6 +619,9 @@ defmodule Nx do
   defp infer_type(value) do
     raise ArgumentError, "invalid value given to Nx.tensor/1, got: #{inspect(value)}"
   end
+
+  defp tensor(true, type, opts), do: tensor(1, type, opts)
+  defp tensor(false, type, opts), do: tensor(0, type, opts)
 
   defp tensor(arg, type, opts) when is_number(arg) do
     names = Nx.Shape.named_axes!(opts[:names], {})
@@ -669,6 +696,9 @@ defmodule Nx do
      Enum.reduce(list, acc, &[tensor_or_number_to_binary(&1, type) | &2])}
   end
 
+  defp tensor_or_number_to_binary(true, type), do: tensor_or_number_to_binary(1, type)
+  defp tensor_or_number_to_binary(false, type), do: tensor_or_number_to_binary(0, type)
+  
   defp tensor_or_number_to_binary(%Complex{re: re, im: im}, {:c, size}) do
     number_to_binary(re, {:f, div(size, 2)}) <> number_to_binary(im, {:f, div(size, 2)})
   end

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -376,7 +376,7 @@ defmodule Nx do
   """
   @doc type: :guards
   defguard is_tensor(t)
-           when is_number(t) or is_struct(t, T) or is_struct(t, Complex) or is_boolean(t)
+           when is_number(t) or is_struct(t, T) or is_struct(t, Complex)
 
   ## Creation API
 
@@ -1636,14 +1636,6 @@ defmodule Nx do
     {backend, options} = default_backend()
     {_, size} = re |> Nx.Type.infer() |> Nx.Type.merge(Nx.Type.infer(im))
     out = %T{shape: {}, type: {:c, size * 2}, names: []}
-    backend.constant(out, number, options)
-  end
-
-  def to_tensor(bool) when is_boolean(bool) do
-    {backend, options} = default_backend()
-    type = Nx.Type.infer(bool)
-    out = %T{shape: {}, type: type, names: []}
-    number = if bool == true, do: 1, else: 0
     backend.constant(out, number, options)
   end
 

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -375,7 +375,8 @@ defmodule Nx do
   See also: `t:t/0`
   """
   @doc type: :guards
-  defguard is_tensor(t) when is_number(t) or is_struct(t, T) or is_struct(t, Complex) or is_boolean(t)
+  defguard is_tensor(t)
+           when is_number(t) or is_struct(t, T) or is_struct(t, Complex) or is_boolean(t)
 
   ## Creation API
 

--- a/nx/lib/nx/defn/composite.ex
+++ b/nx/lib/nx/defn/composite.ex
@@ -135,7 +135,7 @@ defmodule Nx.Defn.Composite do
   defp flatten_each(%T{} = tensor, acc, _fun),
     do: [tensor | acc]
 
-  defp flatten_each(number, acc, fun) when is_number(number) or is_struct(number, Complex),
+  defp flatten_each(number, acc, fun) when is_number(number) or is_struct(number, Complex) or is_boolean(number),
     do: [fun.(number) | acc]
 
   defp flatten_each(container, acc, fun),

--- a/nx/lib/nx/defn/composite.ex
+++ b/nx/lib/nx/defn/composite.ex
@@ -87,7 +87,7 @@ defmodule Nx.Defn.Composite do
   Otherwise the function is invoked with the tensor (be it a
   number, complex, or actual tensor).
   """
-  def traverse(expr, acc, fun) when is_tensor(expr) and is_function(fun, 2),
+  def traverse(expr, acc, fun) when (is_tensor(expr) or is_boolean(expr)) and is_function(fun, 2),
     do: fun.(expr, acc)
 
   def traverse(container, acc, fun),
@@ -136,7 +136,7 @@ defmodule Nx.Defn.Composite do
     do: [tensor | acc]
 
   defp flatten_each(number, acc, fun)
-       when is_number(number) or is_struct(number, Complex) or is_boolean(number),
+       when is_number(number) or is_struct(number, Complex),
        do: [fun.(number) | acc]
 
   defp flatten_each(container, acc, fun),
@@ -193,8 +193,12 @@ defmodule Nx.Defn.Composite do
   def to_inputs(args) do
     {args, _} =
       Enum.map_reduce(args, 0, fn arg, i ->
-        traverse(arg, i, fn arg, i ->
-          {Expr.parameter(Nx.to_tensor(arg), :root, i), i + 1}
+        traverse(arg, i, fn
+          arg, _i when is_boolean(arg) ->
+            raise ArgumentError, "booleans are not supported as defn inputs"
+
+          arg, i ->
+            {Expr.parameter(Nx.to_tensor(arg), :root, i), i + 1}
         end)
       end)
 

--- a/nx/lib/nx/defn/composite.ex
+++ b/nx/lib/nx/defn/composite.ex
@@ -135,8 +135,9 @@ defmodule Nx.Defn.Composite do
   defp flatten_each(%T{} = tensor, acc, _fun),
     do: [tensor | acc]
 
-  defp flatten_each(number, acc, fun) when is_number(number) or is_struct(number, Complex) or is_boolean(number),
-    do: [fun.(number) | acc]
+  defp flatten_each(number, acc, fun)
+       when is_number(number) or is_struct(number, Complex) or is_boolean(number),
+       do: [fun.(number) | acc]
 
   defp flatten_each(container, acc, fun),
     do: Nx.Container.reduce(container, acc, &flatten_each(&1, &2, fun))

--- a/nx/lib/nx/defn/kernel.ex
+++ b/nx/lib/nx/defn/kernel.ex
@@ -567,6 +567,7 @@ defmodule Nx.Defn.Kernel do
   @doc false
   def __and__(left, right) when is_boolean(left), do: __and__(boolean_to_number(left), right)
   def __and__(left, right) when is_boolean(right), do: __and__(left, boolean_to_number(right))
+
   def __and__(left, right) when Kernel.and(is_number(left), is_number(right)),
     do: logical_and(left, right)
 
@@ -592,6 +593,7 @@ defmodule Nx.Defn.Kernel do
   @doc false
   def __or__(left, right) when is_boolean(left), do: __or__(boolean_to_number(left), right)
   def __or__(left, right) when is_boolean(right), do: __or__(left, boolean_to_number(right))
+
   def __or__(left, right) when Kernel.and(is_number(left), is_number(right)),
     do: logical_or(left, right)
 
@@ -755,8 +757,11 @@ defmodule Nx.Defn.Kernel do
   defnguard(left != right, :__not_equal__)
 
   @doc false
-  def __not_equal__(left, right) when is_boolean(left), do: __not_equal__(boolean_to_number(left), right)
-  def __not_equal__(left, right) when is_boolean(right), do: __not_equal__(left, boolean_to_number(right))
+  def __not_equal__(left, right) when is_boolean(left),
+    do: __not_equal__(boolean_to_number(left), right)
+
+  def __not_equal__(left, right) when is_boolean(right),
+    do: __not_equal__(left, boolean_to_number(right))
 
   def __not_equal__(left, right) when Kernel.and(is_number(left), is_number(right)),
     do: to_constant(Kernel.!=(left, right))
@@ -778,8 +783,11 @@ defmodule Nx.Defn.Kernel do
   defnguard(left < right, :__less_than__)
 
   @doc false
-  def __less_than__(left, right) when is_boolean(left), do: __less_than__(boolean_to_number(left), right)
-  def __less_than__(left, right) when is_boolean(right), do: __less_than__(left, boolean_to_number(right))
+  def __less_than__(left, right) when is_boolean(left),
+    do: __less_than__(boolean_to_number(left), right)
+
+  def __less_than__(left, right) when is_boolean(right),
+    do: __less_than__(left, boolean_to_number(right))
 
   def __less_than__(left, right) when Kernel.and(is_number(left), is_number(right)),
     do: to_constant(Kernel.<(left, right))
@@ -827,8 +835,11 @@ defmodule Nx.Defn.Kernel do
   defnguard(left <= right, :__less_than_equal_to__)
 
   @doc false
-  def __less_than_equal_to__(left, right) when is_boolean(left), do: __less_than_equal_to__(boolean_to_number(left), right)
-  def __less_than_equal_to__(left, right) when is_boolean(right), do: __less_than_equal_to__(left, boolean_to_number(right))
+  def __less_than_equal_to__(left, right) when is_boolean(left),
+    do: __less_than_equal_to__(boolean_to_number(left), right)
+
+  def __less_than_equal_to__(left, right) when is_boolean(right),
+    do: __less_than_equal_to__(left, boolean_to_number(right))
 
   def __less_than_equal_to__(left, right) when Kernel.and(is_number(left), is_number(right)),
     do: to_constant(Kernel.<=(left, right))
@@ -850,8 +861,11 @@ defmodule Nx.Defn.Kernel do
   defnguard(left >= right, :__more_than_equal_to__)
 
   @doc false
-  def __more_than_equal_to__(left, right) when is_boolean(left), do: __more_than_equal_to__(boolean_to_number(left), right)
-  def __more_than_equal_to__(left, right) when is_boolean(right), do: __more_than_equal_to__(left, boolean_to_number(right))
+  def __more_than_equal_to__(left, right) when is_boolean(left),
+    do: __more_than_equal_to__(boolean_to_number(left), right)
+
+  def __more_than_equal_to__(left, right) when is_boolean(right),
+    do: __more_than_equal_to__(left, boolean_to_number(right))
 
   def __more_than_equal_to__(left, right) when Kernel.and(is_number(left), is_number(right)),
     do: to_constant(Kernel.>=(left, right))

--- a/nx/lib/nx/defn/kernel.ex
+++ b/nx/lib/nx/defn/kernel.ex
@@ -566,11 +566,7 @@ defmodule Nx.Defn.Kernel do
 
   @doc false
   def __and__(left, right) when Kernel.or(is_boolean(left), is_boolean(right)) do
-    raise ArgumentError,
-          "boolean value passed to Nx.Defn.Kernel.and/2, " <>
-            "values passed to Nx.Defn.Kernel.and/2 must be " <>
-            "tensors or numbers, consider using 1 for true " <>
-            "and 0 for false as an alternative"
+    __and__(boolean_to_number(left), boolean_to_number(right))
   end
 
   def __and__(left, right) when Kernel.and(is_number(left), is_number(right)),
@@ -596,13 +592,8 @@ defmodule Nx.Defn.Kernel do
   defnguard(left or right, :__or__)
 
   @doc false
-  def __or__(left, right) when Kernel.or(is_boolean(left), is_boolean(right)) do
-    raise ArgumentError,
-          "boolean value passed to Nx.Defn.Kernel.or/2, " <>
-            "values passed to Nx.Defn.Kernel.or/2 must be " <>
-            "tensors or numbers, consider using 1 for true " <>
-            "and 0 for false as an alternative"
-  end
+  def __or__(left, right) when Kernel.or(is_boolean(left), is_boolean(right)),
+    do: __or__(boolean_to_number(left), boolean_to_number(right))
 
   def __or__(left, right) when Kernel.and(is_number(left), is_number(right)),
     do: logical_or(left, right)
@@ -625,14 +616,7 @@ defmodule Nx.Defn.Kernel do
   defnguard(not tensor, :__not__)
 
   @doc false
-  def __not__(tensor) when is_boolean(tensor) do
-    raise ArgumentError,
-          "boolean value passed to Nx.Defn.Kernel.not/1, " <>
-            "values passed to Nx.Defn.Kernel.not/1 must be " <>
-            "tensors or numbers, consider using 1 for true " <>
-            "and 0 for false as an alternative"
-  end
-
+  def __not__(value) when is_boolean(value), do: to_constant(Kernel.not(value))
   def __not__(tensor) when is_number(tensor), do: logical_not(tensor)
   def __not__(tensor), do: Nx.logical_not(tensor)
 
@@ -858,6 +842,10 @@ defmodule Nx.Defn.Kernel do
 
   defp to_constant(true), do: one()
   defp to_constant(false), do: zero()
+
+  defp boolean_to_number(true), do: 1
+  defp boolean_to_number(false), do: 0
+  defp boolean_to_number(value), do: value
 
   @doc """
   Ensures the first argument is a `keyword` with the given

--- a/nx/lib/nx/defn/kernel.ex
+++ b/nx/lib/nx/defn/kernel.ex
@@ -804,8 +804,11 @@ defmodule Nx.Defn.Kernel do
   defnguard(left > right, :__more_than__)
 
   @doc false
-  def __more_than__(left, right) when Kernel.or(is_boolean(left), is_boolean(right)),
-    do: __more_than__(boolean_to_number(left), boolean_to_number(right))
+  def __more_than__(left, right) when is_boolean(left),
+    do: __more_than__(boolean_to_number(left), right)
+
+  def __more_than__(left, right) when is_boolean(right),
+    do: __more_than__(left, boolean_to_number(right))
 
   def __more_than__(left, right) when Kernel.and(is_number(left), is_number(right)),
     do: to_constant(Kernel.>(left, right))

--- a/nx/lib/nx/defn/kernel.ex
+++ b/nx/lib/nx/defn/kernel.ex
@@ -565,10 +565,8 @@ defmodule Nx.Defn.Kernel do
   defnguard(left and right, :__and__)
 
   @doc false
-  def __and__(left, right) when Kernel.or(is_boolean(left), is_boolean(right)) do
-    __and__(boolean_to_number(left), boolean_to_number(right))
-  end
-
+  def __and__(left, right) when is_boolean(left), do: __and__(boolean_to_number(left), right)
+  def __and__(left, right) when is_boolean(right), do: __and__(left, boolean_to_number(right))
   def __and__(left, right) when Kernel.and(is_number(left), is_number(right)),
     do: logical_and(left, right)
 
@@ -592,9 +590,8 @@ defmodule Nx.Defn.Kernel do
   defnguard(left or right, :__or__)
 
   @doc false
-  def __or__(left, right) when Kernel.or(is_boolean(left), is_boolean(right)),
-    do: __or__(boolean_to_number(left), boolean_to_number(right))
-
+  def __or__(left, right) when is_boolean(left), do: __or__(boolean_to_number(left), right)
+  def __or__(left, right) when is_boolean(right), do: __or__(left, boolean_to_number(right))
   def __or__(left, right) when Kernel.and(is_number(left), is_number(right)),
     do: logical_or(left, right)
 
@@ -735,8 +732,8 @@ defmodule Nx.Defn.Kernel do
   defnguard(left == right, :__equal__)
 
   @doc false
-  def __equal__(left, right) when Kernel.or(is_boolean(left), is_boolean(right)),
-    do: __equal__(boolean_to_number(left), boolean_to_number(right))
+  def __equal__(left, right) when is_boolean(left), do: __equal__(boolean_to_number(left), right)
+  def __equal__(left, right) when is_boolean(right), do: __equal__(left, boolean_to_number(right))
 
   def __equal__(left, right) when Kernel.and(is_number(left), is_number(right)),
     do: to_constant(Kernel.==(left, right))
@@ -758,8 +755,8 @@ defmodule Nx.Defn.Kernel do
   defnguard(left != right, :__not_equal__)
 
   @doc false
-  def __not_equal__(left, right) when Kernel.or(is_boolean(left), is_boolean(right)),
-    do: __not_equal__(boolean_to_number(left), boolean_to_number(right))
+  def __not_equal__(left, right) when is_boolean(left), do: __not_equal__(boolean_to_number(left), right)
+  def __not_equal__(left, right) when is_boolean(right), do: __not_equal__(left, boolean_to_number(right))
 
   def __not_equal__(left, right) when Kernel.and(is_number(left), is_number(right)),
     do: to_constant(Kernel.!=(left, right))
@@ -781,8 +778,8 @@ defmodule Nx.Defn.Kernel do
   defnguard(left < right, :__less_than__)
 
   @doc false
-  def __less_than__(left, right) when Kernel.or(is_boolean(left), is_boolean(right)),
-    do: __less_than__(boolean_to_number(left), boolean_to_number(right))
+  def __less_than__(left, right) when is_boolean(left), do: __less_than__(boolean_to_number(left), right)
+  def __less_than__(left, right) when is_boolean(right), do: __less_than__(left, boolean_to_number(right))
 
   def __less_than__(left, right) when Kernel.and(is_number(left), is_number(right)),
     do: to_constant(Kernel.<(left, right))
@@ -830,8 +827,8 @@ defmodule Nx.Defn.Kernel do
   defnguard(left <= right, :__less_than_equal_to__)
 
   @doc false
-  def __less_than_equal_to__(left, right) when Kernel.or(is_boolean(left), is_boolean(right)),
-    do: __less_than_equal_to__(boolean_to_number(left), boolean_to_number(right))
+  def __less_than_equal_to__(left, right) when is_boolean(left), do: __less_than_equal_to__(boolean_to_number(left), right)
+  def __less_than_equal_to__(left, right) when is_boolean(right), do: __less_than_equal_to__(left, boolean_to_number(right))
 
   def __less_than_equal_to__(left, right) when Kernel.and(is_number(left), is_number(right)),
     do: to_constant(Kernel.<=(left, right))
@@ -853,8 +850,8 @@ defmodule Nx.Defn.Kernel do
   defnguard(left >= right, :__more_than_equal_to__)
 
   @doc false
-  def __more_than_equal_to__(left, right) when Kernel.or(is_boolean(left), is_boolean(right)),
-    do: __more_than_equal_to__(boolean_to_number(left), boolean_to_number(right))
+  def __more_than_equal_to__(left, right) when is_boolean(left), do: __more_than_equal_to__(boolean_to_number(left), right)
+  def __more_than_equal_to__(left, right) when is_boolean(right), do: __more_than_equal_to__(left, boolean_to_number(right))
 
   def __more_than_equal_to__(left, right) when Kernel.and(is_number(left), is_number(right)),
     do: to_constant(Kernel.>=(left, right))

--- a/nx/lib/nx/defn/kernel.ex
+++ b/nx/lib/nx/defn/kernel.ex
@@ -735,6 +735,9 @@ defmodule Nx.Defn.Kernel do
   defnguard(left == right, :__equal__)
 
   @doc false
+  def __equal__(left, right) when Kernel.or(is_boolean(left), is_boolean(right)),
+    do: __equal__(boolean_to_number(left), boolean_to_number(right))
+
   def __equal__(left, right) when Kernel.and(is_number(left), is_number(right)),
     do: to_constant(Kernel.==(left, right))
 
@@ -755,6 +758,9 @@ defmodule Nx.Defn.Kernel do
   defnguard(left != right, :__not_equal__)
 
   @doc false
+  def __not_equal__(left, right) when Kernel.or(is_boolean(left), is_boolean(right)),
+    do: __not_equal__(boolean_to_number(left), boolean_to_number(right))
+
   def __not_equal__(left, right) when Kernel.and(is_number(left), is_number(right)),
     do: to_constant(Kernel.!=(left, right))
 
@@ -775,6 +781,9 @@ defmodule Nx.Defn.Kernel do
   defnguard(left < right, :__less_than__)
 
   @doc false
+  def __less_than__(left, right) when Kernel.or(is_boolean(left), is_boolean(right)),
+    do: __less_than__(boolean_to_number(left), boolean_to_number(right))
+
   def __less_than__(left, right) when Kernel.and(is_number(left), is_number(right)),
     do: to_constant(Kernel.<(left, right))
 
@@ -795,6 +804,9 @@ defmodule Nx.Defn.Kernel do
   defnguard(left > right, :__more_than__)
 
   @doc false
+  def __more_than__(left, right) when Kernel.or(is_boolean(left), is_boolean(right)),
+    do: __more_than__(boolean_to_number(left), boolean_to_number(right))
+
   def __more_than__(left, right) when Kernel.and(is_number(left), is_number(right)),
     do: to_constant(Kernel.>(left, right))
 
@@ -815,6 +827,9 @@ defmodule Nx.Defn.Kernel do
   defnguard(left <= right, :__less_than_equal_to__)
 
   @doc false
+  def __less_than_equal_to__(left, right) when Kernel.or(is_boolean(left), is_boolean(right)),
+    do: __less_than_equal_to__(boolean_to_number(left), boolean_to_number(right))
+
   def __less_than_equal_to__(left, right) when Kernel.and(is_number(left), is_number(right)),
     do: to_constant(Kernel.<=(left, right))
 
@@ -835,6 +850,9 @@ defmodule Nx.Defn.Kernel do
   defnguard(left >= right, :__more_than_equal_to__)
 
   @doc false
+  def __more_than_equal_to__(left, right) when Kernel.or(is_boolean(left), is_boolean(right)),
+    do: __more_than_equal_to__(boolean_to_number(left), boolean_to_number(right))
+
   def __more_than_equal_to__(left, right) when Kernel.and(is_number(left), is_number(right)),
     do: to_constant(Kernel.>=(left, right))
 

--- a/nx/lib/nx/shared.ex
+++ b/nx/lib/nx/shared.ex
@@ -377,9 +377,9 @@ defmodule Nx.Shared do
   @doc """
   Builds the type of an element-wise binary operation.
   """
-  def binary_type(a, b) when is_number(a) and is_number(b), do: Nx.Type.infer(a + b)
-  def binary_type(a, b) when is_number(a), do: Nx.Type.merge_number(type(b), a)
-  def binary_type(a, b) when is_number(b), do: Nx.Type.merge_number(type(a), b)
+  def binary_type(a, b) when (is_number(a) or is_boolean(a)) and (is_number(b) or is_boolean(b)), do: Nx.Type.infer(a + b)
+  def binary_type(a, b) when is_number(a) or is_boolean(a), do: Nx.Type.merge_number(type(b), a)
+  def binary_type(a, b) when is_number(b) or is_boolean(b), do: Nx.Type.merge_number(type(a), b)
   def binary_type(a, b), do: Nx.Type.merge(type(a), type(b))
 
   # For unknown types, return {:f, 32} as the caller
@@ -387,6 +387,7 @@ defmodule Nx.Shared do
   defp type(%T{type: type}), do: type
   defp type({_, _} = type), do: type
   defp type(%Complex{}), do: {:c, 64}
+  defp type(bool) when is_boolean(bool), do: {:u, 8}
   defp type(_other), do: {:f, 32}
 
   ## Helpers

--- a/nx/lib/nx/shared.ex
+++ b/nx/lib/nx/shared.ex
@@ -377,11 +377,11 @@ defmodule Nx.Shared do
   @doc """
   Builds the type of an element-wise binary operation.
   """
-  def binary_type(a, b) when (is_number(a) or is_boolean(a)) and (is_number(b) or is_boolean(b)),
+  def binary_type(a, b) when is_number(a) and is_number(b),
     do: Nx.Type.infer(a + b)
 
-  def binary_type(a, b) when is_number(a) or is_boolean(a), do: Nx.Type.merge_number(type(b), a)
-  def binary_type(a, b) when is_number(b) or is_boolean(b), do: Nx.Type.merge_number(type(a), b)
+  def binary_type(a, b) when is_number(a), do: Nx.Type.merge_number(type(b), a)
+  def binary_type(a, b) when is_number(b), do: Nx.Type.merge_number(type(a), b)
   def binary_type(a, b), do: Nx.Type.merge(type(a), type(b))
 
   # For unknown types, return {:f, 32} as the caller
@@ -389,7 +389,6 @@ defmodule Nx.Shared do
   defp type(%T{type: type}), do: type
   defp type({_, _} = type), do: type
   defp type(%Complex{}), do: {:c, 64}
-  defp type(bool) when is_boolean(bool), do: {:u, 8}
   defp type(_other), do: {:f, 32}
 
   ## Helpers

--- a/nx/lib/nx/shared.ex
+++ b/nx/lib/nx/shared.ex
@@ -377,7 +377,9 @@ defmodule Nx.Shared do
   @doc """
   Builds the type of an element-wise binary operation.
   """
-  def binary_type(a, b) when (is_number(a) or is_boolean(a)) and (is_number(b) or is_boolean(b)), do: Nx.Type.infer(a + b)
+  def binary_type(a, b) when (is_number(a) or is_boolean(a)) and (is_number(b) or is_boolean(b)),
+    do: Nx.Type.infer(a + b)
+
   def binary_type(a, b) when is_number(a) or is_boolean(a), do: Nx.Type.merge_number(type(b), a)
   def binary_type(a, b) when is_number(b) or is_boolean(b), do: Nx.Type.merge_number(type(a), b)
   def binary_type(a, b), do: Nx.Type.merge(type(a), type(b))

--- a/nx/lib/nx/type.ex
+++ b/nx/lib/nx/type.ex
@@ -130,6 +130,7 @@ defmodule Nx.Type do
   """
   def infer(value) when is_integer(value), do: {:s, 64}
   def infer(value) when is_float(value), do: {:f, 32}
+  def infer(value) when is_boolean(value), do: {:u, 8}
   def infer(%Complex{}), do: {:c, 64}
   def infer(value) when value in [:neg_infinity, :infinity, :nan], do: {:f, 32}
 
@@ -493,6 +494,10 @@ defmodule Nx.Type do
 
   def merge_number(_, number) when is_number(number) do
     {:f, 32}
+  end
+
+  def merge_number(type, bool) when is_boolean(bool) do
+    merge(type, {:u, 8})
   end
 
   @doc """

--- a/nx/lib/nx/type.ex
+++ b/nx/lib/nx/type.ex
@@ -496,10 +496,6 @@ defmodule Nx.Type do
     {:f, 32}
   end
 
-  def merge_number(type, bool) when is_boolean(bool) do
-    merge(type, {:u, 8})
-  end
-
   @doc """
   Returns true if the type is an integer in Elixir.
 

--- a/nx/test/nx/defn_test.exs
+++ b/nx/test/nx/defn_test.exs
@@ -555,22 +555,6 @@ defmodule Nx.DefnTest do
     end
   end
 
-  describe "boolean constants" do
-    @tag compiler: Evaluator
-    test "upcast to numbers in tensor operations" do
-      # note: this is not extensive, it's just to ensure that
-      # both defn and the underlying functions cast properly
-      for fun <- [&add_two/2, &Nx.add/2], {sign, _} = type <- [s: 8, u: 8] do
-        width = if sign == :s, do: 16, else: 8
-
-        assert Nx.tensor(2, type: {sign, width}) == fun.(true, Nx.tensor(1, type: type))
-        assert Nx.tensor(1, type: {sign, width}) == fun.(false, Nx.tensor(1, type: type))
-        assert Nx.tensor(2, type: {sign, width}) == fun.(Nx.tensor(1, type: type), true)
-        assert Nx.tensor(1, type: {sign, width}) == fun.(Nx.tensor(1, type: type), false)
-      end
-    end
-  end
-
   describe "operators" do
     defn add_two(a, b), do: a + b
 
@@ -611,16 +595,27 @@ defmodule Nx.DefnTest do
       assert Nx.tensor(1, type: {:u, 8}) == land_true(2)
       assert Nx.tensor(0, type: {:u, 8}) == land_true(0)
 
-      assert Nx.tensor(1, type: {:u, 8}) == land_two(true, true)
-      assert Nx.tensor(0, type: {:u, 8}) == land_two(true, false)
-      assert Nx.tensor(0, type: {:u, 8}) == land_two(false, true)
-      assert Nx.tensor(0, type: {:u, 8}) == land_two(false, false)
+      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
+        land_two(true, true)
+      end
+
+      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
+        land_two(true, false)
+      end
+
+      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
+        land_two(false, true)
+      end
+
+      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
+        land_two(false, false)
+      end
     end
 
     defn lor_two(a, b), do: a or b
 
-    defn lor_true(a) do
-      true or a
+    defn lor_true(opts \\ []) do
+      true or opts[:value]
     end
 
     test "or" do
@@ -628,13 +623,25 @@ defmodule Nx.DefnTest do
     end
 
     @tag compiler: Evaluator
-    test "or works with boolean" do
-      assert Nx.tensor(1, type: {:u, 8}) == lor_true(false)
-      assert Nx.tensor(1, type: {:u, 8}) == lor_true(true)
-      assert Nx.tensor(1, type: {:u, 8}) == lor_two(true, false)
-      assert Nx.tensor(1, type: {:u, 8}) == lor_two(false, true)
-      assert Nx.tensor(1, type: {:u, 8}) == lor_two(true, true)
-      assert Nx.tensor(0, type: {:u, 8}) == lor_two(false, false)
+    test "or (boolean)" do
+      assert Nx.tensor(1, type: {:u, 8}) == lor_true(value: false)
+      assert Nx.tensor(1, type: {:u, 8}) == lor_true(value: true)
+
+      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
+        lor_two(true, false)
+      end
+
+      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
+        lor_two(false, true)
+      end
+
+      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
+        lor_two(true, true)
+      end
+
+      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
+        lor_two(false, false)
+      end
     end
 
     defn lnot(a), do: not a
@@ -655,8 +662,14 @@ defmodule Nx.DefnTest do
 
     @tag compiler: Evaluator
     test "not works with boolean" do
-      assert Nx.tensor(0, type: {:u, 8}) == lnot(true)
-      assert Nx.tensor(1, type: {:u, 8}) == lnot(false)
+      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
+        lnot(true)
+      end
+
+      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
+        lnot(false)
+      end
+
       assert Nx.tensor(1, type: {:u, 8}) == lnot_boolean(value: false)
       assert Nx.tensor(0, type: {:u, 8}) == lnot_boolean(value: true)
     end
@@ -712,11 +725,22 @@ defmodule Nx.DefnTest do
     end
 
     @tag compiler: Evaluator
-    test "== works with boolean" do
-      assert Nx.tensor(1, type: {:u, 8}) == equality(true, true)
-      assert Nx.tensor(1, type: {:u, 8}) == equality(false, false)
-      assert Nx.tensor(0, type: {:u, 8}) == equality(false, true)
-      assert Nx.tensor(0, type: {:u, 8}) == equality(true, false)
+    test "== (boolean)" do
+      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
+        equality(true, true)
+      end
+
+      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
+        equality(false, false)
+      end
+
+      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
+        equality(false, true)
+      end
+
+      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
+        equality(true, false)
+      end
     end
 
     defn inequality(a, b), do: a != b
@@ -726,11 +750,22 @@ defmodule Nx.DefnTest do
     end
 
     @tag compiler: Evaluator
-    test "!= works with boolean" do
-      assert Nx.tensor(0, type: {:u, 8}) == inequality(true, true)
-      assert Nx.tensor(0, type: {:u, 8}) == inequality(false, false)
-      assert Nx.tensor(1, type: {:u, 8}) == inequality(false, true)
-      assert Nx.tensor(1, type: {:u, 8}) == inequality(true, false)
+    test "!= (boolean)" do
+      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
+        inequality(true, true)
+      end
+
+      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
+        inequality(false, false)
+      end
+
+      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
+        inequality(false, true)
+      end
+
+      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
+        inequality(true, false)
+      end
     end
 
     defn less_than(a, b), do: a < b
@@ -741,10 +776,21 @@ defmodule Nx.DefnTest do
 
     @tag compiler: Evaluator
     test "< (boolean)" do
-      assert Nx.tensor(1, type: {:u, 8}) == less_than(false, true)
-      assert Nx.tensor(0, type: {:u, 8}) == less_than(true, false)
-      assert Nx.tensor(0, type: {:u, 8}) == less_than(true, true)
-      assert Nx.tensor(0, type: {:u, 8}) == less_than(false, false)
+      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
+        less_than(false, true)
+      end
+
+      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
+        less_than(true, false)
+      end
+
+      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
+        less_than(true, true)
+      end
+
+      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
+        less_than(false, false)
+      end
     end
 
     defn greater_than(a, b), do: a > b
@@ -755,10 +801,21 @@ defmodule Nx.DefnTest do
 
     @tag compiler: Evaluator
     test "> (boolean)" do
-      assert Nx.tensor(1, type: {:u, 8}) == greater_than(true, false)
-      assert Nx.tensor(0, type: {:u, 8}) == greater_than(false, true)
-      assert Nx.tensor(0, type: {:u, 8}) == greater_than(true, true)
-      assert Nx.tensor(0, type: {:u, 8}) == greater_than(false, false)
+      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
+        greater_than(true, false)
+      end
+
+      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
+        greater_than(false, true)
+      end
+
+      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
+        greater_than(true, true)
+      end
+
+      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
+        greater_than(false, false)
+      end
     end
 
     defn less_than_or_equal(a, b), do: a <= b
@@ -769,10 +826,21 @@ defmodule Nx.DefnTest do
 
     @tag compiler: Evaluator
     test "<= (boolean)" do
-      assert Nx.tensor(1, type: {:u, 8}) == less_than_or_equal(false, true)
-      assert Nx.tensor(0, type: {:u, 8}) == less_than_or_equal(true, false)
-      assert Nx.tensor(1, type: {:u, 8}) == less_than_or_equal(true, true)
-      assert Nx.tensor(1, type: {:u, 8}) == less_than_or_equal(false, false)
+      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
+        less_than_or_equal(false, true)
+      end
+
+      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
+        less_than_or_equal(true, false)
+      end
+
+      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
+        less_than_or_equal(true, true)
+      end
+
+      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
+        less_than_or_equal(false, false)
+      end
     end
 
     defn greater_than_or_equal(a, b), do: a >= b
@@ -783,10 +851,21 @@ defmodule Nx.DefnTest do
 
     @tag compiler: Evaluator
     test ">= (boolean)" do
-      assert Nx.tensor(0, type: {:u, 8}) == greater_than_or_equal(false, true)
-      assert Nx.tensor(1, type: {:u, 8}) == greater_than_or_equal(true, false)
-      assert Nx.tensor(1, type: {:u, 8}) == greater_than_or_equal(true, true)
-      assert Nx.tensor(1, type: {:u, 8}) == greater_than_or_equal(false, false)
+      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
+        Nx.tensor(0, type: {:u, 8}) == greater_than_or_equal(false, true)
+      end
+
+      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
+        Nx.tensor(1, type: {:u, 8}) == greater_than_or_equal(true, false)
+      end
+
+      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
+        Nx.tensor(1, type: {:u, 8}) == greater_than_or_equal(true, true)
+      end
+
+      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
+        Nx.tensor(1, type: {:u, 8}) == greater_than_or_equal(false, false)
+      end
     end
   end
 

--- a/nx/test/nx/defn_test.exs
+++ b/nx/test/nx/defn_test.exs
@@ -590,28 +590,6 @@ defmodule Nx.DefnTest do
       assert %T{data: %Expr{op: :logical_and, args: [_, _]}} = land_two(1, 2)
     end
 
-    @tag compiler: Evaluator
-    test "and (boolean)" do
-      assert Nx.tensor(1, type: {:u, 8}) == land_true(2)
-      assert Nx.tensor(0, type: {:u, 8}) == land_true(0)
-
-      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
-        land_two(true, true)
-      end
-
-      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
-        land_two(true, false)
-      end
-
-      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
-        land_two(false, true)
-      end
-
-      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
-        land_two(false, false)
-      end
-    end
-
     defn lor_two(a, b), do: a or b
 
     defn lor_true(opts \\ []) do
@@ -620,28 +598,6 @@ defmodule Nx.DefnTest do
 
     test "or" do
       assert %T{data: %Expr{op: :logical_or, args: [_, _]}} = lor_two(1, 2)
-    end
-
-    @tag compiler: Evaluator
-    test "or (boolean)" do
-      assert Nx.tensor(1, type: {:u, 8}) == lor_true(value: false)
-      assert Nx.tensor(1, type: {:u, 8}) == lor_true(value: true)
-
-      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
-        lor_two(true, false)
-      end
-
-      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
-        lor_two(false, true)
-      end
-
-      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
-        lor_two(true, true)
-      end
-
-      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
-        lor_two(false, false)
-      end
     end
 
     defn lnot(a), do: not a
@@ -653,25 +609,6 @@ defmodule Nx.DefnTest do
       else
         false
       end
-    end
-
-    test "not" do
-      assert %T{data: %Expr{op: :optional, args: [%T{data: %Expr{op: :logical_not}}, _]}} =
-               lnot(1)
-    end
-
-    @tag compiler: Evaluator
-    test "not works with boolean" do
-      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
-        lnot(true)
-      end
-
-      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
-        lnot(false)
-      end
-
-      assert Nx.tensor(1, type: {:u, 8}) == lnot_boolean(value: false)
-      assert Nx.tensor(0, type: {:u, 8}) == lnot_boolean(value: true)
     end
 
     defn band_two(a, b), do: a &&& b
@@ -724,48 +661,10 @@ defmodule Nx.DefnTest do
       assert %T{data: %Expr{op: :equal, args: [_, _]}} = equality(1, 2)
     end
 
-    @tag compiler: Evaluator
-    test "== (boolean)" do
-      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
-        equality(true, true)
-      end
-
-      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
-        equality(false, false)
-      end
-
-      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
-        equality(false, true)
-      end
-
-      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
-        equality(true, false)
-      end
-    end
-
     defn inequality(a, b), do: a != b
 
     test "!=" do
       assert %T{data: %Expr{op: :not_equal, args: [_, _]}} = inequality(1, 2)
-    end
-
-    @tag compiler: Evaluator
-    test "!= (boolean)" do
-      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
-        inequality(true, true)
-      end
-
-      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
-        inequality(false, false)
-      end
-
-      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
-        inequality(false, true)
-      end
-
-      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
-        inequality(true, false)
-      end
     end
 
     defn less_than(a, b), do: a < b
@@ -774,48 +673,10 @@ defmodule Nx.DefnTest do
       assert %T{data: %Expr{op: :less, args: [_, _]}} = less_than(1, 2)
     end
 
-    @tag compiler: Evaluator
-    test "< (boolean)" do
-      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
-        less_than(false, true)
-      end
-
-      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
-        less_than(true, false)
-      end
-
-      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
-        less_than(true, true)
-      end
-
-      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
-        less_than(false, false)
-      end
-    end
-
     defn greater_than(a, b), do: a > b
 
     test ">" do
       assert %T{data: %Expr{op: :greater, args: [_, _]}} = greater_than(1, 2)
-    end
-
-    @tag compiler: Evaluator
-    test "> (boolean)" do
-      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
-        greater_than(true, false)
-      end
-
-      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
-        greater_than(false, true)
-      end
-
-      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
-        greater_than(true, true)
-      end
-
-      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
-        greater_than(false, false)
-      end
     end
 
     defn less_than_or_equal(a, b), do: a <= b
@@ -824,48 +685,10 @@ defmodule Nx.DefnTest do
       assert %T{data: %Expr{op: :less_equal, args: [_, _]}} = less_than_or_equal(1, 2)
     end
 
-    @tag compiler: Evaluator
-    test "<= (boolean)" do
-      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
-        less_than_or_equal(false, true)
-      end
-
-      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
-        less_than_or_equal(true, false)
-      end
-
-      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
-        less_than_or_equal(true, true)
-      end
-
-      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
-        less_than_or_equal(false, false)
-      end
-    end
-
     defn greater_than_or_equal(a, b), do: a >= b
 
     test ">=" do
       assert %T{data: %Expr{op: :greater_equal, args: [_, _]}} = greater_than_or_equal(1, 2)
-    end
-
-    @tag compiler: Evaluator
-    test ">= (boolean)" do
-      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
-        Nx.tensor(0, type: {:u, 8}) == greater_than_or_equal(false, true)
-      end
-
-      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
-        Nx.tensor(1, type: {:u, 8}) == greater_than_or_equal(true, false)
-      end
-
-      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
-        Nx.tensor(1, type: {:u, 8}) == greater_than_or_equal(true, true)
-      end
-
-      assert_raise ArgumentError, "booleans are not supported as defn inputs", fn ->
-        Nx.tensor(1, type: {:u, 8}) == greater_than_or_equal(false, false)
-      end
     end
   end
 

--- a/nx/test/nx/defn_test.exs
+++ b/nx/test/nx/defn_test.exs
@@ -594,6 +594,11 @@ defmodule Nx.DefnTest do
     test "and works with boolean" do
       assert Nx.tensor(1, type: {:u, 8}) == land_true(2)
       assert Nx.tensor(0, type: {:u, 8}) == land_true(0)
+
+      assert Nx.tensor(1, type: {:u, 8}) == land_two(true, true)
+      assert Nx.tensor(0, type: {:u, 8}) == land_two(true, false)
+      assert Nx.tensor(0, type: {:u, 8}) == land_two(false, true)
+      assert Nx.tensor(0, type: {:u, 8}) == land_two(false, false)
     end
 
     defn lor_two(a, b), do: a or b
@@ -634,6 +639,8 @@ defmodule Nx.DefnTest do
 
     @tag compiler: Evaluator
     test "not works with boolean" do
+      assert Nx.tensor(0, type: {:u, 8}) == lnot(true)
+      assert Nx.tensor(1, type: {:u, 8}) == lnot(false)
       assert Nx.tensor(1, type: {:u, 8}) == lnot_boolean(value: false)
       assert Nx.tensor(0, type: {:u, 8}) == lnot_boolean(value: true)
     end
@@ -688,10 +695,27 @@ defmodule Nx.DefnTest do
       assert %T{data: %Expr{op: :equal, args: [_, _]}} = equality(1, 2)
     end
 
+    @tag compiler: Evaluator
+    test "== works with boolean" do
+      assert Nx.tensor(1, type: {:u, 8}) == equality(true, true)
+      assert Nx.tensor(1, type: {:u, 8}) == equality(false, false)
+      assert Nx.tensor(0, type: {:u, 8}) == equality(false, true)
+      assert Nx.tensor(0, type: {:u, 8}) == equality(true, false)
+    end
+
     defn inequality(a, b), do: a != b
 
     test "!=" do
       assert %T{data: %Expr{op: :not_equal, args: [_, _]}} = inequality(1, 2)
+    end
+
+
+    @tag compiler: Evaluator
+    test "!= works with boolean" do
+      assert Nx.tensor(0, type: {:u, 8}) == inequality(true, true)
+      assert Nx.tensor(0, type: {:u, 8}) == inequality(false, false)
+      assert Nx.tensor(1, type: {:u, 8}) == inequality(false, true)
+      assert Nx.tensor(1, type: {:u, 8}) == inequality(true, false)
     end
 
     defn less_than(a, b), do: a < b
@@ -700,10 +724,26 @@ defmodule Nx.DefnTest do
       assert %T{data: %Expr{op: :less, args: [_, _]}} = less_than(1, 2)
     end
 
+    @tag compiler: Evaluator
+    test "< (boolean)" do
+      assert Nx.tensor(1, type: {:u, 8}) == less_than(false, true)
+      assert Nx.tensor(0, type: {:u, 8}) == less_than(true, false)
+      assert Nx.tensor(0, type: {:u, 8}) == less_than(true, true)
+      assert Nx.tensor(0, type: {:u, 8}) == less_than(false, false)
+    end
+
     defn greater_than(a, b), do: a > b
 
     test ">" do
       assert %T{data: %Expr{op: :greater, args: [_, _]}} = greater_than(1, 2)
+    end
+
+    @tag compiler: Evaluator
+    test "> (boolean)" do
+      assert Nx.tensor(1, type: {:u, 8}) == greater_than(true, false)
+      assert Nx.tensor(0, type: {:u, 8}) == greater_than(false, true)
+      assert Nx.tensor(0, type: {:u, 8}) == greater_than(true, true)
+      assert Nx.tensor(0, type: {:u, 8}) == greater_than(false, false)
     end
 
     defn less_than_or_equal(a, b), do: a <= b
@@ -712,10 +752,26 @@ defmodule Nx.DefnTest do
       assert %T{data: %Expr{op: :less_equal, args: [_, _]}} = less_than_or_equal(1, 2)
     end
 
+    @tag compiler: Evaluator
+    test "<= (boolean)" do
+      assert Nx.tensor(1, type: {:u, 8}) == less_than_or_equal(false, true)
+      assert Nx.tensor(0, type: {:u, 8}) == less_than_or_equal(true, false)
+      assert Nx.tensor(1, type: {:u, 8}) == less_than_or_equal(true, true)
+      assert Nx.tensor(1, type: {:u, 8}) == less_than_or_equal(false, false)
+    end
+
     defn greater_than_or_equal(a, b), do: a >= b
 
     test ">=" do
       assert %T{data: %Expr{op: :greater_equal, args: [_, _]}} = greater_than_or_equal(1, 2)
+    end
+
+    @tag compiler: Evaluator
+    test ">= (boolean)" do
+      assert Nx.tensor(0, type: {:u, 8}) == greater_than_or_equal(false, true)
+      assert Nx.tensor(1, type: {:u, 8}) == greater_than_or_equal(true, false)
+      assert Nx.tensor(1, type: {:u, 8}) == greater_than_or_equal(true, true)
+      assert Nx.tensor(1, type: {:u, 8}) == greater_than_or_equal(false, false)
     end
   end
 

--- a/nx/test/nx/defn_test.exs
+++ b/nx/test/nx/defn_test.exs
@@ -1892,4 +1892,28 @@ defmodule Nx.DefnTest do
       assert Nx.tensor(20) == multi_clause_transform_bodiless4(a: 20, b: 10)
     end
   end
+
+  describe "boolean values" do
+    defn supports_booleans(opts \\ []) do
+      l = opts[:l]
+      r = opts[:r]
+
+      Nx.stack([l < r, l <= r, l > r, l >= r, l == r, l != r, l and r, l or r, not l, not r])
+    end
+
+    @tag compiler: Evaluator
+    test "supports booleans in some operations" do
+      for l <- [true, false, 1, 0], r <- [true, false, 1, 0] do
+        lb = l == 1 or l == true
+        rb = r == 1 or r == true
+
+        ln = if lb, do: 1, else: 0
+        rn = if rb, do: 1, else: 0
+
+        expected_list = [ln < rn, ln <= rn, ln > rn, ln >= rn, ln == rn, ln != rn, lb and rb, lb or rb, not lb, not rb]
+
+        assert Nx.tensor(expected_list) == supports_booleans(l: l, r: r)
+      end
+    end
+  end
 end

--- a/nx/test/nx/defn_test.exs
+++ b/nx/test/nx/defn_test.exs
@@ -1910,20 +1910,19 @@ defmodule Nx.DefnTest do
         ln = if lb, do: 1, else: 0
         rn = if rb, do: 1, else: 0
 
-        expected_list = [
-          ln < rn,
-          ln <= rn,
-          ln > rn,
-          ln >= rn,
-          ln == rn,
-          ln != rn,
-          lb and rb,
-          lb or rb,
-          not lb,
-          not rb
-        ]
-
-        assert Nx.tensor(expected_list) == supports_booleans(l: l, r: r)
+        assert supports_booleans(l: l, r: r) ==
+                 Nx.tensor([
+                   ln < rn,
+                   ln <= rn,
+                   ln > rn,
+                   ln >= rn,
+                   ln == rn,
+                   ln != rn,
+                   lb and rb,
+                   lb or rb,
+                   not lb,
+                   not rb
+                 ])
       end
     end
   end

--- a/nx/test/nx/defn_test.exs
+++ b/nx/test/nx/defn_test.exs
@@ -1910,7 +1910,18 @@ defmodule Nx.DefnTest do
         ln = if lb, do: 1, else: 0
         rn = if rb, do: 1, else: 0
 
-        expected_list = [ln < rn, ln <= rn, ln > rn, ln >= rn, ln == rn, ln != rn, lb and rb, lb or rb, not lb, not rb]
+        expected_list = [
+          ln < rn,
+          ln <= rn,
+          ln > rn,
+          ln >= rn,
+          ln == rn,
+          ln != rn,
+          lb and rb,
+          lb or rb,
+          not lb,
+          not rb
+        ]
 
         assert Nx.tensor(expected_list) == supports_booleans(l: l, r: r)
       end

--- a/nx/test/nx/defn_test.exs
+++ b/nx/test/nx/defn_test.exs
@@ -555,6 +555,22 @@ defmodule Nx.DefnTest do
     end
   end
 
+  describe "boolean constants" do
+    @tag compiler: Evaluator
+    test "upcast to numbers in tensor operations" do
+      # note: this is not extensive, it's just to ensure that
+      # both defn and the underlying functions cast properly
+      for fun <- [&add_two/2, &Nx.add/2], {sign, _} = type <- [s: 8, u: 8] do
+        width = if sign == :s, do: 16, else: 8
+
+        assert Nx.tensor(2, type: {sign, width}) == fun.(true, Nx.tensor(1, type: type))
+        assert Nx.tensor(1, type: {sign, width}) == fun.(false, Nx.tensor(1, type: type))
+        assert Nx.tensor(2, type: {sign, width}) == fun.(Nx.tensor(1, type: type), true)
+        assert Nx.tensor(1, type: {sign, width}) == fun.(Nx.tensor(1, type: type), false)
+      end
+    end
+  end
+
   describe "operators" do
     defn add_two(a, b), do: a + b
 
@@ -591,7 +607,7 @@ defmodule Nx.DefnTest do
     end
 
     @tag compiler: Evaluator
-    test "and works with boolean" do
+    test "and (boolean)" do
       assert Nx.tensor(1, type: {:u, 8}) == land_true(2)
       assert Nx.tensor(0, type: {:u, 8}) == land_true(0)
 
@@ -708,7 +724,6 @@ defmodule Nx.DefnTest do
     test "!=" do
       assert %T{data: %Expr{op: :not_equal, args: [_, _]}} = inequality(1, 2)
     end
-
 
     @tag compiler: Evaluator
     test "!= works with boolean" do

--- a/torchx/.formatter.exs
+++ b/torchx/.formatter.exs
@@ -1,5 +1,6 @@
 # Used by "mix format"
 [
-  locals_without_parens: [deftensor: 1, defdevice: 1, defvalue: 1, defn: 2, defnp: 2],
+  import_deps: [:nx],
+  locals_without_parens: [deftensor: 1, defdevice: 1, defvalue: 1],
   inputs: ["{mix,.formatter}.exs", "{bench,examples,config,lib,test}/**/*.{ex,exs}"]
 ]


### PR DESCRIPTION
This PR adds support for booleans as tensor inputs (true -> 1, false -> 0),
which means that:

- We now support literal true and false being used as explicit tensor constants (i.e. `Nx.tensor(true)`)
~- Booleans are now valid inputs for defn and for Nx functions~
- logical and comparison expressions also work accordingly with booleans