### PR TITLE
TorchX - Use symbolic link to library if ENV is not set

### DIFF
--- a/exla/Makefile
+++ b/exla/Makefile
@@ -16,6 +16,10 @@ PRIV_DIR = $(MIX_APP_PATH)/priv
 EXLA_SO = $(PRIV_DIR)/libexla.so
 EXLA_LIB_DIR = $(PRIV_DIR)/lib
 
+# Link paths
+XLA_EXTENSION_LIB_LINK_PATH = $(CWD_RELATIVE_TO_PRIV_PATH)/$(XLA_EXTENSION_LIB)
+EXLA_CACHE_SO_LINK_PATH = $(CWD_RELATIVE_TO_PRIV_PATH)/$(EXLA_CACHE_SO)
+
 # Build flags
 CFLAGS = -fPIC -I$(ERTS_INCLUDE_DIR) -I$(XLA_INCLUDE_PATH) -O3 -Wall -Wno-sign-compare \
 	 -Wno-unused-parameter -Wno-missing-field-initializers -Wno-comment \
@@ -37,9 +41,6 @@ else
 	LDFLAGS += -Wl,-rpath,'$$ORIGIN/lib'
 	POST_INSTALL = $(NOOP)
 endif
-
-XLA_EXTENSION_LIB_LINK_PATH = $(CWD_RELATIVE_TO_PRIV_PATH)/$(XLA_EXTENSION_LIB)
-EXLA_CACHE_SO_LINK_PATH = $(CWD_RELATIVE_TO_PRIV_PATH)/$(EXLA_CACHE_SO)
 
 $(EXLA_SO): $(EXLA_CACHE_SO)
 	@ mkdir -p $(PRIV_DIR)

--- a/torchx/Makefile
+++ b/torchx/Makefile
@@ -28,7 +28,7 @@ $(TORCHX_SO): c_src/torchx.cpp c_src/nx_nif_utils.hpp
 	@ if [ "${MIX_BUILD_EMBEDDED}" = "true" ]; then \
 		cp -a $(abspath $(LIBTORCH_DIR)/lib) $(PRIV_DIR)/$(LIBTORCH_BASE) ; \
 	else \
-		ln -sf $(abspath $(LIBTORCH_DIR)/lib) $(PRIV_DIR)/$(LIBTORCH_BASE) ; \
+		ln -sf $(LIBTORCH_LINK) $(PRIV_DIR)/$(LIBTORCH_BASE) ; \
 	fi
 	@ cd $(CMAKE_BUILD_DIR) && \
 		cmake -DCMAKE_PREFIX_PATH=$(LIBTORCH_DIR) -DC_SRC=$(C_SRC) \

--- a/torchx/mix.exs
+++ b/torchx/mix.exs
@@ -38,13 +38,13 @@ defmodule Torchx.MixProject do
       aliases: aliases(),
       make_env: fn ->
         priv_path = Path.join(Mix.Project.app_path(), "priv")
-        libtorch_link_path = @libtorch_env_dir || relative_to("#{@libtorch_dir}/lib", priv_path)
+        libtorch_link_path = @libtorch_env_dir || relative_to(@libtorch_dir, priv_path)
 
         %{
           "LIBTORCH_DIR" => @libtorch_dir,
           "LIBTORCH_BASE" => @libtorch_base,
           "MIX_BUILD_EMBEDDED" => "#{Mix.Project.config()[:build_embedded]}",
-          "LIBTORCH_LINK" => libtorch_link_path
+          "LIBTORCH_LINK" => "#{libtorch_link_path}/lib"
         }
       end
     ]


### PR DESCRIPTION
Uses the same idea as in #1067, but doesn't create symlink if the Torch location was set in the `LIBTORCH_DIR` env.