### PR TITLE
Unify defn arguments

### DIFF
--- a/exla/test/exla/backend_test.exs
+++ b/exla/test/exla/backend_test.exs
@@ -119,12 +119,13 @@ defmodule EXLA.BackendTest do
     # This is not really meant to work in practice,
     # but it does work with the Nx.BinaryBackend so
     # we make it work for EXLA too.
-    defn double(x \\ 0), do: double_transform(x)
+    defn double(fun), do: double_transform(fun.())
 
     deftransformp(double_transform(x), do: Nx.backend_transfer(Nx.Defn.Kernel.*(x, x)))
 
     test "invokes from within defn" do
-      assert double(Nx.tensor(11)) |> Nx.to_number() == 121
+      t = Nx.tensor(11)
+      assert double(fn -> t end) |> Nx.to_number() == 121
     end
   end
 

--- a/exla/test/exla/defn/expr_test.exs
+++ b/exla/test/exla/defn/expr_test.exs
@@ -4028,7 +4028,7 @@ defmodule EXLA.Defn.ExprTest do
   end
 
   describe "take_along_axis/3" do
-    defn take_along_axis(t, idx, axis \\ 0), do: Nx.take_along_axis(t, idx, axis: axis)
+    defn take_along_axis(t, idx, opts \\ [axis: 0]), do: Nx.take_along_axis(t, idx, opts)
 
     defn sort_with_take_along_axis(t, opts \\ []) do
       idx = Nx.argsort(t, opts)
@@ -4040,7 +4040,7 @@ defmodule EXLA.Defn.ExprTest do
       i = Nx.tensor([[[0, 1], [0, 1]], [[0, 1], [0, 1]], [[0, 1], [0, 1]]])
 
       assert_equal(
-        take_along_axis(t, i, 2),
+        take_along_axis(t, i, axis: 2),
         Nx.tensor([[[1, 2], [3, 4]], [[5, 6], [7, 8]], [[9, 10], [11, 12]]])
       )
     end
