### PR TITLE
feat: matrix_rank

### DIFF
--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -1806,6 +1806,7 @@ defmodule Nx.LinAlg do
     opts = keyword!(opts, eps: 1.0e-10)
     shape = Nx.shape(a)
     size = Nx.rank(shape)
+
     if size <= 1 do
       raise(
         ArgumentError,

--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -1763,9 +1763,14 @@ defmodule Nx.LinAlg do
   @doc """
   Return matrix rank of input M × N matrix using Singular Value Decomposition method.
 
-  Approximate the number of linearly independent rows by calculating the number of singular values greater than `eps * max(singular values) * max(M, N)`.
-  This also appears in Numerical recipes in the discussion of SVD solutions for linear least squares [1].
-  [1] W. H. Press, S. A. Teukolsky, W. T. Vetterling and B. P. Flannery, “Numerical Recipes (3rd edition)”, Cambridge University Press, 2007, page 795.
+  Approximate the number of linearly independent rows by calculating the number
+  of singular values greater than `eps * max(singular values) * max(M, N)`.
+
+  This also appears in Numerical recipes in the discussion of SVD solutions for
+  linear least squares [1].
+
+  [1] W. H. Press, S. A. Teukolsky, W. T. Vetterling and B. P. Flannery,
+  “Numerical Recipes (3rd edition)”, Cambridge University Press, 2007, page 795.
 
   ## Options
     * `:eps` - Rounding error threshold used to assume values as 0. Defaults to `1.0e-10`

--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -1759,4 +1759,63 @@ defmodule Nx.LinAlg do
     |> Nx.take_diagonal(offset: offset)
     |> Nx.product(axes: [rank - 2])
   end
+
+  @doc """
+  Return matrix rank of input M × N matrix using Singular Value Decomposition method.
+  Calculate the number of singular values greater than `eps * max(singular values) * max(M, N)` as a rank.
+  This also appears in Numerical recipes in the discussion of SVD solutions for linear least squares [1].
+  [1] W. H. Press, S. A. Teukolsky, W. T. Vetterling and B. P. Flannery, “Numerical Recipes (3rd edition)”, Cambridge University Press, 2007, page 795.
+
+  ## Options
+    * `:eps` - Rounding error threshold used to assume values as 0. Defaults to `1.0e-10`
+
+  ## Examples
+
+      iex> Nx.LinAlg.matrix_rank(Nx.tensor([[1, 2], [3, 4]]))
+      #Nx.Tensor<
+        u64
+        2
+      >
+
+      iex> Nx.LinAlg.matrix_rank(Nx.tensor([[1, 1, 1, 1], [1, 1, 1, 1], [1, 2, 3, 4]]))
+      #Nx.Tensor<
+        u64
+        2
+      >
+
+      iex> Nx.LinAlg.matrix_rank(Nx.tensor([[1, 1, 1], [2, 2, 2], [8, 9, 10], [-2, 1, 5]]))
+      #Nx.Tensor<
+        u64
+        3
+      >
+
+  ## Error cases
+
+      iex> Nx.LinAlg.matrix_rank(Nx.tensor([1, 2, 3]))
+      ** (ArgumentError) tensor must have at least rank 2, got rank 1 with shape {3}
+  """
+  @doc from_backend: false
+  def matrix_rank(a, opts \\ []) do
+    opts = keyword!(opts, eps: 1.0e-10)
+    shape = Nx.shape(a)
+    :ok = Nx.Shape.matrix_rank(shape)
+
+    # Calculate max dimension
+    {row_dim, col_dim} = shape
+    max_dim = if row_dim > col_dim, do: row_dim, else: col_dim
+
+    # Calculate max singular value
+    {_u, s, _v} = svd(a)
+    s_max = s
+      |> Nx.reduce_max()
+      |> Nx.to_number()
+
+    # Set tolerance values
+    tol = opts[:eps] * max_dim * s_max
+
+    # Calucate matrix rank
+    s
+    |> Nx.greater(tol)
+    |> Nx.sum()
+  end
 end

--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -1806,7 +1806,9 @@ defmodule Nx.LinAlg do
 
     # Calculate max singular value
     {_u, s, _v} = svd(a)
-    s_max = s
+
+    s_max =
+      s
       |> Nx.reduce_max()
       |> Nx.to_number()
 

--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -1762,7 +1762,8 @@ defmodule Nx.LinAlg do
 
   @doc """
   Return matrix rank of input M × N matrix using Singular Value Decomposition method.
-  Calculate the number of singular values greater than `eps * max(singular values) * max(M, N)` as a rank.
+
+  Approximate the number of linearly independent rows by calculating the number of singular values greater than `eps * max(singular values) * max(M, N)`.
   This also appears in Numerical recipes in the discussion of SVD solutions for linear least squares [1].
   [1] W. H. Press, S. A. Teukolsky, W. T. Vetterling and B. P. Flannery, “Numerical Recipes (3rd edition)”, Cambridge University Press, 2007, page 795.
 
@@ -1796,6 +1797,7 @@ defmodule Nx.LinAlg do
   """
   @doc from_backend: false
   def matrix_rank(a, opts \\ []) do
+    # TODO: support batching when SVD supports it too
     opts = keyword!(opts, eps: 1.0e-10)
     shape = Nx.shape(a)
     :ok = Nx.Shape.matrix_rank(shape)
@@ -1815,7 +1817,7 @@ defmodule Nx.LinAlg do
     # Set tolerance values
     tol = opts[:eps] * max_dim * s_max
 
-    # Calucate matrix rank
+    # Calculate matrix rank
     s
     |> Nx.greater(tol)
     |> Nx.sum()

--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -1805,14 +1805,20 @@ defmodule Nx.LinAlg do
     # TODO: support batching when SVD supports it too
     opts = keyword!(opts, eps: 1.0e-10)
     shape = Nx.shape(a)
-    :ok = Nx.Shape.matrix_rank(shape)
+    size = Nx.rank(shape)
+    if size <= 1 do
+      raise(
+        ArgumentError,
+        "tensor must have at least rank 2, got rank #{inspect(size)} with shape #{inspect(shape)}"
+      )
+    end
 
     # Calculate max dimension
     {row_dim, col_dim} = shape
     max_dim = if row_dim > col_dim, do: row_dim, else: col_dim
 
     # Calculate max singular value
-    {_u, s, _v} = svd(a)
+    {_u, s, _v} = Nx.LinAlg.svd(a)
 
     s_max = Nx.reduce_max(s)
 

--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -1801,7 +1801,7 @@ defmodule Nx.LinAlg do
       ** (ArgumentError) tensor must have at least rank 2, got rank 1 with shape {3}
   """
   @doc from_backend: false
-  def matrix_rank(a, opts \\ []) do
+  defn matrix_rank(a, opts \\ []) do
     # TODO: support batching when SVD supports it too
     opts = keyword!(opts, eps: 1.0e-10)
     shape = Nx.shape(a)
@@ -1814,13 +1814,10 @@ defmodule Nx.LinAlg do
     # Calculate max singular value
     {_u, s, _v} = svd(a)
 
-    s_max =
-      s
-      |> Nx.reduce_max()
-      |> Nx.to_number()
+    s_max = Nx.reduce_max(s)
 
     # Set tolerance values
-    tol = opts[:eps] * max_dim * s_max
+    tol = Nx.multiply(opts[:eps] * max_dim, s_max)
 
     # Calculate matrix rank
     s

--- a/nx/lib/nx/shape.ex
+++ b/nx/lib/nx/shape.ex
@@ -2093,4 +2093,15 @@ defmodule Nx.Shape do
           "cannot merge name #{inspect(l_name)} on axis #{l_axis} " <>
             "with name #{inspect(r_name)} on axis #{r_axis}"
   end
+
+  def matrix_rank(shape) when tuple_size(shape) > 1 do
+    :ok
+  end
+
+  def matrix_rank(shape) do
+    raise(
+      ArgumentError,
+      "tensor must have at least rank 2, got rank #{tuple_size(shape)} with shape #{inspect(shape)}"
+    )
+  end
 end

--- a/nx/lib/nx/shape.ex
+++ b/nx/lib/nx/shape.ex
@@ -2093,15 +2093,4 @@ defmodule Nx.Shape do
           "cannot merge name #{inspect(l_name)} on axis #{l_axis} " <>
             "with name #{inspect(r_name)} on axis #{r_axis}"
   end
-
-  def matrix_rank(shape) when tuple_size(shape) > 1 do
-    :ok
-  end
-
-  def matrix_rank(shape) do
-    raise(
-      ArgumentError,
-      "tensor must have at least rank 2, got rank #{tuple_size(shape)} with shape #{inspect(shape)}"
-    )
-  end
 end


### PR DESCRIPTION
# Changes
The `matrix_rank` function is added that has the same function as [numpy.linalg.matrix_rank](https://numpy.org/doc/stable/reference/generated/numpy.linalg.matrix_rank.html).
This function returns matrix rank of input M × N matrix using Singular Value Decomposition (SVD) method.

# References

- [Document of `numpy.linalg.matrix_rank`](https://numpy.org/doc/stable/reference/generated/numpy.linalg.matrix_rank.html)
- Mathematical resources, for example,[ this document from Berkeley University (Proposition 1.3.)](https://math.berkeley.edu/~hutching/teach/54-2017/svd-notes.pdf) 


# Confirmations
I ran the same test on `numpy.linalg.matrix_rank` as doctest and confirmed that the same results were obtained.
<img width="526" alt="numpy_tests" src="https://user-images.githubusercontent.com/42142120/213917295-ecef99e2-49a0-4504-a1a4-5858dfe75fdc.png">
