### PR TITLE
Add quotient test for Torchx. Remove argmax and argmin from exclusion list.

### DIFF
--- a/torchx/test/torchx/nx_doctest_test.exs
+++ b/torchx/test/torchx/nx_doctest_test.exs
@@ -21,11 +21,7 @@ defmodule Torchx.NxDoctestTest do
     # mean - Torchx does not support unsigned 64 bit integer
     mean: 2,
     # quotient - Torchx does not support unsigned 32 bit integer
-    quotient: 2,
-    # argmax - Torchx does not support complex numbers as parameters
-    argmax: 2,
-    # argmin - Torchx does not support complex numbers as parameters
-    argmin: 2
+    quotient: 2
   ]
 
   @rounding_error_doctests [

--- a/torchx/test/torchx/nx_test.exs
+++ b/torchx/test/torchx/nx_test.exs
@@ -479,6 +479,29 @@ defmodule Torchx.NxTest do
       )
     end
 
+    test "quotient when dividing scalars" do
+      out = Nx.quotient(11, 2)
+
+      assert_equal(out, Nx.tensor(5))
+    end
+
+    test "quotient when dividing tensors and scalars" do
+      t1 = Nx.tensor([2, 4, 5])
+
+      out = Nx.quotient(t1, 2)
+
+      assert_equal(out, Nx.tensor([1, 2, 2]))
+    end
+
+    test "quotient when dividing tensors" do
+      left = Nx.tensor([[10, 20]])
+      right = Nx.tensor([[1], [2]])
+
+      out = Nx.quotient(left, right)
+
+      assert_equal(out, Nx.tensor([[10, 20], [5, 10]]))
+    end
+
     test "random_uniform" do
       t = Nx.random_uniform({30, 50})
 

--- a/torchx/test/torchx/nx_test.exs
+++ b/torchx/test/torchx/nx_test.exs
@@ -502,6 +502,17 @@ defmodule Torchx.NxTest do
       assert_equal(out, Nx.tensor([[10, 20], [5, 10]]))
     end
 
+    test "quotient fails when using unsigned integers" do
+      assert_raise(
+        ArgumentError,
+        "Torchx does not support unsigned 32 bit integer",
+        fn -> Nx.quotient(
+          Nx.tensor([[10, 20]], type: {:u, 8}),
+          Nx.tensor([[1], [2]], type: {:u, 32})
+        ) end
+      )
+    end
+
     test "random_uniform" do
       t = Nx.random_uniform({30, 50})
 

--- a/torchx/test/torchx/nx_test.exs
+++ b/torchx/test/torchx/nx_test.exs
@@ -506,10 +506,12 @@ defmodule Torchx.NxTest do
       assert_raise(
         ArgumentError,
         "Torchx does not support unsigned 32 bit integer",
-        fn -> Nx.quotient(
-          Nx.tensor([[10, 20]], type: {:u, 8}),
-          Nx.tensor([[1], [2]], type: {:u, 32})
-        ) end
+        fn ->
+          Nx.quotient(
+            Nx.tensor([[10, 20]], type: {:u, 8}),
+            Nx.tensor([[1], [2]], type: {:u, 32})
+          )
+        end
       )
     end
 


### PR DESCRIPTION
Added tests for `Nx.quotient/2` since the doctests are ignored due to unsigned integers not being supported on Torchx.

`argmax` and `argmin` doctests no longer use complex numbers, which allows them to be restored.

Related to issue #682 