### PR TITLE
Fix ArgumentError for complex case in matrix_rank function

### DIFF
--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -1833,7 +1833,7 @@ defmodule Nx.LinAlg do
       ** (ArgumentError) tensor must have rank 2, got rank 1 with shape {3}
 
       iex> Nx.LinAlg.matrix_rank(Nx.tensor([[1, Complex.new(0, 2)], [3, Complex.new(0, -4)]]))
-      ** (ArgumentError) Nx.LinAlg.matrix_rank is not yet implemented for complex inputs
+      ** (ArgumentError) Nx.LinAlg.matrix_rank/2 is not yet implemented for complex inputs
   """
   @doc from_backend: false
   defn matrix_rank(a, opts \\ []) do
@@ -1844,7 +1844,7 @@ defmodule Nx.LinAlg do
 
     case type do
       {:c, _} ->
-        raise ArgumentError, "Nx.LinAlg.matrix_rank is not yet implemented for complex inputs"
+        raise ArgumentError, "Nx.LinAlg.matrix_rank/2 is not yet implemented for complex inputs"
 
       _ ->
         nil

--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -1831,13 +1831,24 @@ defmodule Nx.LinAlg do
 
       iex> Nx.LinAlg.matrix_rank(Nx.tensor([1, 2, 3]))
       ** (ArgumentError) tensor must have rank 2, got rank 1 with shape {3}
+
+      iex> Nx.LinAlg.matrix_rank(Nx.tensor([[1, Complex.new(0, 2)], [3, Complex.new(0, -4)]]))
+      ** (ArgumentError) Nx.LinAlg.matrix_rank is not yet implemented for complex inputs
   """
   @doc from_backend: false
   defn matrix_rank(a, opts \\ []) do
     # TODO: support batching when SVD supports it too
     opts = keyword!(opts, eps: 1.0e-7)
-    shape = Nx.shape(a)
+    %T{type: type, shape: shape} = Nx.to_tensor(a)
     size = Nx.rank(shape)
+
+    case type do
+      {:c, _} ->
+        raise ArgumentError, "Nx.LinAlg.matrix_rank is not yet implemented for complex inputs"
+
+      _ ->
+        nil
+    end
 
     if size != 2 do
       raise(


### PR DESCRIPTION
When a matrix with complex numbers as elements is entered into `matrix_rank` function, the error comment `"Nx.LinAlg.svd/2 is not yet implemented for complex inputs"` is displayed as below.  
<img width="526" alt="svd" src="https://user-images.githubusercontent.com/42142120/222161036-c17825c8-b40f-4a38-a59a-cdad07edf135.png">

Therefore, I corrected it so that the error comment `"Nx.LinAlg.matrix_rank/2 is not yet implemented for complex inputs"` is displayed.