### PR TITLE
feat(torchx): bitcast

### DIFF
--- a/torchx/lib/torchx/backend.ex
+++ b/torchx/lib/torchx/backend.ex
@@ -1428,6 +1428,20 @@ defmodule Torchx.Backend do
     Enum.reduce(padding, [], fn {a, b}, acc -> [a, b | acc] end)
   end
 
+
+  @impl true
+  def bitcast(out, %T{data: %TB{ref: {device, _}}} = tensor) do
+    blob = Torchx.to_blob(from_nx(tensor))
+
+    Torchx.from_blob(
+      blob,
+      out.shape,
+      to_torch_type(out.type),
+      device_option(device: device)
+    )
+    |> to_nx(out)
+  end
+
   @impl true
   def inspect(%T{} = tensor, inspect_opts) do
     limit = if inspect_opts.limit == :infinity, do: :infinity, else: inspect_opts.limit + 1
@@ -1555,7 +1569,7 @@ defmodule Torchx.Backend do
   ## Functionality we can't provide
 
   not_possible =
-    [bitcast: 2, count_leading_zeros: 2, population_count: 2] ++
+    [count_leading_zeros: 2, population_count: 2] ++
       [map: 4, reduce: 5, window_reduce: 6]
 
   for {fun, arity} <- not_possible do

--- a/torchx/lib/torchx/backend.ex
+++ b/torchx/lib/torchx/backend.ex
@@ -1428,17 +1428,12 @@ defmodule Torchx.Backend do
     Enum.reduce(padding, [], fn {a, b}, acc -> [a, b | acc] end)
   end
 
-
   @impl true
   def bitcast(out, %T{data: %TB{ref: {device, _}}} = tensor) do
-    blob = Torchx.to_blob(from_nx(tensor))
-
-    Torchx.from_blob(
-      blob,
-      out.shape,
-      to_torch_type(out.type),
-      device_option(device: device)
-    )
+    tensor
+    |> from_nx()
+    |> Torchx.to_blob()
+    |> Torchx.from_blob(out.shape, to_torch_type(out.type), device_option(device: device))
     |> to_nx(out)
   end
 

--- a/torchx/test/torchx/nx_doctest_test.exs
+++ b/torchx/test/torchx/nx_doctest_test.exs
@@ -53,6 +53,7 @@ defmodule Torchx.NxDoctestTest do
   @inherently_unsupported_doctests [
     # as_type - the rules change per type
     as_type: 2,
+    # no API available - bit based
     count_leading_zeros: 1,
     population_count: 1,
     # no API available - function based

--- a/torchx/test/torchx/nx_doctest_test.exs
+++ b/torchx/test/torchx/nx_doctest_test.exs
@@ -53,8 +53,6 @@ defmodule Torchx.NxDoctestTest do
   @inherently_unsupported_doctests [
     # as_type - the rules change per type
     as_type: 2,
-    # no API available - bit based
-    bitcast: 2,
     count_leading_zeros: 1,
     population_count: 1,
     # no API available - function based


### PR DESCRIPTION
Taking inspiration from the Pytorch JIT implementation for bitcast, this PR enables bitcast by copying the raw blob into the "wrong" output type.
 https://github.com/pytorch/pytorch/blob/0f6b524665378b18b8682f473267c80c6d5ca3df/torch/csrc/jit/tensorexpr/cpp_intrinsics.h#L27

closes #848 