@@ -4056,7 +4056,7 @@ defmodule EXLA.Defn.ExprTest do
         ])
 
       assert_equal(
-        take_along_axis(t, i, 2),
+        take_along_axis(t, i, axis: 2),
         Nx.tensor([
           [[1, 2, 2, 1], [3, 4, 4, 3]],
           [[5, 6, 6, 5], [7, 8, 8, 7]],

--- a/nx/lib/nx/defn.ex
+++ b/nx/lib/nx/defn.ex
@@ -157,16 +157,21 @@ defmodule Nx.Defn do
   ## Inputs and outputs types
 
   `Nx` and `defn` expect the arguments to be numbers, tensors,
-  or one of the following composite data types:
+  or one composite data type that implements `Nx.LazyContainer`.
+  Tuples and maps implement `Nx.LazyContainer` by default.
+  As previously described, `defn` are cached based on the shape,
+  type, and names of the input tensors, but not their values.
 
-    1. tuples of numbers/tensors
-    2. maps of any key with numbers/tensors as values
-    3. any struct that implements `Nx.Container`
+  `defn` also accepts two special arguments: functions (or tuples
+  of functions) and lists (most commonly as keyword lists). Those
+  values are passed as is to numerical definitions and cached as
+  a whole. For this reason, you must never capture tensors in
+  functions or pass tensors in keyword lists.
 
   When numbers are given as arguments, they are always immediately
   converted to tensors on invocation. If you want to keep numbers
   as is or if you want to pass any other value to numerical definitions,
-  they must be given as default arguments (see next subsection).
+  they must be given as keyword lists.
 
   ### Default arguments
 
@@ -188,14 +193,11 @@ defmodule Nx.Defn do
   you have to use transforms, as described in the "Invoking custom Elixir
   code" section.
 
-  Additionally, `defn` supports anonymous as a direct input, without wrapping
-  in a default argument.
-
   > **Important!** When it comes to JIT compilation, each different set of
-  > options and anonymous functions will lead to a different compilation of
-  > the numerical function.
+  > options (as well as anonymous functions) will lead to a different
+  > compilation of the numerical function.
   >
-  > Furthermore, if tensors are given through default arguments, they won't
+  > Furthermore, if tensors are given through keyword lists, they won't
   > be cached effectively. Tensors in `defn` are cached based on their shape
   > and type, not their value, but this is not true if the tensor is given
   > via a default argument or captured by an anonymous function. For this
@@ -302,6 +304,14 @@ defmodule Nx.Defn do
       fun = Nx.Defn.compile(&softmax/1, [Nx.template({3}, {:s, 64})], compiler: EXLA)
       fun.(Nx.tensor([1, 2, 3]))
 
+  You can also pass a mixture of templates and options when
+  compiling a function. In such cases, you must only pass
+  the inputs when invoking the compiled function, as the options
+  will already be embedded in its compiled value:
+
+      fun = Nx.Defn.compile(&Nx.sum/2, [Nx.template({2, 2}, {:s, 64}), [axes: [1]]])
+      fun.(Nx.iota({2, 2}))
+
   If the input tensors do not match the shape of the tensors
   given on compilation, it will raise.
 
@@ -314,7 +324,7 @@ defmodule Nx.Defn do
   """
   def compile(fun, template_args, opts \\ [])
       when is_function(fun) and is_list(template_args) and is_list(opts) do
-    {params, _flatten} = Nx.Defn.Composite.to_lazy_params(template_args)
+    {fun, params, _flatten} = Nx.Defn.Compiler.to_lazy_params(fun, template_args)
     opts = prepare_options(opts)
     compiled_fun = Nx.Defn.Compiler.__compile__(fun, params, opts)
 
@@ -323,7 +333,7 @@ defmodule Nx.Defn do
         raise "cannot invoke compiled function when there is a JIT compilation happening"
       end
 
-      {templates, flatten} = Nx.Defn.Composite.to_lazy_template(args)
+      {templates, flatten} = Nx.Defn.Compiler.to_lazy_template(args)
       assert_compatible!(templates, params, 1)
       [res] = compiled_fun.([flatten])
       res
@@ -428,7 +438,7 @@ defmodule Nx.Defn do
 
   defp do_jit_apply(fun, args, opts) do
     opts = prepare_options(opts)
-    {params, flatten} = Nx.Defn.Composite.to_lazy_params(args)
+    {fun, params, flatten} = Nx.Defn.Compiler.to_lazy_params(fun, args)
     [res] = Nx.Defn.Compiler.__jit__(fun, params, [flatten], opts)
     res
   end
@@ -470,7 +480,7 @@ defmodule Nx.Defn do
   """
   def debug_expr_apply(fun, args, opts \\ []) when is_function(fun) and is_list(args) do
     opts = opts |> prepare_options() |> Keyword.put(:compiler, Nx.Defn.Debug)
-    {params, flatten} = Nx.Defn.Composite.to_lazy_params(args)
+    {fun, params, flatten} = Nx.Defn.Compiler.to_lazy_params(fun, args)
     [res] = Nx.Defn.Compiler.__jit__(fun, params, [flatten], opts)
     res
   end
@@ -536,7 +546,7 @@ defmodule Nx.Defn do
     end
 
     opts = prepare_options(opts)
-    {params, flatten} = Nx.Defn.Composite.to_lazy_params(args)
+    {fun, params, flatten} = Nx.Defn.Compiler.to_lazy_params(fun, args)
 
     case args do
       [_input, acc | _] ->
@@ -561,15 +571,7 @@ defmodule Nx.Defn do
 
   defp wrap(fun, callback) do
     {:arity, arity} = Function.info(fun, :arity)
-    wrap_arity(arity, callback)
-  end
-
-  for i <- 0..128 do
-    args = Macro.generate_arguments(i, __MODULE__)
-
-    defp wrap_arity(unquote(i), callback) do
-      fn unquote_splicing(args) -> callback.(unquote(args)) end
-    end
+    Nx.Defn.Compiler.fun(arity, callback)
   end
 
   @doc """

--- a/nx/lib/nx/defn.ex
+++ b/nx/lib/nx/defn.ex
@@ -800,7 +800,7 @@ defmodule Nx.Defn do
 
     defaults =
       for {{:\\, meta, [_, default]}, i} <- Enum.with_index(args),
-          do: {i, {meta, default}},
+          do: {i, {meta, Macro.escape(default)}},
           into: []
 
     quote do
@@ -826,9 +826,9 @@ defmodule Nx.Defn do
     arity = length(args)
 
     defaults =
-      for {{:\\, meta, [_, default]}, i} <- Enum.with_index(args), into: [] do
-        {i, {meta, default}}
-      end
+      for {{:\\, meta, [_, default]}, i} <- Enum.with_index(args),
+          do: {i, {meta, Macro.escape(default)}},
+          into: []
 
     define_ast =
       quote do

--- a/nx/lib/nx/defn/compiler.ex
+++ b/nx/lib/nx/defn/compiler.ex
@@ -30,7 +30,7 @@ defmodule Nx.Defn.Compiler do
               key :: term,
               vars :: [Nx.Container.t()],
               fun :: ([Nx.Container.t()] -> Nx.Container.t()),
-              args_list :: [[(() -> Nx.t())]],
+              args_list :: [[(-> Nx.t())]],
               opts :: keyword
             ) :: [Nx.Container.t()]
 
@@ -72,7 +72,7 @@ defmodule Nx.Defn.Compiler do
               acc,
               vars :: [Nx.t()],
               fun :: ([Nx.t()] -> {output, acc}),
-              args_list :: [[(() -> Nx.t())]],
+              args_list :: [[(-> Nx.t())]],
               opts :: keyword
             ) :: [Nx.Stream.t()]
             when input: Nx.Container.t(), output: Nx.Container.t(), acc: Nx.Container.t()
@@ -136,7 +136,7 @@ defmodule Nx.Defn.Compiler do
     try do
       fun
       |> apply(args)
-      |> Nx.Defn.Composite.to_output()
+      |> Nx.Defn.Composite.traverse(&Nx.Defn.Expr.tensor/1)
     after
       Nx.default_backend(tuple)
 
@@ -258,23 +258,6 @@ defmodule Nx.Defn.Compiler do
       end)
 
     all_args = Macro.generate_arguments(arity, __MODULE__)
-
-    fn_args =
-      for {arg, i} <- Enum.with_index(all_args),
-          not Map.has_key?(defaults, i),
-          do: arg
-
-    fun =
-      if defaults == [] do
-        quote do
-          &(unquote(Macro.var(defn_name, __MODULE__)) / unquote(arity))
-        end
-      else
-        quote do
-          fn unquote_splicing(fn_args) -> unquote(defn_name)(unquote_splicing(all_args)) end
-        end
-      end
-
     Module.delete_definition(state.module, def)
 
     entrypoint =
@@ -283,7 +266,10 @@ defmodule Nx.Defn.Compiler do
           if Process.get(Nx.Defn.Compiler) do
             unquote(defn_name)(unquote_splicing(all_args))
           else
-            Nx.Defn.Compiler.__runtime__(unquote(fun), unquote(fn_args))
+            Nx.Defn.Compiler.__runtime__(
+              &(unquote(Macro.var(defn_name, __MODULE__)) / unquote(arity)),
+              unquote(all_args)
+            )
           end
         end
       end
@@ -326,11 +312,9 @@ defmodule Nx.Defn.Compiler do
     {compiler, compiler_opts} =
       Keyword.pop(Nx.Defn.default_options(), :compiler, Nx.Defn.Evaluator)
 
-    {cache, split_args} = Nx.Defn.Composite.split_compile_args(args, fun)
-    {params, flatten} = Nx.Defn.Composite.to_lazy_params(split_args)
-    runtime_fun = &runtime_fun(Nx.Defn.Composite.join_compile_args(&1, args), fun, compiler)
-
-    [res] = compiler.__jit__(cache, params, runtime_fun, [flatten], compiler_opts)
+    {fun, params, flatten} = to_lazy_params(fun, args)
+    runtime_fun = &runtime_fun(&1, fun, compiler)
+    [res] = compiler.__jit__(fun, params, runtime_fun, [flatten], compiler_opts)
     res
   end
 
@@ -729,6 +713,60 @@ defmodule Nx.Defn.Compiler do
     end)
 
     :ok
+  end
+
+  ## Params manipulation
+
+  for i <- 0..128 do
+    args = Macro.generate_arguments(i, __MODULE__)
+
+    def fun(unquote(i), callback) do
+      fn unquote_splicing(args) -> callback.(unquote(args)) end
+    end
+  end
+
+  @doc false
+  def to_lazy_params(fun, args) do
+    {params, cache, {funs, _}} =
+      Enum.reduce(args, {[], [], {[], 0}}, fn
+        arg, {params, cache, acc}
+        when is_list(arg)
+        when is_function(arg)
+        when is_tuple(arg) and is_function(elem(arg, 0)) ->
+          {params, [arg | cache], acc}
+
+        container, {params, cache, acc} ->
+          {param, acc} =
+            Nx.LazyContainer.traverse(container, acc, fn template, fun, {acc, i} ->
+              {Nx.Defn.Expr.parameter(template, :root, i), {[fun | acc], i + 1}}
+            end)
+
+          {[param | params], [nil | cache], acc}
+      end)
+
+    if Enum.all?(cache, &is_nil/1) do
+      {fun, Enum.reverse(params), Enum.reverse(funs)}
+    else
+      cache = Enum.reverse(cache)
+      fun = fun(length(params), &apply(fun, merge_cache(cache, &1)))
+      {fun, Enum.reverse(params), Enum.reverse(funs)}
+    end
+  end
+
+  defp merge_cache([nil | cache], [head | tail]), do: [head | merge_cache(cache, tail)]
+  defp merge_cache([head | tail], params), do: [head | merge_cache(tail, params)]
+  defp merge_cache([], []), do: []
+
+  @doc false
+  def to_lazy_template(args) do
+    {template_args, funs} =
+      Enum.map_reduce(args, [], fn container, acc ->
+        Nx.LazyContainer.traverse(container, acc, fn template, fun, acc ->
+          {template, [fun | acc]}
+        end)
+      end)
+
+    {template_args, Enum.reverse(funs)}
   end
 
   ## Helpers

--- a/nx/lib/nx/defn/compiler.ex
+++ b/nx/lib/nx/defn/compiler.ex
@@ -30,7 +30,7 @@ defmodule Nx.Defn.Compiler do
               key :: term,
               vars :: [Nx.Container.t()],
               fun :: ([Nx.Container.t()] -> Nx.Container.t()),
-              args_list :: [[(-> Nx.t())]],
+              args_list :: [[(() -> Nx.t())]],
               opts :: keyword
             ) :: [Nx.Container.t()]
 
@@ -72,7 +72,7 @@ defmodule Nx.Defn.Compiler do
               acc,
               vars :: [Nx.t()],
               fun :: ([Nx.t()] -> {output, acc}),
-              args_list :: [[(-> Nx.t())]],
+              args_list :: [[(() -> Nx.t())]],
               opts :: keyword
             ) :: [Nx.Stream.t()]
             when input: Nx.Container.t(), output: Nx.Container.t(), acc: Nx.Container.t()

--- a/nx/lib/nx/lazy_container.ex
+++ b/nx/lib/nx/lazy_container.ex
@@ -36,7 +36,7 @@ defprotocol Nx.LazyContainer do
   be containers, you must call `Nx.LazyContainer.traverse/3`
   on said arguments so they are recursively traversed.
   """
-  @spec traverse(t(), acc, (Nx.template(), (-> Nx.Tensor.t()), acc -> {term(), acc})) :: acc
+  @spec traverse(t(), acc, (Nx.template(), (() -> Nx.Tensor.t()), acc -> {term(), acc})) :: acc
         when acc: term()
   def traverse(data, acc, fun)
 end

--- a/nx/lib/nx/lazy_container.ex
+++ b/nx/lib/nx/lazy_container.ex
@@ -36,7 +36,7 @@ defprotocol Nx.LazyContainer do
   be containers, you must call `Nx.LazyContainer.traverse/3`
   on said arguments so they are recursively traversed.
   """
-  @spec traverse(t(), acc, (Nx.template(), (() -> Nx.Tensor.t()), acc -> {term(), acc})) :: acc
+  @spec traverse(t(), acc, (Nx.template(), (-> Nx.Tensor.t()), acc -> {term(), acc})) :: acc
         when acc: term()
   def traverse(data, acc, fun)
 end

--- a/nx/test/nx/defn/grad_test.exs
+++ b/nx/test/nx/defn/grad_test.exs
@@ -3173,12 +3173,12 @@ defmodule Nx.Defn.GradTest do
   end
 
   describe "take" do
-    defn grad_sum_take(t, i, axis \\ 0) do
+    defn grad_sum_take(t, i, opts \\ [axis: 0]) do
       grad(
         t,
         fn t ->
           t
-          |> Nx.take(i, axis: axis)
+          |> Nx.take(i, opts)
           |> Nx.sum()
         end
       )
@@ -3307,7 +3307,7 @@ defmodule Nx.Defn.GradTest do
                      [[2], [1]]
                    ]
                  ]),
-                 1
+                 axis: 1
                )
     end
   end

--- a/nx/test/nx/defn_test.exs
+++ b/nx/test/nx/defn_test.exs
@@ -1972,6 +1972,12 @@ defmodule Nx.DefnTest do
       assert Nx.Defn.jit(&defn_jit(&1, 3)).({4, 5}) == Nx.tensor(6)
     end
 
+    @tag compiler: Evaluator
+    test "applies with options" do
+      fun = Nx.Defn.jit(&Nx.sum/2)
+      assert fun.(Nx.iota({2, 2}), axes: [1]) == Nx.tensor([1, 5])
+    end
+
     defn defn_jit_or_apply(ab, c),
       do: Nx.Defn.jit_apply(&defn_jit/2, [ab, c], on_conflict: :reuse)
 
@@ -2054,6 +2060,12 @@ defmodule Nx.DefnTest do
       fun = Nx.Defn.compile(&defn_compile(&1, 3), [{4, 5}])
       assert fun.({4, 5}) == Nx.tensor(6)
       assert fun.({40, 50}) == Nx.tensor(87)
+    end
+
+    @tag compiler: Evaluator
+    test "compiles defn function with options" do
+      fun = Nx.Defn.compile(&Nx.sum/2, [Nx.template({2, 2}, :s64), [axes: [1]]])
+      assert fun.(Nx.iota({2, 2})) == Nx.tensor([1, 5])
     end
 
     @tag compiler: Evaluator

--- a/nx/test/nx/defn_test.exs
+++ b/nx/test/nx/defn_test.exs
@@ -2158,6 +2158,7 @@ defmodule Nx.DefnTest do
   end
 
   describe "default arguments" do
+    defn id_default(empty \\ {}), do: empty
     defn sum_axis_opts(a, opts \\ []), do: Nx.sum(a, opts)
     defn local_calls_sum_axis_opts(a), do: sum_axis_opts(a)
     defn remote_calls_sum_axis_opts(a), do: __MODULE__.sum_axis_opts(a)
@@ -2167,6 +2168,13 @@ defmodule Nx.DefnTest do
       assert sum_axis_opts(Nx.tensor([[1, 2], [3, 4]])) == Nx.tensor(10)
       assert sum_axis_opts(Nx.tensor([[1, 2], [3, 4]]), axes: [0]) == Nx.tensor([4, 6])
       assert sum_axis_opts(Nx.tensor([[1, 2], [3, 4]]), axes: [1]) == Nx.tensor([3, 7])
+    end
+
+    @tag compiler: Evaluator
+    test "accept any valid defn value" do
+      assert id_default() == {}
+      assert id_default(1) == Nx.tensor(1)
+      assert id_default({1}) == {Nx.tensor(1)}
     end
 
     @tag compiler: Evaluator

--- a/nx/test/nx_test.exs
+++ b/nx/test/nx_test.exs
@@ -1942,9 +1942,13 @@ defmodule NxTest do
 
   describe "eye/2" do
     test "raises for non-square shape" do
-      assert_raise(ArgumentError, "eye/2 expects a square shape or an integer as argument, got: {2, 3}", fn ->
-        Nx.eye({2, 3})
-      end)
+      assert_raise(
+        ArgumentError,
+        "eye/2 expects a square shape or an integer as argument, got: {2, 3}",
+        fn ->
+          Nx.eye({2, 3})
+        end
+      )
     end
   end
 


### PR DESCRIPTION
Prior to this patch, `compile`/`jit` accepted only tensors while `defn` allowed functions and keyword lists as default arguments.

This PR unifies the approaches such that functions and lists are allowed in all APIs, regardless if a default argument or not.

This simplifies the implementation and makes the
process of compiling/jitting a `defn` simpler.