### PR TITLE
Support batched tensors in another part of `Nx.LinAlg` functions 

### DIFF
--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -383,11 +383,11 @@ defmodule Nx.LinAlg do
   end
 
   @doc """
-  Solve the equation `a x = b` for x, assuming `a` is a triangular matrix.
+  Solve the equation `a x = b` for x, assuming `a` is a batch of triangular matrices.
   Can also solve `x a = b` for x. See the `:left_side` option below.
 
-  `b` must either be a square matrix with the same dimensions as `a` or a 1-D tensor
-  with as many rows as `a`.
+  `b` must either be a batch of square matrices with the same dimensions as `a` or a batch of 1-D tensors
+  with as many rows as `a`. Batch dimensions of `a` and `b` must be the same.
 
   ## Options
 
@@ -497,10 +497,21 @@ defmodule Nx.LinAlg do
         [1.0+0.0i, 0.0+2.0i, 3.0+0.0i]
       >
 
+      iex> a = Nx.tensor([[[1, 0], [2, 3]], [[4, 0], [5, 6]]])
+      iex> b = Nx.tensor([[2, -1], [3, 7]])
+      iex> Nx.LinAlg.triangular_solve(a, b)
+      #Nx.Tensor<
+        f32[2][2]
+        [
+          [2.0, -1.6666666269302368],
+          [0.75, 0.5416666865348816]
+        ]
+      >
+
   ### Error cases
 
       iex> Nx.LinAlg.triangular_solve(Nx.tensor([[3, 0, 0, 0], [2, 1, 0, 0]]), Nx.tensor([4, 2, 4, 2]))
-      ** (ArgumentError) triangular_solve/3 expected a square tensor, got tensor with shape: {2, 4}
+      ** (ArgumentError) triangular_solve/3 expected a square matrix or a batch of square matrices, got tensor with shape: {2, 4}
 
       iex> Nx.LinAlg.triangular_solve(Nx.tensor([[3, 0, 0, 0], [2, 1, 0, 0], [1, 1, 1, 1], [1, 1, 1, 1]]), Nx.tensor([4]))
       ** (ArgumentError) incompatible dimensions for a and b on triangular solve
@@ -544,7 +555,7 @@ defmodule Nx.LinAlg do
   @doc """
   Solves the system `AX = B`.
 
-  `A` must have shape `{n, n}` and `B` must have shape `{n, m}` or `{n}`.
+  `A` must have shape `{..., n, n}` and `B` must have shape `{..., n, m}` or `{..., n}`.
   `X` has the same shape as `B`.
 
   ## Examples
@@ -575,6 +586,23 @@ defmodule Nx.LinAlg do
         ]
       >
 
+      iex> a = Nx.tensor([[[14, 10], [9, 9]], [[4, 11], [2, 3]]])
+      iex> b = Nx.tensor([[[2, 4], [3, 2]], [[1, 5], [-3, -1]]])
+      iex> Nx.LinAlg.solve(a, b) |> Nx.round()
+      #Nx.Tensor<
+        f32[2][2][2]
+        [
+          [
+            [0.0, 0.0],
+            [1.0, 0.0]
+          ],
+          [
+            [-4.0, -3.0],
+            [1.0, 1.0]
+          ]
+        ]
+      >
+
   If the axes are named, their names are not preserved in the output:
 
       iex> a = Nx.tensor([[1, 0, 1], [1, 1, 0], [1, 1, 1]], names: [:x, :y])
@@ -590,7 +618,7 @@ defmodule Nx.LinAlg do
       ** (ArgumentError) `b` tensor has incompatible dimensions, expected {2, 2} or {2}, got: {4}
 
       iex> Nx.LinAlg.solve(Nx.tensor([[3, 0, 0, 0], [2, 1, 0, 0], [1, 1, 1, 1]]), Nx.tensor([4]))
-      ** (ArgumentError) `a` tensor has incompatible dimensions, expected a 2-D tensor with as many rows as columns, got: {3, 4}
+      ** (ArgumentError) `a` tensor has incompatible dimensions, expected a square matrix or a batch of square matrices, got: {3, 4}
   """
   # IMPORTANT: This function cannot be a defn because
   # optional needs to work on the actual backend.
@@ -633,9 +661,9 @@ defmodule Nx.LinAlg do
   end
 
   @doc """
-  Inverts a square 2-D tensor.
+  Inverts a batch of square matrices.
 
-  For non-square tensors, use `svd/2` for pseudo-inverse calculations.
+  For non-square matrices, use `svd/2` for pseudo-inverse calculations.
 
   ## Examples
 
