### PR TITLE
Cache libexla.so across builds

### DIFF
--- a/exla/mix.exs
+++ b/exla/mix.exs
@@ -132,7 +132,10 @@ defmodule EXLA.MixProject do
           {:ok, contents} <- [File.read(path)],
           do: contents
 
-    md5 = [XLA.archive_path!() | contents] |> :erlang.md5() |> Base.encode32(padding: false, case: :lower)
+    md5 =
+      [XLA.archive_path!() | contents]
+      |> :erlang.md5()
+      |> Base.encode32(padding: false, case: :lower)
 
     cache_key =
       "elixir-#{System.version()}-erts-#{:erlang.system_info(:version)}-xla-#{Application.spec(:xla, :vsn)}-exla-#{@version}-#{md5}"

--- a/exla/mix.exs
+++ b/exla/mix.exs
@@ -137,7 +137,7 @@ defmodule EXLA.MixProject do
     cache_key =
       "elixir-#{System.version()}-erts-#{:erlang.system_info(:version)}-xla-#{Application.spec(:xla, :vsn)}-exla-#{@version}-#{md5}"
 
-    cached_so = Path.join([xla_cache_dir(), cache_key, "libexla.so"])
+    cached_so = Path.join([xla_cache_dir(), "exla", cache_key, "libexla.so"])
     cached? = File.exists?(cached_so)
 
     if cached? do

--- a/exla/mix.exs
+++ b/exla/mix.exs
@@ -21,9 +21,10 @@ defmodule EXLA.MixProject do
         docs: :docs,
         "hex.publish": :docs
       ],
-      compilers: [:exla, :elixir_make] ++ Mix.compilers(),
+      compilers: [:extract_xla, :cached_make] ++ Mix.compilers(),
       aliases: [
-        "compile.exla": &compile/1
+        "compile.extract_xla": &extract_xla/1,
+        "compile.cached_make": &cached_make/1
       ],
       make_env: %{
         "MIX_BUILD_EMBEDDED" => "#{Mix.Project.config()[:build_embedded]}"
@@ -101,7 +102,7 @@ defmodule EXLA.MixProject do
   # We keep track of the current XLA archive path in xla_snapshot.txt.
   # Whenever the path changes, we extract it again and Makefile picks
   # up this change
-  defp compile(_) do
+  defp extract_xla(_) do
     xla_archive_path = XLA.archive_path!()
 
     cache_dir = Path.join(__DIR__, "cache")
@@ -114,17 +115,54 @@ defmodule EXLA.MixProject do
 
       _ ->
         File.rm_rf!(xla_extension_path)
-
         Mix.shell().info("Unpacking #{xla_archive_path} into #{cache_dir}")
 
         case :erl_tar.extract(xla_archive_path, [:compressed, cwd: cache_dir]) do
-          :ok -> :ok
+          :ok -> File.write!(xla_snapshot_path, xla_archive_path)
           {:error, term} -> Mix.raise("failed to extract xla archive, reason: #{inspect(term)}")
         end
-
-        File.write!(xla_snapshot_path, xla_archive_path)
     end
 
     {:ok, []}
+  end
+
+  defp cached_make(_) do
+    contents =
+      for path <- Path.wildcard("c_src/**/*"),
+          {:ok, contents} <- [File.read(path)],
+          do: contents
+
+    md5 = [XLA.archive_path!() | contents] |> :erlang.md5() |> Base.encode16()
+
+    cache_key =
+      "elixir-#{System.version()}-erts-#{:erlang.system_info(:version)}-xla-#{Application.spec(:xla, :vsn)}-exla-#{@version}-#{md5}"
+
+    cached_so = Path.join([xla_cache_dir(), cache_key, "libexla.so"])
+    cached? = File.exists?(cached_so)
+
+    if cached? do
+      Mix.shell().info("Using libexla.so from #{cached_so}")
+      File.cp!(cached_so, "cache/libexla.so")
+      Mix.Tasks.Compile.ElixirMake.run([])
+    end
+
+    result = Mix.Tasks.Compile.ElixirMake.run([])
+
+    if not cached? and match?({:ok, _}, result) do
+      Mix.shell().info("Caching libexla.so at #{cached_so}")
+      File.mkdir_p!(Path.dirname(cached_so))
+      File.cp!("cache/libexla.so", cached_so)
+    end
+
+    result
+  end
+
+  defp xla_cache_dir() do
+    # The directory where we store all the archives
+    if dir = System.get_env("XLA_CACHE_DIR") do
+      Path.expand(dir)
+    else
+      :filename.basedir(:user_cache, "xla")
+    end
   end
 end

--- a/exla/mix.exs
+++ b/exla/mix.exs
@@ -132,7 +132,7 @@ defmodule EXLA.MixProject do
           {:ok, contents} <- [File.read(path)],
           do: contents
 
-    md5 = [XLA.archive_path!() | contents] |> :erlang.md5() |> Base.encode16()
+    md5 = [XLA.archive_path!() | contents] |> :erlang.md5() |> Base.encode32(padding: false, case: :lower)
 
     cache_key =
       "elixir-#{System.version()}-erts-#{:erlang.system_info(:version)}-xla-#{Application.spec(:xla, :vsn)}-exla-#{@version}-#{md5}"

--- a/exla/mix.exs
+++ b/exla/mix.exs
@@ -143,7 +143,6 @@ defmodule EXLA.MixProject do
     if cached? do
       Mix.shell().info("Using libexla.so from #{cached_so}")
       File.cp!(cached_so, "cache/libexla.so")
-      Mix.Tasks.Compile.ElixirMake.run([])
     end
 
     result = Mix.Tasks.Compile.ElixirMake.run([])


### PR DESCRIPTION
Currently, every variation of Mix.install/2 has to compile EXLA from scratch. This PR builds a cache for the operating system, ensuring a given elixir-erlang-xla-exla is only compiled once.

@jonatanklosko please let me know if you find any issues with the cache key.