### PR TITLE
fix(torchx): avoid returning bool type in underlying tensors

### DIFF
--- a/torchx/test/torchx/nx_test.exs
+++ b/torchx/test/torchx/nx_test.exs
@@ -24,7 +24,7 @@ defmodule Torchx.NxTest do
     :logical_or,
     :logical_xor
   ]
-  @unary_ops [:abs, :bitwise_not, :ceil, :floor, :negate, :round, :sign]
+  @unary_ops [:abs, :bitwise_not, :ceil, :floor, :negate, :round, :sign, :argmax, :argmin]
 
   defp test_binary_op(op, data_a \\ [[5, 6], [7, 8]], data_b \\ [[1, 2], [3, 4]], type_a, type_b) do
     a = Nx.tensor(data_a, type: type_a)

--- a/torchx/test/torchx_test.exs
+++ b/torchx/test/torchx_test.exs
@@ -91,4 +91,18 @@ defmodule TorchxTest do
       end
     end
   end
+
+  describe "argminmax" do
+    test "works with bool inputs" do
+      t =
+        {2, 3}
+        |> Nx.iota(type: {:u, 8})
+        |> Torchx.from_nx()
+        |> Torchx.to_type(:bool)
+        |> Torchx.to_nx()
+
+      assert_equal(0, Nx.argmin(t))
+      assert_equal(1, Nx.argmax(t))
+    end
+  end
 end

--- a/torchx/test/torchx_test.exs
+++ b/torchx/test/torchx_test.exs
@@ -92,8 +92,25 @@ defmodule TorchxTest do
     end
   end
 
-  describe "argminmax" do
-    test "works with bool inputs" do
+  describe "bool type" do
+    test "adds correctly" do
+      t_tx =
+        {2, 3}
+        |> Nx.iota(type: {:u, 8})
+        |> Torchx.from_nx()
+        |> Torchx.to_type(:bool)
+
+      # t = Torchx.Backend.to_nx(t_tx, %Nx.Tensor{names: [nil, nil], shape: {2, 3}, type: {:u, 8}})
+      t = Torchx.to_nx(t_tx)
+
+      # Show that bools don't add as expected for u8
+      # This is why we add the cast to byte in Torchx.to_nx
+      assert_equal(Torchx.to_nx(t_tx), t_tx |> Torchx.add(t_tx) |> Torchx.to_nx())
+
+      assert_equal(Nx.add(t, t), Nx.tensor([[0, 2, 2], [2, 2, 2]]))
+    end
+
+    test "works with argmax and argmin" do
       t =
         {2, 3}
         |> Nx.iota(type: {:u, 8})

--- a/torchx/test/torchx_test.exs
+++ b/torchx/test/torchx_test.exs
@@ -100,7 +100,6 @@ defmodule TorchxTest do
         |> Torchx.from_nx()
         |> Torchx.to_type(:bool)
 
-      # t = Torchx.Backend.to_nx(t_tx, %Nx.Tensor{names: [nil, nil], shape: {2, 3}, type: {:u, 8}})
       t = Torchx.to_nx(t_tx)
 
       # Show that bools don't add as expected for u8


### PR DESCRIPTION
closes #895

This is an edge case which I wasn't able to reproduce through normal Nx APIs.
Some torch functions return a bool-typed tensor instead of byte-typed for u8.
This leads to some unexpected behavior which was mostly hidden under an upcast we had specifically for u8 -> s16.

This PR converts all bool underlying tensors to byte tensors when returning to Nx-land