### PR TITLE
Add fundamental mathematical constants

### DIFF
--- a/nx/lib/nx/constants.ex
+++ b/nx/lib/nx/constants.ex
@@ -355,7 +355,7 @@ defmodule Nx.Constants do
 
       iex> Nx.Constants.pi({:f, 32})
       #Nx.Tensor<
-        f64
+        f32
         3.1415927410125732
       >
 

--- a/nx/lib/nx/constants.ex
+++ b/nx/lib/nx/constants.ex
@@ -306,7 +306,7 @@ defmodule Nx.Constants do
         f64
         2.2250738585072014e-308
       >
-      
+
       iex> Nx.Constants.smallest_positive_normal({:f, 32})
       #Nx.Tensor<
         f32
@@ -331,6 +331,144 @@ defmodule Nx.Constants do
   def smallest_positive_normal(type, opts \\ []) do
     type = Nx.Type.normalize!(type)
     from_binary(Nx.Type.smallest_positive_normal_binary(type), type, opts)
+  end
+
+  @doc ~S"""
+  Returns $\pi$ in f32.
+  """
+  def pi, do: pi({:f, 32}, [])
+
+  @doc ~S"""
+  Returns a scalar tensor with the value of $\pi$ for the given type.
+
+  ## Options
+
+    * `:backend` - a backend to allocate the tensor on.
+
+  ## Examples
+
+      iex> Nx.Constants.pi({:f, 64})
+      #Nx.Tensor<
+        f64
+        3.141592653589793
+      >
+
+      iex> Nx.Constants.pi({:f, 32})
+      #Nx.Tensor<
+        f64
+        3.1415927410125732
+      >
+
+      iex> Nx.Constants.pi({:f, 16})
+      #Nx.Tensor<
+        f16
+        3.140625
+      >
+
+      iex> Nx.Constants.pi({:bf, 16})
+      #Nx.Tensor<
+        bf16
+        3.140625
+      >
+
+      iex> Nx.Constants.pi({:s, 32})
+      ** (ArgumentError) only floating types are supported, got: {:s, 32}
+  """
+  def pi(type, opts \\ []) do
+    type = Nx.Type.normalize!(type)
+    from_binary(Nx.Type.pi_binary(type), type, opts)
+  end
+
+  @doc """
+  Returns $e$ in f32.
+  """
+  def e, do: e({:f, 32}, [])
+
+  @doc """
+  Returns a scalar tensor with the value of $e$ for the given type.
+
+  ## Options
+
+    * `:backend` - a backend to allocate the tensor on.
+
+  ## Examples
+
+      iex> Nx.Constants.e({:f, 64})
+      #Nx.Tensor<
+        f64
+        2.718281828459045
+      >
+
+      iex> Nx.Constants.e({:f, 32})
+      #Nx.Tensor<
+        f32
+        2.7182817459106445
+      >
+
+      iex> Nx.Constants.e({:f, 16})
+      #Nx.Tensor<
+        f16
+        2.71875
+      >
+
+      iex> Nx.Constants.e({:bf, 16})
+      #Nx.Tensor<
+        bf16
+        2.703125
+      >
+
+      iex> Nx.Constants.e({:s, 32})
+      ** (ArgumentError) only floating types are supported, got: {:s, 32}
+  """
+  def e(type, opts \\ []) do
+    type = Nx.Type.normalize!(type)
+    from_binary(Nx.Type.e_binary(type), type, opts)
+  end
+
+  @doc ~S"""
+  Returns $\gamma$ (Euler-Mascheroni constant) in f32.
+  """
+  def euler_gamma, do: euler_gamma({:f, 32}, [])
+
+  @doc ~S"""
+  Returns a scalar tensor with the value of $\gamma$ (Euler-Mascheroni constant) for the given type.
+
+  ## Options
+
+    * `:backend` - a backend to allocate the tensor on.
+
+  ## Examples
+
+      iex> Nx.Constants.euler_gamma({:f, 64})
+      #Nx.Tensor<
+        f64
+        0.5772156649015329
+      >
+
+      iex> Nx.Constants.euler_gamma({:f, 32})
+      #Nx.Tensor<
+        f32
+        0.5772156715393066
+      >
+
+      iex> Nx.Constants.euler_gamma({:f, 16})
+      #Nx.Tensor<
+        f16
+        0.5771484375
+      >
+
+      iex> Nx.Constants.euler_gamma({:bf, 16})
+      #Nx.Tensor<
+        bf16
+        0.57421875
+      >
+
+      iex> Nx.Constants.euler_gamma({:s, 32})
+      ** (ArgumentError) only floating types are supported, got: {:s, 32}
+  """
+  def euler_gamma(type, opts \\ []) do
+    type = Nx.Type.normalize!(type)
+    from_binary(Nx.Type.euler_gamma_binary(type), type, opts)
   end
 
   defp from_binary(binary, type, opts) do

