### PR TITLE
Emulate remainder for all u64 integers

### DIFF
--- a/torchx/lib/torchx/backend.ex
+++ b/torchx/lib/torchx/backend.ex
@@ -869,7 +869,7 @@ defmodule Torchx.Backend do
       # Numbers smaller than max_s64 are kept as positive s64 and fmod
       # works fine for those.
 
-      reminder_from_positive = Torchx.fmod(left_tx, right_tx)
+      remainder_from_positive = Torchx.fmod(left_tx, right_tx)
 
       # Numbers bigger than max_s64 are kept as negative s64. Consider
       # such s64 number denoted as x. We can decompose x into two
@@ -895,7 +895,7 @@ defmodule Torchx.Backend do
 
       rest_tx = Torchx.subtract(left_tx, max_s64_tx)
 
-      reminder_from_negative =
+      remainder_from_negative =
         Torchx.fmod(
           Torchx.add(
             Torchx.fmod(rest_tx, right_tx),
@@ -908,7 +908,7 @@ defmodule Torchx.Backend do
 
       left_tx
       |> Torchx.less(zero)
-      |> Torchx.where(reminder_from_negative, reminder_from_positive)
+      |> Torchx.where(remainder_from_negative, remainder_from_positive)
       |> Torchx.to_type(to_torch_type(out.type))
       |> to_nx(out)
     else

--- a/torchx/lib/torchx/backend.ex
+++ b/torchx/lib/torchx/backend.ex
@@ -889,9 +889,7 @@ defmodule Torchx.Backend do
       # s64 numbers.
 
       max_s64_tx =
-        Nx.Constants.max_finite(:s64, backend: Nx.BinaryBackend)
-        |> Nx.to_number()
-        |> Torchx.scalar_tensor(to_torch_type(l.type), device)
+        Nx.Constants.max_finite(:s64, backend: {Nx.BinaryBackend, device: device}) |> from_nx()
 
       rest_tx = Torchx.subtract(left_tx, max_s64_tx)
 

--- a/torchx/test/torchx/nx_test.exs
+++ b/torchx/test/torchx/nx_test.exs
@@ -87,6 +87,13 @@ defmodule Torchx.NxTest do
         test_binary_op(op, data_b, data_a, type, type)
       end
     end
+
+    test "remainder with emulated u64 operands" do
+      a = Nx.tensor([9_223_372_036_854_775_808, 18_446_744_073_709_551_321], type: :u64)
+      b = Nx.tensor(10, type: :u64)
+
+      assert_equal(Nx.remainder(a, b), Nx.tensor([8, 1]))
+    end
   end
 
   # quotient/2 works only with integers, so we put it here.
@@ -428,6 +435,13 @@ defmodule Torchx.NxTest do
 
       assert Nx.shape(out) == {1, 3}
       assert_equal(out, Nx.tensor([[3, 6, 9]]))
+    end
+
+    test "dot with multiple batch axes" do
+      u = Nx.tensor([[[1, 1]], [[2, 2]]])
+      v = Nx.tensor([[[1, 2]], [[1, 2]]])
+
+      assert_equal(Nx.tensor([[3], [6]]), Nx.dot(u, [2], [0, 1], v, [2], [0, 1]))
     end
 
     test "dot does not re-sort the contracting axes" do

--- a/torchx/test/torchx/random_test.exs
+++ b/torchx/test/torchx/random_test.exs
@@ -65,7 +65,7 @@ defmodule Torchx.Nx.RandomTest do
       # Output does not match Nx because of the sign of the remainder.
       distribution_case(:randint_split,
         args: [0, 10, [shape: {5}]],
-        expected: Nx.tensor([3, 0, 4, 4, 4], type: :s64)
+        expected: Nx.tensor([3, 2, 6, 0, 0], type: :s64)
       )
     end
 

--- a/torchx/test/torchx_test.exs
+++ b/torchx/test/torchx_test.exs
@@ -21,13 +21,6 @@ defmodule TorchxTest do
       {:cpu, ref} = Torchx.tensordot(a, b, [0], [0])
       assert is_reference(ref)
     end
-
-    test "dot with multiple batch axes" do
-      u = Nx.tensor([[[1, 1]], [[2, 2]]])
-      v = Nx.tensor([[[1, 2]], [[1, 2]]])
-
-      assert_equal(Nx.tensor([[3], [6]]), Nx.dot(u, [2], [0, 1], v, [2], [0, 1]))
-    end
   end
 
   describe "torchx<->nx" do


### PR DESCRIPTION
This aligns the random values between torchx and the binary backend.