### PR TITLE
fix windows build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
 
   win:
     name: Windows
-    runs-on: windows-latest
+    runs-on: windows-2019
     strategy:
       fail-fast: false
       matrix:
@@ -74,6 +74,10 @@ jobs:
         working-directory: .
       - uses: actions/checkout@v2
       - uses: ilammy/msvc-dev-cmd@v1
+        with:
+          toolset: 14.2
+          vsversion: 2019
+          arch: x64
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ matrix.otp }}


### PR DESCRIPTION
Apparently there's some strange relationship between the windows version of runner and the vs build tools version.
this [issue](https://github.com/SCons/scons/issues/3664) helps me to figure out what version is necessary to use
