### PR TITLE
Fix parsing of the NumPy file header

### DIFF
--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -12485,7 +12485,7 @@ defmodule Nx do
   end
 
   defp parse_header(header) do
-    header = header |> String.trim("{") |> String.trim("}") |> String.trim(", ")
+    header = header |> String.trim("{") |> String.trim() |> String.trim("}") |> String.trim(", ")
 
     case header do
       "'descr': " <> <<dtype::size(5)-binary>> <> ", 'fortran_order': False, 'shape': " <> shape ->


### PR DESCRIPTION
If I save a NumPy array to a `npy` file on NumPy `v1.24.2` with `np.save(my_array)`, and then try to load it with `Nx.load_numpy!`, I get the following error:

```
** (CaseClauseError) no case clause matching: "'descr': '|O', 'fortran_order': False, 'shape': (), }                                                               \n"
    (nx 0.5.2) lib/nx.ex:11517: Nx.parse_header/1
    (nx 0.5.2) lib/nx.ex:11503: Nx.do_numpy_to_tensor/2
```

The issue is in the [`parse_header` private function](https://github.com/elixir-nx/nx/blob/fade169a1cf61c17eaf69754eaa8d99544795f63/nx/lib/nx.ex#L12488), which parses the `npy` file header, expecting the `}` to be the last character in the header. In this case, the `}` is instead followed by several spaces and a newline (see the first line in the error).

This is fixed by trimming trailing whitespace before removing the `}` in `parse_header`:

```elixir
# Before:
header = header |> String.trim("{") |> String.trim("}") |> String.trim(", ")

# Now:
header = header |> String.trim("{") |> String.trim() |> String.trim("}") |> String.trim(", ")
# Trim trailing whitespace here -------^
```