### PR TITLE
No loss of precision in `Nx.complex/2`

### DIFF
--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -5994,7 +5994,7 @@ defmodule Nx do
       Nx.Shared.raise_complex_not_supported("complex", 2)
     end
 
-    t = type(real) |> Nx.Type.merge(type(imag)) |> Nx.Type.to_complex
+    t = type(real) |> Nx.Type.merge(type(imag)) |> Nx.Type.to_complex()
 
     imag
     |> multiply(Nx.Constants.i(type: t))

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -5976,7 +5976,19 @@ defmodule Nx do
 
   ### Examples
 
-      iex> Nx.complex(Nx.tensor(1), Nx.tensor(2))
+      iex> Nx.complex(Nx.tensor(1, type: :f32), Nx.tensor(2, type: :f32))
+      #Nx.Tensor<
+        c64
+        1.0+2.0i
+      >
+
+      iex> Nx.complex(Nx.tensor(1, type: :f64), Nx.tensor(2, type: :f64))
+      #Nx.Tensor<
+        c128
+        1.0+2.0i
+      >
+
+      iex> Nx.complex(Nx.tensor(1, type: :f32), Nx.tensor(2, type: :f64))
       #Nx.Tensor<
         c64
         1.0+2.0i
@@ -5984,7 +5996,7 @@ defmodule Nx do
 
       iex> Nx.complex(Nx.tensor([1, 2]), Nx.tensor([3, 4]))
       #Nx.Tensor<
-        c64[2]
+        c128[2]
         [1.0+3.0i, 2.0+4.0i]
       >
   """
@@ -5994,8 +6006,12 @@ defmodule Nx do
       Nx.Shared.raise_complex_not_supported("complex", 2)
     end
 
+    {_, realprecision} = type(real)
+    {_, imagprecision} = type(imag)
+    precision = Kernel.max(64, Kernel.min(realprecision, imagprecision) * 2)
+
     imag
-    |> multiply(Nx.Constants.i())
+    |> multiply(Nx.Constants.i(type: {:c, precision}))
     |> add(real)
   end
 

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -5976,19 +5976,7 @@ defmodule Nx do
 
   ### Examples
 
-      iex> Nx.complex(Nx.tensor(1, type: :f32), Nx.tensor(2, type: :f32))
-      #Nx.Tensor<
-        c64
-        1.0+2.0i
-      >
-
-      iex> Nx.complex(Nx.tensor(1, type: :f64), Nx.tensor(2, type: :f64))
-      #Nx.Tensor<
-        c128
-        1.0+2.0i
-      >
-
-      iex> Nx.complex(Nx.tensor(1, type: :f32), Nx.tensor(2, type: :f64))
+      iex> Nx.complex(Nx.tensor(1), Nx.tensor(2))
       #Nx.Tensor<
         c64
         1.0+2.0i
@@ -5996,7 +5984,7 @@ defmodule Nx do
 
       iex> Nx.complex(Nx.tensor([1, 2]), Nx.tensor([3, 4]))
       #Nx.Tensor<
-        c128[2]
+        c64[2]
         [1.0+3.0i, 2.0+4.0i]
       >
   """
@@ -6006,12 +5994,10 @@ defmodule Nx do
       Nx.Shared.raise_complex_not_supported("complex", 2)
     end
 
-    {_, realprecision} = type(real)
-    {_, imagprecision} = type(imag)
-    precision = Kernel.max(64, Kernel.min(realprecision, imagprecision) * 2)
+    t = type(real) |> Nx.Type.merge(type(imag)) |> Nx.Type.to_complex
 
     imag
-    |> multiply(Nx.Constants.i(type: {:c, precision}))
+    |> multiply(Nx.Constants.i(type: t))
     |> add(real)
   end
 

--- a/nx/test/nx/defn_test.exs
+++ b/nx/test/nx/defn_test.exs
@@ -1435,10 +1435,10 @@ defmodule Nx.DefnTest do
       assert inspect(t) ==
                """
                #Nx.Tensor<
-                 c64\n\s\s
+                 c128\n\s\s
                  Nx.Defn.Expr
                  parameter a:0         s64
-                 b = add 0.0+2.0i, a   c64
+                 b = add 0.0+2.0i, a   c128
                >
                """
                |> String.trim()

--- a/nx/test/nx/defn_test.exs
+++ b/nx/test/nx/defn_test.exs
@@ -1435,10 +1435,10 @@ defmodule Nx.DefnTest do
       assert inspect(t) ==
                """
                #Nx.Tensor<
-                 c128\n\s\s
+                 c64\n\s\s
                  Nx.Defn.Expr
                  parameter a:0         s64
-                 b = add 0.0+2.0i, a   c128
+                 b = add 0.0+2.0i, a   c64
                >
                """
                |> String.trim()

--- a/nx/test/nx_test.exs
+++ b/nx/test/nx_test.exs
@@ -2352,6 +2352,9 @@ defmodule NxTest do
   end
 
   describe "complex/2" do
+    @t32 Nx.tensor(1, type: :f32)
+    @t64 Nx.tensor(2, type: :f64)
+
     test "preserves precision of real and imaginary parts" do
       t = Nx.tensor(Complex.new(1, 2), type: :c128)
       c = Nx.complex(Nx.real(t), Nx.imag(t))
@@ -2360,6 +2363,19 @@ defmodule NxTest do
       t = Nx.tensor(Complex.new(1, 3), type: :c64)
       c = Nx.complex(Nx.real(t), Nx.imag(t))
       assert Nx.type(c) == {:c, 64}
+    end
+
+    test "returns a tensor with type :c128 for 64 bit inputs" do
+      t = Nx.complex(@t64, @t64)
+      assert Nx.type(t) == {:c, 128}
+    end
+
+    test "returns a tensor with type :c128 for mixed 32 and 64 bit inputs" do
+      t = Nx.complex(@t32, @t64)
+      assert Nx.type(t) == {:c, 128}
+
+      t = Nx.complex(@t64, @t32)
+      assert Nx.type(t) == {:c, 128}
     end
   end
 end

--- a/nx/test/nx_test.exs
+++ b/nx/test/nx_test.exs
@@ -2350,4 +2350,16 @@ defmodule NxTest do
                Nx.tensor([[[5], [6]], [[3], [6]]])
     end
   end
+
+  describe "complex/2" do
+    test "preserves precision of real and imaginary parts" do
+      t = Nx.tensor(Complex.new(1, 2), type: :c128)
+      c = Nx.complex(Nx.real(t), Nx.imag(t))
+      assert Nx.type(c) == {:c, 128}
+
+      t = Nx.tensor(Complex.new(1, 3), type: :c64)
+      c = Nx.complex(Nx.real(t), Nx.imag(t))
+      assert Nx.type(c) == {:c, 64}
+    end
+  end
 end


### PR DESCRIPTION
Ensures that the returned tensor has the same precision for its real and imaginary parts as the lowest precision input by checking precision of inputs, and passing the correct type (`:c64` or `:c128`) to `Nx.Constants.i/1`.

Closes #979 