### PR TITLE
Fix Nx.{any,all} with :keep_axes on EXLA

### DIFF
--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -914,12 +914,12 @@ defmodule EXLA.Defn do
 
   ## to_operator reduction
 
-  defp to_operator(:all, [arg, opts], _ans, state) do
-    to_aggregate(:bitwise_and, {:pred, 8}, {}, arg, 1, opts, state)
+  defp to_operator(:all, [arg, opts], %{shape: shape}, state) do
+    to_aggregate(:bitwise_and, {:pred, 8}, shape, arg, 1, opts, state)
   end
 
-  defp to_operator(:any, [arg, opts], _ans, state) do
-    to_aggregate(:bitwise_or, {:pred, 8}, {}, arg, 0, opts, state)
+  defp to_operator(:any, [arg, opts], %{shape: shape}, state) do
+    to_aggregate(:bitwise_or, {:pred, 8}, shape, arg, 0, opts, state)
   end
 
   defp to_operator(:sum, [arg, opts], %{type: type, shape: shape}, state) do

--- a/exla/mix.exs
+++ b/exla/mix.exs
@@ -52,8 +52,8 @@ defmodule EXLA.MixProject do
 
   defp deps do
     [
-      {:nx, "~> 0.4.0"},
-      # {:nx, path: "../nx"},
+      # {:nx, "~> 0.4.0"},
+      {:nx, path: "../nx"},
       {:xla, "~> 0.3.0", runtime: false},
       {:elixir_make, "~> 0.6", runtime: false},
       {:benchee, "~> 1.0", only: :dev},

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -6192,6 +6192,18 @@ defmodule Nx do
         u8[x: 2]
         [0, 1]
       >
+
+  ### Keeping axes
+
+      iex> Nx.all(Nx.tensor([[-1, 0, 1], [2, 3, 4]], names: [:x, :y]), axes: [:y], keep_axes: true)
+      #Nx.Tensor<
+        u8[x: 2][y: 1]
+        [
+          [0],
+          [1]
+        ]
+      >
+
   """
   @doc type: :aggregation
   def all(tensor, opts \\ []) do
@@ -6232,6 +6244,18 @@ defmodule Nx do
         u8[x: 2]
         [1, 1]
       >
+
+  ### Keeping axes
+
+      iex> Nx.any(Nx.tensor([[0, 1, 0], [0, 1, 2]], names: [:x, :y]), axes: [:y], keep_axes: true)
+      #Nx.Tensor<
+        u8[x: 2][y: 1]
+        [
+          [1],
+          [1]
+        ]
+      >
+
   """
   @doc type: :aggregation
   def any(tensor, opts \\ []) do


### PR DESCRIPTION
Currently `:keep_axes` fails, because we always try to reshape to a scalar.