### PR TITLE
Differentiate between complex and real output in binary backend `as_type`

### DIFF
--- a/nx/lib/nx/binary_backend.ex
+++ b/nx/lib/nx/binary_backend.ex
@@ -2137,6 +2137,7 @@ defmodule Nx.BinaryBackend do
 
       %T{type: input_type} ->
         float_output? = Nx.Type.float?(output_type)
+        real_output? = not Nx.Type.complex?(output_type)
         data = to_binary(tensor)
 
         output_data =
@@ -2145,7 +2146,7 @@ defmodule Nx.BinaryBackend do
               x = read!(x, 0)
 
               case x do
-                %Complex{re: re} when float_output? ->
+                %Complex{re: re} when float_output? and real_output? ->
                   number_to_binary(re, output_type)
 
                 _ when float_output? ->

--- a/nx/lib/nx/type.ex
+++ b/nx/lib/nx/type.ex
@@ -544,6 +544,19 @@ defmodule Nx.Type do
   def float?({_, _}), do: false
 
   @doc """
+  Returns true if the type is a complex number.
+
+  ## Examples
+
+      iex> Nx.Type.complex?({:c, 64})
+      true
+      iex> Nx.Type.complex?({:f, 64})
+      false
+  """
+  def complex?({:c, _}), do: true
+  def complex?({_, _}), do: false
+
+  @doc """
   Returns a string representation of the given type.
 
   ## Examples

--- a/nx/test/nx_test.exs
+++ b/nx/test/nx_test.exs
@@ -2378,4 +2378,14 @@ defmodule NxTest do
       assert Nx.type(t) == {:c, 128}
     end
   end
+
+  describe "as_type/2" do
+    test "preserves the imaginary part when casting between :c68 and :c128" do
+      t64 = Nx.tensor(Complex.new(1, 2), type: :c64)
+      t128 = Nx.tensor(Complex.new(1, 2), type: :c128)
+
+      assert Nx.as_type(t128, :c64) == t64
+      assert Nx.as_type(t64, :c128) == t128
+    end
+  end
 end


### PR DESCRIPTION
Because complex types are considered floats by `Nx.Type.float?/1` the binary backend's implementation of as_type does not preserve the imaginary part of a complex number when casting between :c64 and :c128.

This addresses that error by introducing a new function `Nx.Type.complex?/1` that is used to determine if the output of `as_type/1` should include just the real part of the input.

I considered modifying `Nx.Type.float?/1` to return `false` for complex types. This seems reasonable given the docs which say "is a float in elixir" and complex is a struct. However, this change produces a substantial number of errors in other tests. In the interest of keeping changes to a minimum, I added the `complex?` function and modified the binary backend's `as_type` implementation to check whether the output is real when removing the imaginary part of a complex input.

Closes #983 