### PR TITLE
feat: use types exported from tsl insted of tensorflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,14 +75,14 @@ jobs:
         working-directory: .
       - uses: actions/checkout@v2
       - uses: ilammy/msvc-dev-cmd@v1
+      - uses: microsoft/setup-msbuild@v1.1
+        with:
+          vs-version: '14.34'
+          msbuild-architecture: ${{ matrix.target_platforms }}
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ matrix.otp }}
           elixir-version: ${{ matrix.elixir }}
-      - name: Setup Virtual Studio
-        run: cmd /K "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" $env:target_platform
-        env:
-          target_platform: ${{ matrix.target_platforms }}
       - name: Retrieve dependencies cache
         env:
           cache-name: cache-mix-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
         working_directory: ["nx", "torchx"]
         elixir: ["1.14.2"]
         otp: ["24.0"]
+        target_platforms: [x64]
     defaults:
       run:
         working-directory: ${{ matrix.working_directory }}
@@ -78,6 +79,10 @@ jobs:
         with:
           otp-version: ${{ matrix.otp }}
           elixir-version: ${{ matrix.elixir }}
+      - name: Setup Virtual Studio
+        run: cmd /K "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" $env:target_platform
+        env:
+          target_platform: ${{ matrix.target_platforms }}
       - name: Retrieve dependencies cache
         env:
           cache-name: cache-mix-deps

--- a/exla/c_src/exla/exla.cc
+++ b/exla/c_src/exla/exla.cc
@@ -2128,7 +2128,7 @@ ERL_NIF_TERM transfer_from_outfeed(ErlNifEnv* env, int argc, const ERL_NIF_TERM 
       return exla::nif::error(env, statusor.status().error_message().c_str());
     }
 
-    ERL_NIF_TERM msg = std::move(statusor.ValueOrDie());
+    ERL_NIF_TERM msg = std::move(statusor.value());
 
     if(!enif_send(env, &pid, penv, enif_make_tuple(penv, 2, ref, msg))) {
       enif_clear_env(penv);

--- a/exla/c_src/exla/exla_client.cc
+++ b/exla/c_src/exla/exla_client.cc
@@ -30,7 +30,7 @@ xla::Status ExlaBuffer::Deallocate() {
   }
   else {
     buffer_->Delete();
-    return xla::Status::OK();
+    return tsl::OkStatus();
   }
 }
 

--- a/exla/c_src/exla/exla_nif_util.h
+++ b/exla/c_src/exla/exla_nif_util.h
@@ -49,16 +49,16 @@ namespace exla {
 // however, some methods require a 64-bit integer. You should prefer standard
 // types over these unless you are (1) working with computations, or
 // (2) require a non-standard width numeric type (like 64-bit integer).
-using int8 = tensorflow::int8;
-using int16 = tensorflow::int16;
-using int32 = tensorflow::int32;
-using int64 = tensorflow::int64;
-using uint8 = tensorflow::uint8;
-using uint16 = tensorflow::uint16;
-using uint32 = tensorflow::uint32;
-using uint64 = tensorflow::uint64;
+using int8 = tsl::int8;
+using int16 = tsl::int16;
+using int32 = tsl::int32;
+using int64 = tsl::int64;
+using uint8 = tsl::uint8;
+using uint16 = tsl::uint16;
+using uint32 = tsl::uint32;
+using uint64 = tsl::uint64;
 using float16 = Eigen::half;
-using bfloat16 = tensorflow::bfloat16;
+using bfloat16 = tsl::bfloat16;
 using float32 = float;
 using float64 = double;
 using complex64 = std::complex<float>;


### PR DESCRIPTION
I'm trying to run NX with ROCM support, with the help of @seanmor5, but after some tries, we got into some missing types error, probably this should fix the problem.
ref: https://github.com/elixir-nx/xla/issues/29