### PR TITLE
Fix shortcut atom notation example

### DIFF
--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -58,7 +58,7 @@ defmodule Nx do
 
   The types are tracked as tuples:
 
-      iex> Nx.tensor([1, 2, 3], type: :f32)
+      iex> Nx.tensor([1, 2, 3], type: {:f, 32})
       #Nx.Tensor<
         f32[3]
         [1.0, 2.0, 3.0]


### PR DESCRIPTION
The [documentation](https://github.com/elixir-nx/nx/blob/main/nx/lib/nx.ex#L51-L74) has two code snippets in a row that are the same:
```elixir
Nx.tensor([1, 2, 3], type: :f32)
#Nx.Tensor<
  f32[3]
  [1.0, 2.0, 3.0]
>
```

The first snippet should read
```elixir
Nx.tensor([1, 2, 3], type: {:f, 32})
#Nx.Tensor<
  f32[3]
  [1.0, 2.0, 3.0]
>
```

because the second is intended to highly the "shortcut atom notation." If both snippets use the shortcut there is no contrast. 