### PR TITLE
Fix dependency caching in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,8 @@ jobs:
         id: mix-cache # id to use in retrieve action
         with:
           path: deps
-          key: v1-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-${{ hashFiles('**/mix.lock') }}
+          key: v1-${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.otp }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: v1-${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.otp }}-mix-
       - name: Retrieve libtorch cache
         if: ${{ matrix.working_directory == 'torchx' }}
         uses: actions/cache@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/cache@v3
         id: mix-cache # id to use in retrieve action
         with:
-          path: deps
+          path: ${{ github.workspace }}/deps
           key: deps
       - name: Retrieve libtorch cache
         if: ${{ matrix.working_directory == 'torchx' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         id: mix-cache # id to use in retrieve action
         with:
           path: ${{ github.workspace }}/${{ matrix.working_directory }}/deps
-          key: ${{ runner.os }}-Elixir-v${{ matrix.elixir }}-OTP-${{ matrix.otp }}-backend-${{ matrix.working_directory }}
+          key: ${{ runner.os }}-Elixir-v${{ matrix.elixir }}-OTP-${{ matrix.otp }}-${{ hashFiles(format('{0}/{1}/mix.lock', github.workspace, matrix.working_directory)) }}
       - name: Retrieve libtorch cache
         if: ${{ matrix.working_directory == 'torchx' }}
         uses: actions/cache@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/cache@v3
         id: mix-cache # id to use in retrieve action
         with:
-          path: ${{ github.workspace }}/{{ matrix.working_directory }}/deps
+          path: ${{ github.workspace }}/${{ matrix.working_directory }}/deps
           key: deps
       - name: Retrieve libtorch cache
         if: ${{ matrix.working_directory == 'torchx' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/cache@v3
         id: mix-cache # id to use in retrieve action
         with:
-          path: ~/${matrix.working_directory}/deps
+          path: ~/${{ matrix.working_directory }}/deps
           key: ${{ runner.os }}-${{ matrix.elixir }}
           restore-keys: v1-${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.otp }}-mix-
       - name: Retrieve libtorch cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,8 @@ jobs:
         uses: actions/cache@v3
         id: mix-cache # id to use in retrieve action
         with:
-          path: ${{ github.workspace }}/deps
-          key: ${{ runner.os }}-${{ matrix.elixir }}
-          restore-keys: v1-${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.otp }}-mix-
+          path: deps
+          key: deps
       - name: Retrieve libtorch cache
         if: ${{ matrix.working_directory == 'torchx' }}
         uses: actions/cache@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/cache@v1
         id: mix-cache # id to use in retrieve action
         with:
-          path: ${{ matrix.working_directory }}/deps
+          path: deps
           key: ${{ runner.os }}-${{ matrix.elixir }}
           restore-keys: v1-${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.otp }}-mix-
       - name: Retrieve libtorch cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         id: mix-cache # id to use in retrieve action
         with:
           path: deps
-          key: v1-${{ matrix.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
+          key: v1-${{ matrix.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-${{ hashFiles('**/mix.lock') }}
       - name: Retrieve libtorch cache
         if: ${{ matrix.working_directory == 'torchx' }}
         uses: actions/cache@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/cache@v3
         id: mix-cache # id to use in retrieve action
         with:
-          path: ~/${{ matrix.working_directory }}/deps
+          path: ~/work/${{ matrix.working_directory }}/deps
           key: ${{ runner.os }}-${{ matrix.elixir }}
           restore-keys: v1-${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.otp }}-mix-
       - name: Retrieve libtorch cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/cache@v3
         id: mix-cache # id to use in retrieve action
         with:
-          path: ${{ github.workspace }}/deps
+          path: ${{ github.workspace }}/{{ matrix.working_directory }}/deps
           key: deps
       - name: Retrieve libtorch cache
         if: ${{ matrix.working_directory == 'torchx' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Retrieve dependencies cache
         env:
           cache-name: cache-mix-deps
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         id: mix-cache # id to use in retrieve action
         with:
           path: deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         id: mix-cache # id to use in retrieve action
         with:
           path: ${{ github.workspace }}/${{ matrix.working_directory }}/deps
-          key: deps
+          key: ${{ runner.os }}-Elixir-v${{ matrix.elixir }}-OTP-${{ matrix.otp }}-backend-${{ matrix.working_directory }}
       - name: Retrieve libtorch cache
         if: ${{ matrix.working_directory == 'torchx' }}
         uses: actions/cache@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,11 +81,13 @@ jobs:
           otp-version: ${{ matrix.otp }}
           elixir-version: ${{ matrix.elixir }}
       - name: Retrieve dependencies cache
-        uses: actions/cache@v1
+        env:
+          cache-name: cache-mix-deps
+        uses: actions/cache@v3
         id: mix-cache # id to use in retrieve action
         with:
-          path: deps
-          key: v1-${{ matrix.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
+          path: ${{ github.workspace }}\${{ matrix.working_directory }}\deps
+          key: ${{ runner.os }}-Elixir-v${{ matrix.elixir }}-OTP-${{ matrix.otp }}-${{ hashFiles(format('{0}\{1}\mix.lock', github.workspace, matrix.working_directory)) }}
       - name: Retrieve libtorch cache
         if: ${{ matrix.working_directory == 'torchx' }}
         uses: actions/cache@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     env:
       MIX_ENV: test
       XLA_FLAGS: --xla_force_host_platform_device_count=2
-      LIBTORCH_DIR: ./cache/libtorch
+      LIBTORCH_DIR: ${{ github.workspace }}/torchx/cache/libtorch
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1
@@ -40,7 +40,7 @@ jobs:
         uses: actions/cache@v3
         id: libtorch-cache
         with:
-          path: torchx/${{ env.LIBTORCH_DIR }}
+          path: ${{ env.LIBTORCH_DIR }}
           key: linux-v1-libtorch-cpu
       - name: Install dependencies
         if: ${{ steps.mix-cache.outputs.cache-hit != 'true' }}
@@ -67,7 +67,7 @@ jobs:
     env:
       MIX_ENV: test
       XLA_FLAGS: --xla_force_host_platform_device_count=2
-      LIBTORCH_DIR: ./cache/libtorch
+      LIBTORCH_DIR: ${{ github.workspace }}\torchx\cache\libtorch
     steps:
       - name: Configure Git
         run: git config --global core.autocrlf input
@@ -91,7 +91,7 @@ jobs:
         uses: actions/cache@v3
         id: libtorch-cache-win
         with:
-          path: torchx/${{ env.LIBTORCH_DIR }}
+          path: ${{ env.LIBTORCH_DIR }}
           key: win-v1-libtorch-cpu
       - name: Install dependencies
         if: ${{ steps.mix-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           key: ${{ runner.os }}-Elixir-v${{ matrix.elixir }}-OTP-${{ matrix.otp }}-${{ hashFiles(format('{0}/{1}/mix.lock', github.workspace, matrix.working_directory)) }}
       - name: Retrieve libtorch cache
         if: ${{ matrix.working_directory == 'torchx' }}
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         id: libtorch-cache
         with:
           path: torchx/${{ env.LIBTORCH_DIR }}
@@ -88,7 +88,7 @@ jobs:
           key: ${{ runner.os }}-Elixir-v${{ matrix.elixir }}-OTP-${{ matrix.otp }}-${{ hashFiles(format('{0}\{1}\mix.lock', github.workspace, matrix.working_directory)) }}
       - name: Retrieve libtorch cache
         if: ${{ matrix.working_directory == 'torchx' }}
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         id: libtorch-cache-win
         with:
           path: torchx/${{ env.LIBTORCH_DIR }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         id: mix-cache # id to use in retrieve action
         with:
           path: deps
-          key: v1-${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.otp }}-mix-${{ hashFiles('**/mix.lock') }}
+          key: ${{ runner.os }}
           restore-keys: v1-${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.otp }}-mix-
       - name: Retrieve libtorch cache
         if: ${{ matrix.working_directory == 'torchx' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,6 @@ jobs:
         run: mix format --check-formatted
       - name: Run tests
         run: mix test
-      - name: List file contents
-        run: pwd && ls -lah
 
   win:
     name: Windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         id: mix-cache # id to use in retrieve action
         with:
           path: deps
-          key: ${{ runner.os }}
+          key: ${{ runner.os }}-${{ matrix.elixir }}
           restore-keys: v1-${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.otp }}-mix-
       - name: Retrieve libtorch cache
         if: ${{ matrix.working_directory == 'torchx' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
       - name: Install dependencies
         if: ${{ steps.mix-cache.outputs.cache-hit != 'true' }}
         run: mix deps.get
+      - name: List file contents
+        run: ls -lah
       - name: Compile and check warnings
         run: mix compile --warnings-as-errors
       - name: Check formatting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         id: mix-cache # id to use in retrieve action
         with:
           path: deps
-          key: v1-${{ matrix.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-${{ hashFiles('**/mix.lock') }}
+          key: v1-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-${{ hashFiles('**/mix.lock') }}
       - name: Retrieve libtorch cache
         if: ${{ matrix.working_directory == 'torchx' }}
         uses: actions/cache@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/cache@v3
         id: mix-cache # id to use in retrieve action
         with:
-          path: deps
+          path: ~/${matrix.working_directory}/deps
           key: ${{ runner.os }}-${{ matrix.elixir }}
           restore-keys: v1-${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.otp }}-mix-
       - name: Retrieve libtorch cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,14 +46,15 @@ jobs:
       - name: Install dependencies
         if: ${{ steps.mix-cache.outputs.cache-hit != 'true' }}
         run: mix deps.get
-      - name: List file contents
-        run: ls -lah
       - name: Compile and check warnings
         run: mix compile --warnings-as-errors
       - name: Check formatting
         run: mix format --check-formatted
       - name: Run tests
         run: mix test
+      - name: List file contents
+        run: pwd && ls -lah
+
   win:
     name: Windows
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,12 @@ jobs:
           otp-version: ${{ matrix.otp }}
           elixir-version: ${{ matrix.elixir }}
       - name: Retrieve dependencies cache
+        env:
+          cache-name: cache-mix-deps
         uses: actions/cache@v1
         id: mix-cache # id to use in retrieve action
         with:
-          path: deps
+          path: ${{ matrix.working_directory }}/deps
           key: ${{ runner.os }}-${{ matrix.elixir }}
           restore-keys: v1-${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.otp }}-mix-
       - name: Retrieve libtorch cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/cache@v3
         id: mix-cache # id to use in retrieve action
         with:
-          path: ~/work/${{ matrix.working_directory }}/deps
+          path: ${{ github.workspace }}/deps
           key: ${{ runner.os }}-${{ matrix.elixir }}
           restore-keys: v1-${{ runner.os }}-${{ matrix.elixir }}-${{ matrix.otp }}-mix-
       - name: Retrieve libtorch cache


### PR DESCRIPTION
This commit fixes dependency caching by doing the following:

- Upgrading from cache@v1 to cache@v3
- Using a more verbose cache path
- Changing the key format to be a bit more clearer

Caching attempts were failing as result of an invalid path, which did not account for the change in working directory.
By using a more verbose path, this issue has been eliminated.

Closes #867