### PR TITLE
fix(BinaryBackend): pad

### DIFF
--- a/nx/config/config.exs
+++ b/nx/config/config.exs
@@ -1,6 +1,7 @@
 import Config
 
-# This is a compile time config. We want this off by default
-# but since config files are not imported, it is only set to
+# These are compile time configs. We want them off by default
+# but since config files are not imported, they are only set to
 # true inside Nx.
 config :nx, :verify_grad, true
+config :nx, :verify_binary_size, true


### PR DESCRIPTION
The new check for byte_size revealed the bug with BinaryBackend's pad.
I've made it so the check is only compiled for Nx development.