### PR TITLE
feat: Nx.revectorize

### DIFF
--- a/nx/mix.exs
+++ b/nx/mix.exs
@@ -76,6 +76,7 @@ defmodule Nx.MixProject do
         "Functions: Indexed": &(&1[:type] == :indexed),
         "Functions: N-dim": &(&1[:type] == :ndim),
         "Functions: Shape": &(&1[:type] == :shape),
+        "Functions: Vectorization": &(&1[:type] == :vectorization),
         "Functions: Type": &(&1[:type] == :type),
         "Functions: Window": &(&1[:type] == :window)
       ],

--- a/nx/test/nx_test.exs
+++ b/nx/test/nx_test.exs
@@ -20,7 +20,8 @@ defmodule NxTest do
     :ndim,
     :shape,
     :type,
-    :window
+    :window,
+    :vectorization
   ]
 
   test "defines doc metadata" do


### PR DESCRIPTION
Adds another utility function for vectorized axes manipulation.
This solves the problem of collapsing and re-expanding vectorized axes.