### PR TITLE
Support batched tensors in `Nx.LinAlg.qr`

### DIFF
--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -672,15 +672,15 @@ defmodule Nx.LinAlg do
   end
 
   @doc """
-  Calculates the QR decomposition of a 2-D tensor with shape `{M, N}`.
+  Calculates the QR decomposition of a tensor with shape `{..., M, N}`.
 
   ## Options
 
     * `:mode` - Can be one of `:reduced`, `:complete`. Defaults to `:reduced`
       For the following, `K = min(M, N)`
 
-      * `:reduced` - returns `q` and `r` with shapes `{M, K}` and `{K, N}`
-      * `:complete` - returns `q` and `r` with shapes `{M, M}` and `{M, N}`
+      * `:reduced` - returns `q` and `r` with shapes `{..., M, K}` and `{..., K, N}`
+      * `:complete` - returns `q` and `r` with shapes `{..., M, M}` and `{..., M, N}`
 
     * `:eps` - Rounding error threshold that can be applied during the triangularization
 
@@ -724,6 +724,40 @@ defmodule Nx.LinAlg do
           [3.0, 2.0, 1.0],
           [0.0, 1.0, 1.0],
           [0.0, 0.0, 1.0]
+        ]
+      >
+
+      iex> {qs, rs} = Nx.LinAlg.qr(Nx.tensor([[[-3, 2, 1], [0, 1, 1], [0, 0, -1]],[[3, 2, 1], [0, 1, 1], [0, 0, 1]]]))
+      iex> qs
+      #Nx.Tensor<
+        f32[2][3]
+        [
+          [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0]
+          ],
+          [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0]
+          ]
+        ]
+      >
+      iex> rs
+      #Nx.Tensor<
+        f32[2][3]
+        [
+          [
+            [-3.0, 2.0, 1.0],
+            [0.0, 1.0, 1.0],
+            [0.0, 0.0, -1.0]
+          ],
+          [
+            [3.0, 2.0, 1.0],
+            [0.0, 1.0, 1.0],
+            [0.0, 0.0, 1.0]
+          ]
         ]
       >
 
@@ -774,8 +808,11 @@ defmodule Nx.LinAlg do
 
   ## Error cases
 
-      iex> Nx.LinAlg.qr(Nx.tensor([[1, 1, 1, 1], [-1, 4, 4, -1], [4, -2, 2, 0]]))
-      ** (ArgumentError) tensor must have at least as many rows as columns, got shape: {3, 4}
+      iex> Nx.LinAlg.qr(Nx.tensor([[[1, 1, 1, 1], [-1, 4, 4, -1], [4, -2, 2, 0]]]))
+      ** (ArgumentError) tensor must have at least as many rows as columns in the last two axes, got 3 rows and 4 columns
+
+      iex> Nx.LinAlg.qr(Nx.tensor([1, 2, 3, 4, 5]))
+      ** (ArgumentError) tensor must have at least rank 2, got rank 1 with shape {5}
   """
   def qr(tensor, opts \\ []) do
     opts = keyword!(opts, mode: :reduced, eps: @default_eps)

--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -730,7 +730,7 @@ defmodule Nx.LinAlg do
       iex> {qs, rs} = Nx.LinAlg.qr(Nx.tensor([[[-3, 2, 1], [0, 1, 1], [0, 0, -1]],[[3, 2, 1], [0, 1, 1], [0, 0, 1]]]))
       iex> qs
       #Nx.Tensor<
