### PR TITLE
Include generator parameters in the while expression node

### DIFF
--- a/nx/lib/nx/defn/expr.ex
+++ b/nx/lib/nx/defn/expr.ex
@@ -413,8 +413,9 @@ defmodule Nx.Defn.Expr do
             end)
 
           next = Range.size(internal_unroll) * step
+          gen_arg = {{index_param, generator_param}, arg}
           gen_body = {{Nx.add(index_param, next), generator_param}, body}
-          {_, result} = while(gen_initial, context, arg, condition, gen_body)
+          {_, result} = while(gen_initial, context, gen_arg, condition, gen_body)
           result
 
         nil ->


### PR DESCRIPTION
Currently jitting a while with generator (and no unroll) fails with EXLA, because the generator-specific params are not included as while arguments.