### PR TITLE
Adds `to_list/1` to Nx

### DIFF
--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -1789,6 +1789,18 @@ defmodule Nx do
     end
   end
 
+  def to_list(tensor) do
+    list = to_flat_list(tensor)
+
+    tensor
+    |> shape()
+    |> Tuple.to_list()
+    |> Enum.drop(1)
+    |> Enum.reverse()
+    |> Enum.reduce(list, &Stream.chunk_every(&2, &1))
+    |> Enum.to_list()
+  end
+
   @doc false
   @deprecated "Use to_batched/3 instead"
   def to_batched_list(tensor, batch_size, opts \\ []) do

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -1789,16 +1789,51 @@ defmodule Nx do
     end
   end
 
-  def to_list(tensor) do
-    list = to_flat_list(tensor)
+  @doc """
+  Converts the tensor into a list reflecting its structure.
 
-    tensor
-    |> shape()
-    |> Tuple.to_list()
-    |> Enum.drop(1)
-    |> Enum.reverse()
-    |> Enum.reduce(list, &Stream.chunk_every(&2, &1))
-    |> Enum.to_list()
+  Negative infinity (-Inf), infinity (Inf), and "not a number" (NaN)
+  will be represented by the atoms `:neg_infinity`, `:infinity`, and
+  `:nan` respectively.
+
+  Note: This function cannot be used in `defn`.
+
+  ## Examples
+
+      iex> Nx.iota({2, 3}) |> Nx.to_list()
+      [
+        [0, 1, 2],
+        [3, 4, 5]
+      ]
+  """
+  @doc type: :conversion
+  def to_list(tensor) do
+    %{type: type, shape: shape} = tensor = to_tensor(tensor)
+    binary = to_binary(tensor, [])
+
+    dims = Tuple.to_list(shape)
+    {list, ""} = chunk(dims, binary, type)
+    list
+  end
+
+  defp chunk([], data, type) do
+    match_types [type] do
+      <<match!(head, 0), tail::binary>> = data
+      {read!(head, 0), tail}
+    end
+  end
+
+  defp chunk([dim | dims], data, type) do
+    chunk_each(dim, data, [], dims, type)
+  end
+
+  defp chunk_each(0, data, acc, _dims, _type) do
+    {Enum.reverse(acc), data}
+  end
+
+  defp chunk_each(dim, data, acc, dims, type) do
+    {entry, rest} = chunk(dims, data, type)
+    chunk_each(dim - 1, rest, [entry | acc], dims, type)
   end
 
   @doc false


### PR DESCRIPTION
Currently, to create a tensor from a nested list is pretty easy with `Nx.tensor/1`, but the reverse operation can be a little complicated/frustrating.

There are a few options, such as `to_batched/3` and `to_flat_list/2`, but the problem with them is that additional steps are needed to get a nested list that represents the tensor structure back.

For example: https://elixirforum.com/t/converting-tensor-into-nested-list/44352

Because of that, some libraries end up creating their own `to_list` function to solve this, such as [Bumblebee](https://github.com/elixir-nx/bumblebee/blob/v0.1.2/lib/bumblebee/utils/nx.ex#L31) (where I got the code from).

This PR allows for this:
```elixir
iex> [[1, 2], [3, 4]] |> Nx.tensor() |> Nx.to_list()    
[[1, 2], [3, 4]]
```

This probably have already crossed the core developers mind, so what is the general opinion on this?

Tests and docs are still missing  in this PR, but it would contain some info about when `to_batched/3` should be preferred.