### PR TITLE
Get deps folder and mix.lock file with project name on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/cache@v1
         id: mix-cache # id to use in retrieve action
         with:
-          path: ${{ matrix.working_directory }}/deps
+          path: deps
           key: v1-${{ matrix.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-${{ hashFiles(format('{0}{1}{2}', github.workspace, matrix.working_directory, '/mix.lock')) }}
       - name: Retrieve libtorch cache
         if: ${{ matrix.working_directory == 'torchx' }}
@@ -79,7 +79,7 @@ jobs:
         uses: actions/cache@v1
         id: mix-cache # id to use in retrieve action
         with:
-          path: ${{ matrix.working_directory }}/deps
+          path: deps
           key: v1-${{ matrix.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-${{ hashFiles(format('{0}{1}{2}', github.workspace, matrix.working_directory, '/mix.lock')) }}
       - name: Retrieve libtorch cache
         if: ${{ matrix.working_directory == 'torchx' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
         uses: actions/cache@v1
         id: mix-cache # id to use in retrieve action
         with:
-          path: deps
-          key: v1-${{ matrix.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
+          path: ${{ matrix.working_directory }}/deps
+          key: v1-${{ matrix.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '${{ matrix.working_directory }}/mix.lock')) }}
       - name: Retrieve libtorch cache
         if: ${{ matrix.working_directory == 'torchx' }}
         uses: actions/cache@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         id: mix-cache # id to use in retrieve action
         with:
           path: ${{ matrix.working_directory }}/deps
-          key: v1-${{ matrix.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '${{ matrix.working_directory }}/mix.lock')) }}
+          key: v1-${{ matrix.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-${{ hashFiles(format('{0}{1}{2}', github.workspace, matrix.working_directory, '/mix.lock')) }}
       - name: Retrieve libtorch cache
         if: ${{ matrix.working_directory == 'torchx' }}
         uses: actions/cache@v1
@@ -79,8 +79,8 @@ jobs:
         uses: actions/cache@v1
         id: mix-cache # id to use in retrieve action
         with:
-          path: deps
-          key: v1-${{ matrix.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
+          path: ${{ matrix.working_directory }}/deps
+          key: v1-${{ matrix.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-${{ hashFiles(format('{0}{1}{2}', github.workspace, matrix.working_directory, '/mix.lock')) }}
       - name: Retrieve libtorch cache
         if: ${{ matrix.working_directory == 'torchx' }}
         uses: actions/cache@v1


### PR DESCRIPTION
This is an attempt to solve the issue of deps cache on CI. If I understand this correctly, the key field does need to get the info for the `mix.lock` corresponding to each of the projects and also the deps field will need the path that includes the project name.

Closes #867 