### PR TITLE
Fix wrong Latex delimiters in docs

### DIFF
--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -5789,7 +5789,7 @@ defmodule Nx do
   @doc """
   Calculates the complex conjugate of each element in the tensor.
 
-  If $z = a + bi = r e^\\theta$, $conjugate(z) = z^* = a - bi =  r e^{-\\theta}$
+  If $$z = a + bi = r e^\\theta$$, $$conjugate(z) = z^* = a - bi =  r e^{-\\theta}$$
 
   ## Examples
 
@@ -5820,7 +5820,7 @@ defmodule Nx do
 
   @doc """
   Calculates the complex phase angle of each element in the tensor.
-  $phase(z) = atan2(b, a), z = a + bi \\in \\Complex$
+  $$phase(z) = atan2(b, a), z = a + bi \\in \\Complex$$
 
   ## Examples
 

--- a/nx/lib/nx/shared.ex
+++ b/nx/lib/nx/shared.ex
@@ -317,9 +317,9 @@ defmodule Nx.Shared do
       log:
         {"natural log", quote(do: Complex.ln(var!(x))),
          ~S"""
-         $log(z) = ln(z),\quad \text{if z} \in \Reals$
+         $$log(z) = ln(z),\quad \text{if z} \in \Reals$$
 
-         $log(z) = ln(r) + i\theta,\quad\text{if }z = re^{i\theta} \in \Complex$
+         $$log(z) = ln(r) + i\theta,\quad\text{if }z = re^{i\theta} \in \Complex$$
          """},
       log1p:
         {"natural log plus one", quote(do: Complex.ln(Complex.add(var!(x), 1))),


### PR DESCRIPTION
This PR fixes wrong Latex delimiters in docs about `Nx.phase/1`, `Nx.conjugate/1`, `Nx.log/1`.