@@ -671,10 +699,54 @@ defmodule Nx.LinAlg do
         ]
       >
 
+      iex> a = Nx.tensor([[[1, 2], [0, 1]], [[1, 1], [0, 1]]])
+      iex> a_inv = Nx.LinAlg.invert(a)
+      #Nx.Tensor<
+        f32[2][2][2]
+        [
+          [
+            [1.0, -2.0],
+            [0.0, 1.0]
+          ],
+          [
+            [1.0, -1.0],
+            [0.0, 1.0]
+          ]
+        ]
+      >
+      iex> Nx.dot(a, [2], [0], a_inv, [1], [0])
+      #Nx.Tensor<
+        f32[2][2][2]
+        [
+          [
+            [1.0, 0.0],
+            [0.0, 1.0]
+          ],
+          [
+            [1.0, 0.0],
+            [0.0, 1.0]
+          ]
+        ]
+      >
+      iex> Nx.dot(a_inv, [2], [0], a, [1], [0])
+      #Nx.Tensor<
+        f32[2][2][2]
+        [
+          [
+            [1.0, 0.0],
+            [0.0, 1.0]
+          ],
+          [
+            [1.0, 0.0],
+            [0.0, 1.0]
+          ]
+        ]
+      >
+
   ### Error cases
 
       iex> Nx.LinAlg.invert(Nx.tensor([[3, 0, 0, 0], [2, 1, 0, 0]]))
