### PR TITLE
Implement the get_and_update Access callback on tensors

### DIFF
--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -323,6 +323,79 @@ defmodule Nx do
   For a more complex slicing rules, including strides, you
   can always fallback to `Nx.slice/4`.
 
+  Access also supports updating values with put_in/3 and update_in/3,
+  where the path to the value is a list of integers indicating the sub-dimensions.
+
+  The value that will be used to substitute should be a tensor of the same
+  shape as the one being updated.
+
+      iex> t = Nx.tensor([1, 2, 3])
+      iex> put_in(t, [2], Nx.tensor(2))
+      #Nx.Tensor<
+        s64[3]
+        [1, 2, 2]
+      >
+
+  In a multi-dimensional array, the path will determine at which level
+  the update will be made.
+
+  A whole tensor can be updated:
+
+      iex> t = Nx.tensor([[1, 2], [3, 4]])
+      iex> put_in(t, [1], Nx.tensor([4, 5]))
+      #Nx.Tensor<
+        s64[2][2]
+        [
+          [1, 2],
+          [4, 5]
+        ]
+      >
+
+  Or a scalar in a deeper level:
+
+      iex> t = Nx.tensor([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])
+      iex> put_in(t, [0, 1, 1], Nx.tensor(99))
+      #Nx.Tensor<
+        s64[2][2][2]
+        [
+          [
+            [1, 2],
+            [3, 99]
+          ],
+          [
+            [5, 6],
+            [7, 8]
+          ]
+        ]
+      >
+
+  As long as the update value is the same shape as the target one
+  to be substituted it will replace it, if not it will raise:
+
+      iex> t = Nx.tensor([[1, 2, 3], [4, 5, 6]])
+      iex> put_in(t, [0], Nx.tensor([1, 2]))
+      ** (ArgumentError) the shape {2} of the new value does not match the current value shape {3}
+
+  Out of bound attempts to update will also raise:
+      iex> t = Nx.tensor([[1, 2], [3, 4]])
+      iex> put_in(t, [2], Nx.tensor([5, 6]))
+      ** (ArgumentError) index 2 is out of bounds for axis 0 in shape {2, 2}
+
+  Unlike the access get syntax, it does not accept negative indices.
+
+  As for the update_in function, it accepts any function that can take
+  the tensor as an argument and will apply it to the target:
+
+      iex> t = Nx.tensor([[1, 2, 3], [4, 5, 6]])
+      iex> update_in(t, [0], fn t -> Nx.multiply(t, 2) end)
+      #Nx.Tensor<
+        s64[2][3]
+        [
+          [2, 4, 6],
+          [4, 5, 6]
+        ]
+      >
+
   ## Backends
 
   The `Nx` library has built-in support for multiple backends.

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -336,10 +336,24 @@ defmodule Nx do
         [1, 2, 2]
       >
 
+  The access update syntax also supports negative values, which will access the
+  element from the back:
+
+      iex> t = Nx.tensor([1, 2, 3])
+      iex> put_in(t, [-1], Nx.tensor(4))
+      #Nx.Tensor<
+        s64[3]
+        [1, 2, 4]
+      >
+
+  The length of the path list should always be equal or less than the rank
+  of the tensor.
+
   In a multi-dimensional array, the path will determine at which level
   the update will be made.
 
-  A whole tensor can be updated:
+  The update value can also be a tensor with multiple entries as long
+  as the shape matches the target to be updated:
 
       iex> t = Nx.tensor([[1, 2], [3, 4]])
       iex> put_in(t, [1], Nx.tensor([4, 5]))
@@ -351,7 +365,7 @@ defmodule Nx do
         ]
       >
 
-  Or a scalar in a deeper level:
+  We can also update a single tensor entry at a deeper level:
 
       iex> t = Nx.tensor([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])
       iex> put_in(t, [0, 1, 1], Nx.tensor(99))
@@ -369,8 +383,8 @@ defmodule Nx do
         ]
       >
 
-  As long as the update value is the same shape as the target one
-  to be substituted it will replace it, if not it will raise:
+  If the update value is not the same shape as the target one
+  it will raise:
 
       iex> t = Nx.tensor([[1, 2, 3], [4, 5, 6]])
       iex> put_in(t, [0], Nx.tensor([1, 2]))
@@ -380,8 +394,6 @@ defmodule Nx do
       iex> t = Nx.tensor([[1, 2], [3, 4]])
       iex> put_in(t, [2], Nx.tensor([5, 6]))
       ** (ArgumentError) index 2 is out of bounds for axis 0 in shape {2, 2}
-
-  Unlike the access get syntax, it does not accept negative indices.
 
   As for the update_in function, it accepts any function that can take
   the tensor as an argument and will apply it to the target:

--- a/nx/lib/nx/tensor.ex
+++ b/nx/lib/nx/tensor.ex
@@ -193,6 +193,7 @@ defmodule Nx.Tensor do
   end
 
   defp get_slice(_tensor, _indices, [0 | _]), do: nil
+
   defp get_slice(tensor, indices, lengths) do
     impl = Nx.Shared.impl!(tensor)
 

--- a/nx/lib/nx/tensor.ex
+++ b/nx/lib/nx/tensor.ex
@@ -149,10 +149,7 @@ defmodule Nx.Tensor do
   end
 
   def get_and_update(tensor, index, update) do
-    if index < 0 or index >= elem(tensor.shape, 0) do
-      raise ArgumentError,
-            "index #{index} is out of bounds for axis 0 in shape #{inspect(tensor.shape)}"
-    end
+    index = normalize_index(index, 0, tensor.shape)
 
     {:ok, current_value} = fetch(tensor, index)
     {_, new_value} = update.(current_value)


### PR DESCRIPTION
This is an initial implementation of the `get_and_update` callback so that tensors can support `put_in` and `update_in`. It uses slices by creating a slice of the section before the update and another one afterwards, and at the end concatenating them with the new value in the middle.

I also added this to the documentation and doctests.

Issue #229 