### PR TITLE
docs(nx): specify return values for stateful operations

### DIFF
--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -3411,6 +3411,8 @@ defmodule Nx do
   Or use `Nx.global_default_backend/1` as it changes the
   default backend on all processes.
 
+  The function returns the value that was previously set as backend.
+
   ## Examples
 
       iex> Nx.default_backend({EXLA.Backend, device: :cuda})
@@ -3446,6 +3448,7 @@ defmodule Nx do
         config: [nx: [default_backend: {EXLA.Backend, device: :cuda}]]
       )
 
+  The function returns the value that was previously set as global backend.
   """
   @doc type: :backend
   def global_default_backend(backend) do

--- a/nx/lib/nx/defn.ex
+++ b/nx/lib/nx/defn.ex
@@ -253,6 +253,15 @@ defmodule Nx.Defn do
 
         config :nx, :#{@app_key}, [compiler: EXLA, client: :cuda]
 
+  The function returns the values that were previously set as default
+  options.
+
+  ## Examples
+
+      iex> Nx.Defn.default_options(compiler: EXLA, client: :cuda)
+      []
+      iex> Nx.Defn.default_options()
+      [compiler: EXLA, client: :cuda]
   """
   def default_options(options) when is_list(options) do
     Process.put(@compiler_key, options) || Application.fetch_env!(:nx, @app_key)
@@ -272,6 +281,8 @@ defmodule Nx.Defn do
 
       config :nx, :#{@app_key}, [compiler: EXLA, client: :cuda]
 
+  The function returns the values that were previously set as global
+  default options.
   """
   def global_default_options(options) when is_list(options) do
     current = Application.fetch_env!(:nx, @app_key)

--- a/nx/lib/nx/defn.ex
+++ b/nx/lib/nx/defn.ex
@@ -259,7 +259,6 @@ defmodule Nx.Defn do
   ## Examples
 
       iex> Nx.Defn.default_options(compiler: EXLA, client: :cuda)
-      []
       iex> Nx.Defn.default_options()
       [compiler: EXLA, client: :cuda]
   """


### PR DESCRIPTION
Hey 👋 
this tiny PR is the follow-up on this comment https://github.com/elixir-nx/axon/issues/416#issuecomment-1346634166

It updates the docs for `Nx.default_backend/1`, `Nx.Defn.default_options/1` and their corresponding "global" version to highlight that the returned value is the one that was previously set (and not the updated one).

Plus, I added a doctest for the `Nx.Defn.default_options/1` analogously to the one in the `Nx.default_backend/1` docs.

Let me know if it is clear enough or if I can improve anything.

To conclude, I don't know if you follow any specific convention regarding PR titles, commits, etc. so feel free to change everything  as you wish :)

You are great!

Best,
Nicolò