-        f32[2][3]
+        f32[2][3][3]
         [
           [
             [1.0, 0.0, 0.0],
@@ -746,7 +746,7 @@ defmodule Nx.LinAlg do
       >
       iex> rs
       #Nx.Tensor<
-        f32[2][3]
+        f32[2][3][3]
         [
           [
             [-3.0, 2.0, 1.0],
@@ -830,8 +830,18 @@ defmodule Nx.LinAlg do
     {q_shape, r_shape} = Nx.Shape.qr(shape, opts)
 
     impl!(tensor).qr(
-      {%{tensor | type: output_type, shape: q_shape, names: [nil, nil]},
-       %{tensor | type: output_type, shape: r_shape, names: [nil, nil]}},
+      {%{
+         tensor
+         | type: output_type,
+           shape: q_shape,
+           names: List.duplicate(nil, tuple_size(q_shape))
+       },
+       %{
+         tensor
+         | type: output_type,
+           shape: r_shape,
+           names: List.duplicate(nil, tuple_size(r_shape))
+       }},
       tensor,
       opts
     )

--- a/nx/lib/nx/shape.ex
+++ b/nx/lib/nx/shape.ex
@@ -1773,7 +1773,7 @@ defmodule Nx.Shape do
     do:
       raise(
         ArgumentError,
-        "tensor must have at least as many rows as columns in the last two axes, got shape: #{inspect({m, n})}"
+        "tensor must have at least as many rows as columns in the last two axes, got #{m} rows and #{n} columns"
       )
 
   def qr(shape, _opts),

--- a/nx/lib/nx/shape.ex
+++ b/nx/lib/nx/shape.ex
@@ -1741,6 +1741,22 @@ defmodule Nx.Shape do
         "tensor must have rank 2, got rank #{tuple_size(shape)} with shape #{inspect(shape)}"
       )
 
+  def qr(shape, opts) when tuple_size(shape) > 2 do
+    rank = tuple_size(shape)
+    matrix_shape = {elem(shape, rank - 2), elem(shape, rank - 1)}
+    {{m1, n1}, {m2, n2}} = qr(matrix_shape, opts)
+
+    put_rows_and_columns = fn m, n ->
+      shape
+      |> Tuple.to_list()
+      |> List.replace_at(-2, m)
+      |> List.replace_at(-1, n)
+      |> List.to_tuple()
+    end
+
+    {put_rows_and_columns.(m1, n1), put_rows_and_columns.(m2, n2)}
+  end
+
   def qr({m, n}, opts) when m >= n do
     mode = opts[:mode]
 
@@ -1757,14 +1773,14 @@ defmodule Nx.Shape do
     do:
       raise(
         ArgumentError,
-        "tensor must have at least as many rows as columns, got shape: #{inspect({m, n})}"
+        "tensor must have at least as many rows as columns in the last two axes, got shape: #{inspect({m, n})}"
       )
 
   def qr(shape, _opts),
     do:
       raise(
         ArgumentError,
-        "tensor must have rank 2, got rank #{tuple_size(shape)} with shape #{inspect(shape)}"
+        "tensor must have at least rank 2, got rank #{tuple_size(shape)} with shape #{inspect(shape)}"
       )
 
   def svd({m, n}) do

--- a/nx/test/nx/lin_alg_test.exs
+++ b/nx/test/nx/lin_alg_test.exs
@@ -260,16 +260,60 @@ defmodule Nx.LinAlgTest do
       assert_all_close(Nx.dot(q, r), t)
     end
 
+    test "works with batches of matrices" do
+      t =
+        Nx.tensor([
+          [[1.0, 2.0, 3.0], [0.0, 4.0, 5.0], [0.0, 0.0, 6.0]],
+          [[1.0, 2.0, 3.0], [0.0, 10.0, 5.0], [0.0, 0.0, 20.0]]
+        ])
+
+      {q, r} = Nx.LinAlg.qr(t)
+
+      expected_q =
+        Nx.tensor([
+          [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0]
+          ],
+          [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0]
+          ]
+        ])
+
+      assert_all_close(q, expected_q, atol: 1.0e-10)
+
+      expected_r =
+        Nx.tensor([
+          [
+            [1.0, 2.0, 3.0],
+            [0.0, 4.0, 5.0],
+            [0.0, 0.0, 6.0]
+          ],
+          [
+            [1.0, 2.0, 3.0],
+            [0.0, 10.0, 5.0],
+            [0.0, 0.0, 20.0]
+          ]
+        ])
+
+      assert_all_close(r, expected_r, atol: 1.0e-10)
+
+      assert_all_close(Nx.dot(q, [2], [0], r, [1], [0]), t, atol: 1.0e-10)
+    end
+
     test "property" do
       for _ <- 1..10, type <- [{:f, 32}, {:c, 64}] do
-        square = Nx.random_uniform({4, 4}, type: type)
-        tall = Nx.random_uniform({4, 3}, type: type)
+        square = Nx.random_uniform({2, 4, 4}, type: type)
+        tall = Nx.random_uniform({2, 4, 3}, type: type)
 
         assert {q, r} = Nx.LinAlg.qr(square)
-        assert_all_close(Nx.dot(q, r), square, atol: 1.0e-6)
+        assert_all_close(Nx.dot(q, [2], [0], r, [1], [0]), square, atol: 1.0e-6)
 
         assert {q, r} = Nx.LinAlg.qr(tall)
-        assert_all_close(Nx.dot(q, r), tall, atol: 1.0e-6)
+        assert_all_close(Nx.dot(q, [2], [0], r, [1], [0]), tall, atol: 1.0e-6)
       end
     end
   end


### PR DESCRIPTION
Makes `Nx.LinAlg.qr` work with batched tensors. 

When given batched tensor `Nx.LinAlg.qr` will perform QR decomposition across the matrices in inner-most 2 dimensions, keeping the rest of the shape unaffected.