### PR TITLE
fix: vectorized Nx.take

### DIFF
--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -13321,8 +13321,6 @@ defmodule Nx do
     if tensor.vectorized_axes != [] or indices.vectorized_axes != [] do
       axes_range = axes(tensor)
 
-      indices = if rank(indices) == 0, do: new_axis(indices, 0), else: indices
-
       indices_shape =
         axes_range
         |> Enum.map(fn
@@ -13341,7 +13339,6 @@ defmodule Nx do
           x, _ ->
             x
         end)
-        |> List.flatten()
 
       indices_for_axis =
         indices

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -13321,7 +13321,7 @@ defmodule Nx do
     if tensor.vectorized_axes != [] or indices.vectorized_axes != [] do
       axes_range = axes(tensor)
 
-      indices = flatten(indices)
+      indices = if rank(indices) == 0, do: new_axis(indices, 0), else: indices
 
       indices_shape =
         axes_range

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -13325,9 +13325,9 @@ defmodule Nx do
 
       indices_shape =
         axes_range
-        |> Enum.flat_map(fn
-          ^axis -> Tuple.to_list(indices.shape)
-          _ -> [1]
+        |> Enum.map(fn
+          ^axis -> Tuple.product(indices.shape)
+          _ -> 1
         end)
         |> List.to_tuple()
 
@@ -13336,7 +13336,7 @@ defmodule Nx do
         |> Tuple.to_list()
         |> Enum.with_index(fn
           _x, ^axis ->
-            List.duplicate(1, rank(indices))
+            1
 
           x, _ ->
             x
@@ -13348,24 +13348,16 @@ defmodule Nx do
         |> reshape(indices_shape)
         |> tile(idx_tiling)
 
-      axis_offset = rank(indices) - 1
-
       indices =
         axes_range
         |> Enum.map(fn
           ^axis ->
             reshape(indices_for_axis, {:auto, 1})
 
-          current when current < axis ->
+          current ->
             indices_for_axis
             |> shape()
             |> iota(axis: current, vectorized_axes: indices.vectorized_axes)
-            |> reshape({:auto, 1})
-
-          current when current > axis ->
-            indices_for_axis
-            |> shape()
-            |> iota(axis: current + axis_offset, vectorized_axes: indices.vectorized_axes)
             |> reshape({:auto, 1})
         end)
         |> concatenate(axis: 1)

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -13323,6 +13323,7 @@ defmodule Nx do
       Nx.Shape.take(
         tensor.shape,
         tensor.names,
+        # forcing this for testing the case where both are vectorized with [x: 3]
         put_elem(indices.shape, 0, 1),
         indices.names,
         axis
@@ -13349,6 +13350,7 @@ defmodule Nx do
             List.duplicate(1, Nx.rank(indices))
 
           _, 0 ->
+            # forcing this for testing the case where both are vectorized with [x: 3]
             1
 
           x, _ ->

--- a/torchx/lib/torchx/backend.ex
+++ b/torchx/lib/torchx/backend.ex
@@ -468,13 +468,6 @@ defmodule Torchx.Backend do
       |> Nx.concatenate(axis: 1)
 
     gather(out, t, indices)
-    |> tap(fn x ->
-      actual_shape = x |> Torchx.from_nx() |> Torchx.shape()
-
-      if actual_shape != x.shape do
-        raise "error"
-      end
-    end)
   end
 
   @impl true

--- a/torchx/lib/torchx/backend.ex
+++ b/torchx/lib/torchx/backend.ex
@@ -424,13 +424,13 @@ defmodule Torchx.Backend do
 
   @impl true
   def take(out, t, i, axis) do
-    axes_range = 0..(Nx.rank(t) - 1)//1
+    axes = Nx.axes(t)
 
     indices_shape =
-      axes_range
-      |> Enum.flat_map(fn
-        ^axis -> Tuple.to_list(i.shape)
-        _ -> [1]
+      axes
+      |> Enum.map(fn
+        ^axis -> Tuple.product(i.shape)
+        _ -> 1
       end)
       |> List.to_tuple()
 
@@ -439,12 +439,11 @@ defmodule Torchx.Backend do
       |> Tuple.to_list()
       |> Enum.with_index(fn
         _x, ^axis ->
-          List.duplicate(1, Nx.rank(i))
+          1
 
         x, _ ->
           x
       end)
-      |> List.flatten()
 
     indices_for_axis =
       i
@@ -453,29 +452,29 @@ defmodule Torchx.Backend do
 
     num_elements = Tuple.product(indices_for_axis.shape)
 
-    axis_offset = Nx.rank(i) - 1
-
     indices =
-      axes_range
+      axes
       |> Enum.map(fn
         ^axis ->
           Nx.reshape(indices_for_axis, {num_elements, 1})
 
-        current when current < axis ->
+        current ->
+          # current when current < axis ->
           indices_for_axis
           |> Nx.shape()
           |> Nx.iota(axis: current, backend: __MODULE__)
-          |> Nx.reshape({num_elements, 1})
-
-        current when current > axis ->
-          indices_for_axis
-          |> Nx.shape()
-          |> Nx.iota(axis: current + axis_offset, backend: __MODULE__)
           |> Nx.reshape({num_elements, 1})
       end)
       |> Nx.concatenate(axis: 1)
 
     gather(out, t, indices)
+    |> tap(fn x ->
+      actual_shape = x |> Torchx.from_nx() |> Torchx.shape()
+
+      if actual_shape != x.shape do
+        raise "error"
+      end
+    end)
   end
 
   @impl true


### PR DESCRIPTION
closes #1192

This basically replicates the algorithm for take-over-gather used in Torchx, so that we extend the still-vectorized indices to be passed onto the vectorized gather implementation.

Implementing directly over take would imply lots of really weird slicing and wouldn't yield much memory footprint improvement over what we have now.