### PR TITLE
Minor fix the svd function's comment for eps

### DIFF
--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -1063,7 +1063,7 @@ defmodule Nx.LinAlg do
     * `:max_iter` - `integer`. Defaults to `1000`
       Number of maximum iterations before stopping the decomposition
 
-    * `:eps` - `float`. Defaults to 1.0e-12
+    * `:eps` - `float`. Defaults to 1.0e-10
       Tolerance applied during the decomposition
 
   Note not all options apply to all backends, as backends may have


### PR DESCRIPTION
In a minor fix, [the value 1.0e-10 defined in `@default_eps`](https://github.com/elixir-nx/nx/blob/c01b2302620e51af212d752e83712af95860bf51/nx/lib/nx/lin_alg.ex#L12) was different from the value 1.0e-12 in the doc comment, so the comment was fixed.