--- a/nx/lib/nx/type.ex
+++ b/nx/lib/nx/type.ex
@@ -614,4 +614,40 @@ defmodule Nx.Type do
   defp signed_size(x) when x <= 32767, do: 16
   defp signed_size(x) when x <= 2_147_483_647, do: 32
   defp signed_size(_), do: 64
+
+  @doc ~S"""
+  Returns $\pi$ as a binary for the given type
+  """
+  def pi_binary(type)
+  def pi_binary({:bf, 16}), do: <<73, 64>>
+  def pi_binary({:f, 16}), do: <<72, 66>>
+  def pi_binary({:f, 32}), do: <<219, 15, 73, 64>>
+  def pi_binary({:f, 64}), do: <<24, 45, 68, 84, 251, 33, 9, 64>>
+
+  def pi_binary(type),
+    do: raise(ArgumentError, "only floating types are supported, got: #{inspect(type)}")
+
+  @doc """
+  Returns $e$ as a binary for the given type
+  """
+  def e_binary(type)
+  def e_binary({:bf, 16}), do: <<45, 64>>
+  def e_binary({:f, 16}), do: <<112, 65>>
+  def e_binary({:f, 32}), do: <<84, 248, 45, 64>>
+  def e_binary({:f, 64}), do: <<105, 87, 20, 139, 10, 191, 5, 64>>
+
+  def e_binary(type),
+    do: raise(ArgumentError, "only floating types are supported, got: #{inspect(type)}")
+
+  @doc ~S"""
+  Returns Euler–Mascheroni constant ($\gamma$) as a binary for the given type
+  """
+  def euler_gamma_binary(type)
+  def euler_gamma_binary({:bf, 16}), do: <<19, 63>>
+  def euler_gamma_binary({:f, 16}), do: <<158, 56>>
+  def euler_gamma_binary({:f, 32}), do: <<104, 196, 19, 63>>
+  def euler_gamma_binary({:f, 64}), do: <<25, 182, 111, 252, 140, 120, 226, 63>>
+
+  def euler_gamma_binary(type),
+    do: raise(ArgumentError, "only floating types are supported, got: #{inspect(type)}")
 end

--- a/nx/mix.exs
+++ b/nx/mix.exs
@@ -120,6 +120,16 @@ defmodule Nx.MixProject do
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.13.19/dist/katex.min.js" integrity="sha384-aaNb715UK1HuP4rjZxyzph+dVss/5Nx3mLImBe9b0EW4vMUkc1Guw4VRyQKBC0eG" crossorigin="anonymous"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.13.19/dist/contrib/auto-render.min.js" integrity="sha384-+XBljXPPiv+OzfbB3cVmLHf4hdUFHlWNZN5spNQ7rmHTXpd7WvJum6fIACpNNfIR" crossorigin="anonymous"
             onload="renderMathInElement(document.body);"></script>
+    <script>
+      document.addEventListener("DOMContentLoaded", function() {
+        renderMathInElement(document.body, {
+          delimiters: [
+            { left: "$$", right: "$$", display: true },
+            { left: "$", right: "$", display: false },
+          ]
+        });
+      });
+    </script>
     """
   end
 


### PR DESCRIPTION
Closes #1092 

Except mathematical constants, this PR also adds math notation in docs with the same configuration as in Axon.