-      ** (ArgumentError) invert/1 expects a square tensor, got tensor with shape: {2, 4}
+      ** (ArgumentError) invert/1 expects a square matrix or a batch of square matrices, got tensor with shape: {2, 4}
 
       iex> Nx.LinAlg.invert(Nx.tensor([[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [1, 1, 1, 1]]))
       ** (ArgumentError) can't solve for singular matrix
@@ -711,7 +783,7 @@ defmodule Nx.LinAlg do
 
       _ ->
         raise ArgumentError,
-              "invert/1 expects a square tensor, got tensor with shape: #{inspect(shape)}"
+              "invert/1 expects a square matrix or a batch of square matrices, got tensor with shape: #{inspect(shape)}"
     end
   end
 
@@ -892,7 +964,7 @@ defmodule Nx.LinAlg do
   end
 
   @doc """
-  Calculates the Eigenvalues and Eigenvectors of symmetric 2-D tensors.
+  Calculates the Eigenvalues and Eigenvectors of batched symmetric 2-D matrices.
 
   It returns `{eigenvals, eigenvecs}`.
 
@@ -937,6 +1009,30 @@ defmodule Nx.LinAlg do
           [0.4082472324371338, 0.9128734469413757, 0.0],
           [0.40824851393699646, -0.18257413804531097, 0.8944271802902222],
           [0.8164970278739929, -0.36514827609062195, -0.4472135901451111]
+        ]
+      >
+
+      iex> {eigenvals, eigenvecs} = Nx.LinAlg.eigh(Nx.tensor([[[2, 5],[5, 6]], [[1, 0], [0, 4]]]))
+      iex> Nx.round(eigenvals)
+      #Nx.Tensor<
+        f32[2][2]
+        [
+          [9.0, -1.0],
+          [1.0, 4.0]
+        ]
+      >
+      iex> eigenvecs
+      #Nx.Tensor<
+        f32[2][2][2]
+        [
+          [
+            [0.5606290698051453, -0.828070342540741],
+            [0.8280670642852783, 0.5606313347816467]
+          ],
+          [
+            [1.0, 0.0],
+            [0.0, 1.0]
+          ]
         ]
       >
 

--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -520,7 +520,7 @@ defmodule Nx.LinAlg do
   def triangular_solve(a, b, opts \\ []) do
     opts = keyword!(opts, lower: true, left_side: true, transform_a: :none)
     output_type = binary_type(a, b) |> Nx.Type.to_floating()
-    %T{shape: a_shape = {m, _}} = a = Nx.to_tensor(a)
+    %T{shape: a_shape} = a = Nx.to_tensor(a)
     %T{shape: b_shape} = b = Nx.to_tensor(b)
 
     case opts[:transform_a] do
@@ -536,30 +536,7 @@ defmodule Nx.LinAlg do
                 "got: #{inspect(t)}"
     end
 
-    case a_shape do
-      {n, n} ->
-        nil
-
-      other ->
-        raise ArgumentError,
-              "triangular_solve/3 expected a square tensor, got tensor with shape: #{inspect(other)}"
-    end
-
-    left_side = opts[:left_side]
-
-    case b_shape do
-      {^m, _} when left_side ->
-        nil
-
-      {_, ^m} when not left_side ->
-        nil
-
-      {^m} ->
-        nil
-
-      _ ->
-        raise ArgumentError, "incompatible dimensions for a and b on triangular solve"
-    end
+    :ok = Nx.Shape.triangular_solve(a_shape, b_shape, opts[:left_side])
 
     impl!(a, b).triangular_solve(%{b | type: output_type}, a, b, opts)
   end

--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -941,7 +941,7 @@ defmodule Nx.LinAlg do
   ## Error cases
 
       iex> Nx.LinAlg.eigh(Nx.tensor([[1, 2, 3], [4, 5, 6]]))
-      ** (ArgumentError) eigh/2 expects a square tensor, got tensor with shape: {2, 3}
+      ** (ArgumentError) tensor must be a square matrix or a batch of square matrices, got shape: {2, 3}
 
       iex> Nx.LinAlg.eigh(Nx.tensor([[1, 2], [3, 4]]))
       ** (ArgumentError) input tensor must be symmetric
@@ -954,19 +954,14 @@ defmodule Nx.LinAlg do
 
     output_type = Nx.Type.to_floating(type)
 
-    {eigenvals_shape, eigenvecs_shape} =
-      case shape do
-        {n, n} ->
-          {{n}, {n, n}}
-
-        shape ->
-          raise ArgumentError,
-                "eigh/2 expects a square tensor, got tensor with shape: #{inspect(shape)}"
-      end
+    {eigenvals_shape, eigenvecs_shape} = Nx.Shape.eigh(shape)
+    rank = tuple_size(shape)
+    eigenvals_name = List.duplicate(nil, rank - 1)
+    eigenvecs_name = List.duplicate(nil, rank)
 
     impl!(tensor).eigh(
-      {%{tensor | names: [nil], type: output_type, shape: eigenvals_shape},
-       %{tensor | names: [nil, nil], type: output_type, shape: eigenvecs_shape}},
+      {%{tensor | names: eigenvals_name, type: output_type, shape: eigenvals_shape},
+       %{tensor | names: eigenvecs_name, type: output_type, shape: eigenvecs_shape}},
       tensor,
       opts
     )

--- a/nx/lib/nx/shape.ex
+++ b/nx/lib/nx/shape.ex
@@ -1873,7 +1873,7 @@ defmodule Nx.Shape do
   def triangular_solve({m, n}, _, _) when m != n do
     raise(
       ArgumentError,
-      "triangular_solve/3 expected a square tensor, got tensor with shape: #{inspect({m, n})}"
+      "triangular_solve/3 expected a square matrix or a batch of square matrices, got tensor with shape: #{inspect({m, n})}"
     )
   end
 
@@ -1885,7 +1885,7 @@ defmodule Nx.Shape do
 
     unless a_m == a_n do
       raise ArgumentError,
-            "triangular_solve/3 expected a square tensor, got tensor with shape: #{inspect(a_shape)}"
+            "triangular_solve/3 expected a square matrix or a batch of square matrices, got tensor with shape: #{inspect(a_shape)}"
     end
 
     cond do
@@ -1925,7 +1925,7 @@ defmodule Nx.Shape do
     unless a_m == a_n do
       raise(
         ArgumentError,
-        "`a` tensor has incompatible dimensions, expected a 2-D tensor with as many rows as columns, got: " <>
+        "`a` tensor has incompatible dimensions, expected a square matrix or a batch of square matrices, got: " <>
           inspect(a_shape)
       )
     end
@@ -1952,7 +1952,7 @@ defmodule Nx.Shape do
   def solve(a_shape, _b_shape) do
     raise(
       ArgumentError,
-      "`a` tensor has incompatible dimensions, expected a 2-D tensor with as many rows as columns, got: " <>
+      "`a` tensor has incompatible dimensions, expected a square matrix or a batch of square matrices, got: " <>
         inspect(a_shape)
     )
   end

--- a/nx/lib/nx/shape.ex
+++ b/nx/lib/nx/shape.ex
@@ -1807,13 +1807,10 @@ defmodule Nx.Shape do
       )
     end
 
-    [
-      [unchanged_shape, [m]],
-      [unchanged_shape, [m, m]]
-    ]
-    |> Enum.map(&List.flatten/1)
-    |> Enum.map(&List.to_tuple/1)
-    |> List.to_tuple()
+    {
+      List.to_tuple(unchanged_shape ++ [m]),
+      List.to_tuple(unchanged_shape ++ [m, m])
+    }
   end
 
   def eigh(shape),
@@ -1938,8 +1935,8 @@ defmodule Nx.Shape do
         b_shape
 
       true ->
-        expected_1d = [a_batch_shape, a_n] |> List.flatten() |> List.to_tuple()
-        expected_2d = [a_batch_shape, a_n, "m"] |> List.flatten() |> List.to_tuple()
+        expected_1d = List.to_tuple(a_batch_shape ++ [a_n])
+        expected_2d = List.to_tuple(a_batch_shape ++ [a_n, "m"])
 
         raise(
           ArgumentError,

--- a/nx/lib/nx/shape.ex
+++ b/nx/lib/nx/shape.ex
@@ -1795,6 +1795,34 @@ defmodule Nx.Shape do
         "tensor must have at least rank 2, got rank #{tuple_size(shape)} with shape #{inspect(shape)}"
       )
 
+  def eigh(shape) when tuple_size(shape) > 1 do
+    rank = tuple_size(shape)
+    {m, n} = {elem(shape, rank - 2), elem(shape, rank - 1)}
+    {unchanged_shape, _} = Tuple.to_list(shape) |> Enum.split(-2)
+
+    unless m == n do
+      raise(
+        ArgumentError,
+        "tensor must be a square matrix or a batch of square matrices, got shape: #{inspect(shape)}"
+      )
+    end
+
+    [
+      [unchanged_shape, [m]],
+      [unchanged_shape, [m, m]]
+    ]
+    |> Enum.map(&List.flatten/1)
+    |> Enum.map(&List.to_tuple/1)
+    |> List.to_tuple()
+  end
+
+  def eigh(shape),
+    do:
+      raise(
+        ArgumentError,
+        "tensor must have at least rank 2, got rank #{tuple_size(shape)} with shape #{inspect(shape)}"
+      )
+
   def svd(shape) when tuple_size(shape) > 1 do
     rank = tuple_size(shape)
     {m, n} = {elem(shape, rank - 2), elem(shape, rank - 1)}

--- a/nx/test/nx/lin_alg_test.exs
+++ b/nx/test/nx/lin_alg_test.exs
@@ -353,7 +353,7 @@ defmodule Nx.LinAlgTest do
 
       for _ <- 1..10 do
         # Orthogonal matrix from a random matrix
-        {q, _} = Nx.random_uniform({3, 3}) |> Nx.LinAlg.qr()
+        {q, _} = Nx.random_uniform({3, 3, 3}) |> Nx.LinAlg.qr()
 
         # Different eigenvalues from random values
         evals_test =
@@ -374,9 +374,9 @@ defmodule Nx.LinAlgTest do
         # using A = A^t = Q^t.Λ.Q.
         a =
           q
-          |> Nx.transpose()
+          |> Nx.LinAlg.adjoint()
           |> Nx.multiply(evals_test)
-          |> Nx.dot(q)
+          |> Nx.dot([2], [0], q, [1], [0])
 
         # Eigenvalues and eigenvectors
         assert {evals, evecs} = Nx.LinAlg.eigh(a)
@@ -384,7 +384,7 @@ defmodule Nx.LinAlgTest do
 
         # Eigenvalue equation
         evecs_evals = Nx.multiply(evecs, evals)
-        a_evecs = Nx.dot(a, evecs)
+        a_evecs = Nx.dot(a, [2], [0], evecs, [1], [0])
 
         assert_all_close(evecs_evals, a_evecs, atol: 1.0e-3)
       end
@@ -396,7 +396,7 @@ defmodule Nx.LinAlgTest do
 
       for _ <- 1..10 do
         # Orthogonal matrix from a random matrix
-        {q, _} = Nx.random_uniform({3, 3}) |> Nx.LinAlg.qr()
+        {q, _} = Nx.random_uniform({3, 3, 3}) |> Nx.LinAlg.qr()
 
         # ensure that eval1 is far apart from the other two eigenvals
         eval1 = :rand.uniform() * 10 + 10
@@ -404,15 +404,16 @@ defmodule Nx.LinAlgTest do
         eval2 = :rand.uniform() * 0.01 + 1
         # eval3 also in the same range as eval2
         eval3 = :rand.uniform() * 0.01 + 1
+
         evals_test = Nx.tensor([eval1, eval2, eval3])
 
         # Symmetric matrix with different eigenvalues
         # using A = A^t = Q^tΛQ.
         a =
           q
-          |> Nx.transpose()
+          |> Nx.LinAlg.adjoint()
           |> Nx.multiply(evals_test)
-          |> Nx.dot(q)
+          |> Nx.dot([2], [0], q, [1], [0])
           |> round(3)
 
         # Eigenvalues and eigenvectors
@@ -421,7 +422,7 @@ defmodule Nx.LinAlgTest do
 
         # Eigenvalue equation
         evecs_evals = Nx.multiply(evecs, evals)
-        a_evecs = Nx.dot(a, evecs)
+        a_evecs = Nx.dot(a, [2], [0], evecs, [1], [0])
         assert_all_close(evecs_evals, a_evecs, atol: 1.0e-2)
       end
     end

--- a/nx/test/nx/lin_alg_test.exs
+++ b/nx/test/nx/lin_alg_test.exs
@@ -9,6 +9,13 @@ defmodule Nx.LinAlgTest do
   @types [{:f, 32}, {:c, 64}]
 
   describe "triangular_solve" do
+    test "works with batched input" do
+      a = Nx.tensor([[[-1, 0, 0], [1, 1, 0], [1, 1, 1]], [[2, 0, 0], [4, -2, 0], [-5, 1, 3]]])
+      b = Nx.tensor([[1.0, 2.0, 3.0], [6, 10, 1]])
+
+      assert Nx.dot(a, [2], [0], Nx.LinAlg.triangular_solve(a, b), [1], [0]) == b
+    end
+
     test "property" do
       a = Nx.tensor([[1, 0, 0], [1, 1, 0], [0, 1, 1]])
       b = Nx.tensor([[1.0, 2.0, 3.0], [2.0, 2.0, 4.0], [2.0, 0.0, 1.0]])
@@ -40,6 +47,13 @@ defmodule Nx.LinAlgTest do
                Nx.tensor([1.0, 1.0, -1.0])
     end
 
+    test "works with batched input" do
+      a = Nx.tensor([[[1, 3, -2], [3, 5, 6], [2, 4, 3]], [[1, 1, 1], [6, -4, 5], [5, 2, 2]]])
+      b = Nx.tensor([[5, 7, 8], [2, 31, 13]])
+
+      assert_all_close(Nx.dot(a, [2], [0], Nx.LinAlg.solve(a, b), [1], [0]), b)
+    end
+
     test "works with complex tensors" do
       a = ~M[
         1 0 i
@@ -56,6 +70,25 @@ defmodule Nx.LinAlgTest do
   end
 
   describe "invert" do
+    test "works with batched input" do
+      a = Nx.tensor([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])
+      expected_result = Nx.tensor([[[-2, 1], [1.5, -0.5]], [[-4, 3], [3.5, -2.5]]])
+
+      result = Nx.LinAlg.invert(a)
+
+      assert_all_close(result, expected_result)
+
+      assert_all_close(
+        Nx.dot(a, [2], [0], result, [1], [0]),
+        Nx.broadcast(Nx.eye(2), Nx.shape(a))
+      )
+
+      assert_all_close(
+        Nx.dot(result, [2], [0], a, [1], [0]),
+        Nx.broadcast(Nx.eye(2), Nx.shape(a))
+      )
+    end
+
     test "works with complex tensors" do
       a = ~M[
         1 0 i

--- a/torchx/lib/torchx/backend.ex
+++ b/torchx/lib/torchx/backend.ex
@@ -1055,12 +1055,17 @@ defmodule Torchx.Backend do
       raise ArgumentError, "left_side: false option not supported in Torchx"
     end
 
-    batched_a_shape = Tuple.insert_at(a.shape, 0, 1)
+    batched_a_shape =
+      case a.shape do
+        {m, m} -> {1, m, m}
+        shape -> shape
+      end
 
     batched_b_shape =
       case b.shape do
         {n} -> {1, n, 1}
         {m, n} -> {1, m, n}
+        shape -> shape
       end
 
     out_type = to_torch_type(out.type)
@@ -1106,8 +1111,8 @@ defmodule Torchx.Backend do
       tensor
       |> Torchx.determinant()
       |> Torchx.abs()
-      |> Torchx.reshape({})
       |> Torchx.less_equal(eps)
+      |> Torchx.all()
       |> Torchx.to_nx()
       |> Nx.to_number()
       |> Kernel.==(1)


### PR DESCRIPTION
Batched tensors support for:
- `Nx.LinAlg.eigh`
- `Nx.LinAlg.invert`
- `Nx.LinAlg.solve`
- `Nx.LinAlg.triangular_solve`