### PR TITLE
Respect default EXLA.Backend client when jitting argumentless operations

### DIFF
--- a/exla/lib/exla/backend.ex
+++ b/exla/lib/exla/backend.ex
@@ -319,6 +319,15 @@ defmodule EXLA.Backend do
           client_name
       end
 
-    EXLA.jit_apply(fun, args, on_conflict: :force, client: client || EXLA.Client.default_name())
+    default_backend_client =
+      case Nx.default_backend() do
+        {EXLA.Backend, opts} -> opts[:client]
+        _ -> nil
+      end
+
+    EXLA.jit_apply(fun, args,
+      on_conflict: :force,
+      client: client || default_backend_client || EXLA.Client.default_name()
+    )
   end
 end


### PR DESCRIPTION
Given

```elixir
Mix.install(
  [
    {:nx, path: "~/git/nx/nx", override: true},
    {:exla, path: "~/git/nx/exla", override: true}
  ],
  config: [
    exla: [
      clients: [
        host1: [platform: :host],
        host2: [platform: :host]
      ],
      preferred_clients: [:host2]
    ]
  ]
)

Nx.default_backend({EXLA.Backend, client: :host1})
```

This gets allocated on `:host1` as expected, because we respect the default backend and options:

```elixir
Nx.tensor([1])
```

However, this gets allocated on `:host2`:

```elixir
Nx.iota({10})
```

Because we fallback to `EXLA.Client.default_name()` when jitting. This PR changes it such that we respect the default backend options instead.