### PR TITLE
Fix typo in intro-to-nx

### DIFF
--- a/nx/guides/intro-to-nx.livemd
+++ b/nx/guides/intro-to-nx.livemd
@@ -522,10 +522,9 @@ import Nx.Defn
 ```
 
 Just as the Elixir language supports `def`, `defmacro`, and `defp`,
-Nx supports `defn`. There are a few restrictions. It allows only
+Nx supports `defn`. `There are a few restrictions. It allows only
 numerical arguments in the form of primitives or tensors as arguments
-or return values, and has a subset of the language within
-the `def` block.
+or return values, and supports only a subset of the language.
 
 The subset of Elixir allowed within `defn` is quite broad, though. We can
 use macros, pipes, and even conditionals, so we're not giving up

--- a/nx/guides/intro-to-nx.livemd
+++ b/nx/guides/intro-to-nx.livemd
@@ -522,7 +522,7 @@ import Nx.Defn
 ```
 
 Just as the Elixir language supports `def`, `defmacro`, and `defp`,
-Nx supports `defn`. `There are a few restrictions. It allows only
+Nx supports `defn`. There are a few restrictions. It allows only
 numerical arguments in the form of primitives or tensors as arguments
 or return values, and supports only a subset of the language.
 

--- a/nx/guides/intro-to-nx.livemd
+++ b/nx/guides/intro-to-nx.livemd
@@ -525,7 +525,7 @@ Just as the Elixir language supports `def`, `defmacro`, and `defp`,
 Nx supports `defn`. There are a few restrictions. It allows only
 numerical arguments in the form of primitives or tensors as arguments
 or return values, and has a subset of the language within
-the `defn` block.
+the `def` block.
 
 The subset of Elixir allowed within `defn` is quite broad, though. We can
 use macros, pipes, and even conditionals, so we're not giving up


### PR DESCRIPTION
I think what that sentence is meant to say is

> `defn` is a subset of the language allowed in the `def` block.
