### PR TITLE
Support batched tensors in `determinant/1`, `matrix_power/2`, and `take_diagonal/2`

### DIFF
--- a/nx/lib/nx/shape.ex
+++ b/nx/lib/nx/shape.ex
@@ -1867,6 +1867,27 @@ defmodule Nx.Shape do
         "tensor must have at least rank 2, got rank #{tuple_size(shape)} with shape #{inspect(shape)}"
       )
 
+  def matrix_power(shape) when tuple_size(shape) > 1 do
+    rank = tuple_size(shape)
+    matrix_shape = {elem(shape, rank - 2), elem(shape, rank - 1)}
+
+    unless match?({n, n}, matrix_shape) do
+      raise(
+        ArgumentError,
+        "matrix_power/2 expects a square matrix or a batch of square matrices, got tensor with shape: #{inspect(shape)}"
+      )
+    end
+
+    :ok
+  end
+
+  def matrix_power(shape) do
+    raise(
+      ArgumentError,
+      "matrix_power/2 expects a square matrix or a batch of square matrices, got tensor with shape: #{inspect(shape)}"
+    )
+  end
+
   def triangular_solve({n, n}, {n}, _left_side), do: :ok
   def triangular_solve({n, n}, {n, _}, true), do: :ok
   def triangular_solve({n, n}, {_, n}, false), do: :ok

--- a/nx/lib/nx/shape.ex
+++ b/nx/lib/nx/shape.ex
@@ -1251,17 +1251,18 @@ defmodule Nx.Shape do
   end
 
   @doc """
-  Returns shape if valid and raises error if not.
+  Returns {batch_shape, matrix_shape} if valid and raises error if not.
   """
   def take_diagonal(shape)
 
-  def take_diagonal({len, breadth}) do
-    {len, breadth}
+  def take_diagonal(shape) when tuple_size(shape) > 1 do
+    {batch_shape, matrix_shape} = shape |> Tuple.to_list() |> Enum.split(-2)
+    {List.to_tuple(batch_shape), List.to_tuple(matrix_shape)}
   end
 
   def take_diagonal(invalid_shape) do
     raise ArgumentError,
-          "take_diagonal/2 expects tensor of rank 2, got tensor of rank: #{tuple_size(invalid_shape)}"
+          "take_diagonal/2 expects tensor of rank 2 or higher, got tensor of rank: #{tuple_size(invalid_shape)}"
   end
 
   @doc """

--- a/nx/test/nx/lin_alg_test.exs
+++ b/nx/test/nx/lin_alg_test.exs
@@ -121,6 +121,37 @@ defmodule Nx.LinAlgTest do
 
       assert Nx.LinAlg.determinant(three_by_three) == Nx.tensor(48.0)
     end
+
+    test "supports batched matrices" do
+      two_by_two = Nx.tensor([[[2, 3], [4, 5]], [[6, 3], [4, 8]]])
+      assert Nx.LinAlg.determinant(two_by_two) == Nx.tensor([-2.0, 36.0])
+
+      three_by_three =
+        Nx.tensor([
+          [[1.0, 2.0, 3.0], [1.0, 5.0, 3.0], [7.0, 6.0, 9.0]],
+          [[5.0, 2.0, 3.0], [8.0, 5.0, 4.0], [3.0, 1.0, -9.0]]
+        ])
+
+      assert Nx.LinAlg.determinant(three_by_three) == Nx.tensor([-36.0, -98.0])
+
+      four_by_four =
+        Nx.tensor([
+          [
+            [1.0, 2.0, 3.0, 0.0],
+            [1.0, 5.0, 3.0, 0.0],
+            [7.0, 6.0, 9.0, 0.0],
+            [0.0, -11.0, 2.0, 3.0]
+          ],
+          [
+            [5.0, 2.0, 3.0, 0.0],
+            [8.0, 5.0, 4.0, 0.0],
+            [3.0, 1.0, -9.0, 0.0],
+            [8.0, 2.0, -4.0, 5.0]
+          ]
+        ])
+
+      assert_all_close(Nx.LinAlg.determinant(four_by_four), Nx.tensor([-108.0, -490]))
+    end
   end
 
   describe "norm/2" do

--- a/nx/test/nx/lin_alg_test.exs
+++ b/nx/test/nx/lin_alg_test.exs
@@ -187,6 +187,22 @@ defmodule Nx.LinAlgTest do
 
       assert_all_close(Nx.LinAlg.matrix_power(a, -4), result)
     end
+
+    test "supports batched matrices" do
+      a =
+        Nx.tensor([
+          [[5, 3], [1, 2]],
+          [[9, 0], [4, 7]]
+        ])
+
+      result =
+        Nx.tensor([
+          [[161, 126], [42, 35]],
+          [[729, 0], [772, 343]]
+        ])
+
+      assert_all_close(Nx.LinAlg.matrix_power(a, 3), result)
+    end
   end
 
   describe "qr" do

--- a/nx/test/nx_test.exs
+++ b/nx/test/nx_test.exs
@@ -2004,12 +2004,21 @@ defmodule NxTest do
       assert diag == Nx.tensor([3, 7])
     end
 
+    test "extracts valid diagonal given batched matrices" do
+      diag =
+        {2, 3, 3}
+        |> Nx.iota()
+        |> Nx.take_diagonal()
+
+      assert diag == Nx.tensor([[0, 4, 8], [9, 13, 17]])
+    end
+
     test "raises error given tensor with invalid rank" do
-      t = Nx.iota({3, 3, 3})
+      t = Nx.iota({3})
 
       assert_raise(
         ArgumentError,
-        "take_diagonal/2 expects tensor of rank 2, got tensor of rank: 3",
+        "take_diagonal/2 expects tensor of rank 2 or higher, got tensor of rank: 1",
         fn -> Nx.take_diagonal(t) end
       )
     end


### PR DESCRIPTION
Batched tensors support for:
- `Nx.LinAlg.determinant`
- `Nx.LinAlg.matrix_power`
- `Nx.take_diagonal`