### PR TITLE
Fix the issue of my_defn

### DIFF
--- a/nx/lib/nx/shape.ex
+++ b/nx/lib/nx/shape.ex
@@ -48,8 +48,8 @@ defmodule Nx.Shape do
         However, defn treats all arguments as inputs. To address this, you can pass \
         the dimension or the shape as an option instead:
 
-            defn my_defn(opts \\ []) do
-              opts = keyword(opts, dim: 1)
+            defn my_defn(opts \\\\ []) do
+              opts = keyword!(opts, dim: 1)
               Nx.iota({opts[:dim]})
             end
 


### PR DESCRIPTION
The message when using `defn` with integer argument causes ArgumentError, but the message is incorrect:  

```elixir
** (ArgumentError) invalid dimension in axis 0 found in shape. Each dimension must be a positive integer, but instead got a tensor as dimension: #Nx.Tensor<
  s64
  
  Nx.Defn.Expr
  parameter a:0   s64
>

This may happen if you are trying to pass a dimension or a shape as an argument to a defn function, for example:

    defn my_defn(dim) do
      Nx.iota({dim})
    end

However, defn treats all arguments as inputs. To address this, you can pass the dimension or the shape as an option instead:

    defn my_defn(opts \ []) do
      opts = keyword(opts, dim: 1)
      Nx.iota({opts[:dim]})
    end

Invalid shape: {#Nx.Tensor<
   s64
   
   Nx.Defn.Expr
   parameter a:0   s64
 >}
```

This PR corrects it as follows:

```elixir
** (ArgumentError) invalid dimension in axis 0 found in shape. Each dimension must be a positive integer, but instead got a tensor as dimension: #Nx.Tensor<
  s64
  
  Nx.Defn.Expr
  parameter a:0   s64
>

This may happen if you are trying to pass a dimension or a shape as an argument to a defn function, for example:

    defn my_defn(dim) do
      Nx.iota({dim})
    end

However, defn treats all arguments as inputs. To address this, you can pass the dimension or the shape as an option instead:

    defn my_defn(opts \\ []) do
      opts = keyword!(opts, dim: 1)
      Nx.iota({opts[:dim]})
    end

Invalid shape: {#Nx.Tensor<
   s64
   
   Nx.Defn.Expr
   parameter a:0   s64
 >}
```
