### PR TITLE
feat: send telemetry event after XLA compilation

### DIFF
--- a/exla/lib/exla.ex
+++ b/exla/lib/exla.ex
@@ -162,6 +162,18 @@ defmodule EXLA do
   Alternatively, you can pass the `--init` flag to `docker run`, so
   it runs an `init` inside the container that forwards signals and
   reaps processes.
+
+  ## Telemetry events
+
+  EXLA executes a telemetry event every time a function is JIT-compiled.
+  The events are named `[:exla, :compilation]` and include the following
+  measurements, given in microseconds:
+
+    * `:eval_time` - the time spent on turning the function into XLA
+      computation
+    * `:compile_time` - the time spent on compiling the XLA computation
+      into an executable
+    * `:total_time` - the sum of `:eval_time` and `:compile_time`
   """
 
   @behaviour Nx.Defn.Compiler

--- a/exla/mix.exs
+++ b/exla/mix.exs
@@ -54,6 +54,7 @@ defmodule EXLA.MixProject do
     [
       # {:nx, "~> 0.4.0"},
       {:nx, path: "../nx"},
+      {:telemetry, "~> 0.4.0 or ~> 1.0"},
       {:xla, "~> 0.3.0", runtime: false},
       {:elixir_make, "~> 0.6", runtime: false},
       {:benchee, "~> 1.0", only: :dev},

--- a/exla/mix.lock
+++ b/exla/mix.lock
@@ -11,5 +11,6 @@
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.3", "244836e6e3f1200c7f30cb56733fd808744eca61fd182f731eac4af635cc6d0b", [:mix], [], "hexpm", "c8d789e39b9131acf7b99291e93dae60ab48ef14a7ee9d58c6964f59efb570b0"},
   "nx": {:hex, :nx, "0.4.0", "2ec2cebec6a9ac8a3d5ae8ef79345cf92f37f9018d50817684e51e97b86f3d36", [:mix], [{:complex, "~> 0.4.2", [hex: :complex, repo: "hexpm", optional: false]}], "hexpm", "bab955768dadfe2208723fbffc9255341b023291f2aabcbd25bf98167dd3399e"},
   "statistex": {:hex, :statistex, "1.0.0", "f3dc93f3c0c6c92e5f291704cf62b99b553253d7969e9a5fa713e5481cd858a5", [:mix], [], "hexpm", "ff9d8bee7035028ab4742ff52fc80a2aa35cece833cf5319009b52f1b5a86c27"},
+  "telemetry": {:hex, :telemetry, "1.1.0", "a589817034a27eab11144ad24d5c0f9fab1f58173274b1e9bae7074af9cbee51", [:rebar3], [], "hexpm", "b727b2a1f75614774cff2d7565b64d0dfa5bd52ba517f16543e6fc7efcc0df48"},
   "xla": {:hex, :xla, "0.3.0", "7f40d3d799447bd745e6e61985c922821e355eca37c25754bac299d11f137f2e", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm", "0de304f5624ea2f2ae1afdcbd72d33855364be36fed2cc5de8d6d2ec8950926e"},
 }

--- a/exla/test/exla/defn/api_test.exs
+++ b/exla/test/exla/defn/api_test.exs
@@ -414,4 +414,54 @@ defmodule EXLA.Defn.APITest do
       refute_received _
     end
   end
+
+  describe "telemetry" do
+    defn telemetry_add_two(a, b), do: a + b
+
+    def telemetry_handler(_event_name, measurements, metadata, _config) do
+      send(self(), {measurements, metadata})
+    end
+
+    test "executes event when function is compiled" do
+      :ok =
+        :telemetry.attach(__MODULE__, [:exla, :compilation], &__MODULE__.telemetry_handler/4, nil)
+
+      on_exit(fn -> :telemetry.detach(__MODULE__) end)
+
+      fun = &telemetry_add_two/2
+      EXLA.jit(fun).(2, 3)
+      assert_received {measurements, metadata}
+
+      assert %{compile_time: compile_time, eval_time: eval_time, total_time: total_time} =
+               measurements
+
+      assert metadata == %{}
+
+      assert is_integer(compile_time)
+      assert eval_time > 0
+      assert is_integer(eval_time)
+      assert compile_time > 0
+      assert total_time == compile_time + eval_time
+
+      EXLA.jit(fun).(4, 5)
+      refute_received _
+
+      a = Nx.tensor([1, 2])
+      b = Nx.tensor([3, 4])
+      EXLA.jit(fun).(a, b)
+
+      assert_received {measurements, metadata}
+
+      assert %{compile_time: compile_time, eval_time: eval_time, total_time: total_time} =
+               measurements
+
+      assert metadata == %{}
+
+      assert is_integer(compile_time)
+      assert eval_time > 0
+      assert is_integer(eval_time)
+      assert compile_time > 0
+      assert total_time == compile_time + eval_time
+    end
+  end
 end


### PR DESCRIPTION
This commit adds telemetry events that are executed when EXLA compiles a function into an executable.

These events can be used to have observability into how many times functions are compiled and how long compiling them takes.

When a function is compiled, an event with name `[:exla, :compilation]`
is executed. The measurements include the following:
- `eval_time` - time it took to call the defn function that is compiled
- `compile_time` - time it took for XLA to compile the instructions into
an executable
- `total_time` - sum of `eval_time` and `compile_time`

This commit is related to the issue
https://github.com/elixir-nx/nx/issues/974