### PR TITLE
fix: access on vectorized tensor with unvectorized indices

### DIFF
--- a/exla/test/exla/defn/vectorize_test.exs
+++ b/exla/test/exla/defn/vectorize_test.exs
@@ -195,7 +195,10 @@ defmodule EXLA.Defn.VectorizeTest do
       pred1 = Nx.vectorize(~V[1 0 0], :pred)
       pred2 = Nx.vectorize(~V[0 0 0], :pred)
 
-      assert_equal(vectorized_cond(pred1, 1, pred2, 2, 3, pid: self()), Nx.vectorize(~V[1 3 3], :pred))
+      assert_equal(
+        vectorized_cond(pred1, 1, pred2, 2, 3, pid: self()),
+        Nx.vectorize(~V[1 3 3], :pred)
+      )
 
       assert_received {t, clause: "clause_1"}
       assert_equal(t, Nx.tensor(1))
@@ -207,24 +210,23 @@ defmodule EXLA.Defn.VectorizeTest do
     test "if with container result" do
       pred1 = Nx.vectorize(~V[2 0 0], :pred)
 
-          result =
-            vectorized_if(
-              pred1,
-              {1, 2, 3},
-              {7, 8, Nx.vectorize(~V[9 10 11], :x)},
-              pid: self()
-            )
+      result =
+        vectorized_if(
+          pred1,
+          {1, 2, 3},
+          {7, 8, Nx.vectorize(~V[9 10 11], :x)},
+          pid: self()
+        )
 
-          assert_equal(result, {
-                   Nx.vectorize(~V[1 7 7], :pred),
-                   Nx.vectorize(~V[2 8 8], :pred),
-                   Nx.vectorize(~M[
+      assert_equal(result, {
+        Nx.vectorize(~V[1 7 7], :pred),
+        Nx.vectorize(~V[2 8 8], :pred),
+        Nx.vectorize(~M[
                   3 3 3
                   9 10 11
                   9 10 11
                 ], pred: 3, x: 3)
-                 })
-
+      })
 
       assert_received {t, clause: "if"}
       assert_equal(t, {Nx.tensor(1), Nx.tensor(2), Nx.tensor(3)})

--- a/exla/test/exla/defn/vectorize_test.exs
+++ b/exla/test/exla/defn/vectorize_test.exs
@@ -2,6 +2,7 @@ defmodule EXLA.Defn.VectorizeTest do
   use EXLA.Case, async: true
 
   import Nx.Defn
+  import Nx, only: :sigils
 
   setup do
     Nx.default_backend(EXLA.Backend)
@@ -154,5 +155,205 @@ defmodule EXLA.Defn.VectorizeTest do
       EXLA.jit(&Nx.squeeze/1).(Nx.iota({1, 1, 2}) |> Nx.vectorize(:x)),
       Nx.iota({1, 2}) |> Nx.vectorize(:x)
     )
+  end
+
+  describe "cond" do
+    deftransformp send_value(val, opts \\ []) do
+      Nx.Defn.Kernel.hook(val, &send(opts[:pid] || self(), {&1, clause: opts[:clause]}))
+    end
+
+    defn vectorized_if(pred, then, other, opts \\ []) do
+      cond do
+        pred -> send_value(then, pid: opts[:pid], clause: "if")
+        true -> send_value(other, pid: opts[:pid], clause: "else")
+      end
+    end
+
+    defn vectorized_cond(pred1, clause1, pred2, clause2, clause3, opts \\ []) do
+      cond do
+        pred1 -> send_value(clause1, pid: opts[:pid], clause: "clause_1")
+        pred2 -> send_value(clause2, pid: opts[:pid], clause: "clause_2")
+        true -> send_value(clause3, pid: opts[:pid], clause: "clause_3")
+      end
+    end
+
+    test "simple if" do
+      # this tests the case where we have a single vectorized predicate
+      pred = Nx.vectorize(~V[0 1 0], :pred)
+
+      assert_equal(vectorized_if(pred, 1, 2, pid: self()), Nx.vectorize(~V[2 1 2], :pred))
+
+      assert_received {t, clause: "if"}
+      assert_equal(t, Nx.tensor(1))
+      assert_received {t, clause: "else"}
+      assert_equal(t, Nx.tensor(2))
+      refute_received _
+    end
+
+    test "simple cond" do
+      # this tests the case where we have a two vectorized predicates
+      pred1 = Nx.vectorize(~V[1 0 0], :pred)
+      pred2 = Nx.vectorize(~V[0 0 0], :pred)
+
+      assert_equal(vectorized_cond(pred1, 1, pred2, 2, 3, pid: self()), Nx.vectorize(~V[1 3 3], :pred))
+
+      assert_received {t, clause: "clause_1"}
+      assert_equal(t, Nx.tensor(1))
+      assert_received {t, clause: "clause_3"}
+      assert_equal(t, Nx.tensor(3))
+      refute_received _
+    end
+
+    test "if with container result" do
+      pred1 = Nx.vectorize(~V[2 0 0], :pred)
+
+          result =
+            vectorized_if(
+              pred1,
+              {1, 2, 3},
+              {7, 8, Nx.vectorize(~V[9 10 11], :x)},
+              pid: self()
+            )
+
+          assert_equal(result, {
+                   Nx.vectorize(~V[1 7 7], :pred),
+                   Nx.vectorize(~V[2 8 8], :pred),
+                   Nx.vectorize(~M[
+                  3 3 3
+                  9 10 11
+                  9 10 11
+                ], pred: 3, x: 3)
+                 })
+
+
+      assert_received {t, clause: "if"}
+      assert_equal(t, {Nx.tensor(1), Nx.tensor(2), Nx.tensor(3)})
+      assert_received {t, clause: "else"}
+      assert_equal(t, {Nx.tensor(7), Nx.tensor(8), Nx.vectorize(Nx.tensor([9, 10, 11]), :x)})
+      refute_received _
+    end
+
+    defn cond4(p1, c1, p2, c2, p3, c3, c4, opts \\ []) do
+      cond do
+        p1 -> send_value(c1, pid: opts[:pid], clause: "c1")
+        p2 -> send_value(c2, pid: opts[:pid], clause: "c2")
+        p3 -> send_value(c3, pid: opts[:pid], clause: "c3")
+        true -> send_value(c4, pid: opts[:pid], clause: "c4")
+      end
+    end
+
+    test "only executes selected branches" do
+      t = Nx.vectorize(~V[1], :pred)
+      f = Nx.vectorize(~V[0], :pred)
+
+      assert = fn res, val, clause ->
+        t = Nx.tensor(val)
+        assert_equal(Nx.vectorize(Nx.new_axis(t, 0), :pred), res)
+        assert_received {rec_t, clause: ^clause}
+        assert_equal(rec_t, t)
+        refute_received _
+      end
+
+      assert.(cond4(t, 10, 0, 20, 0, 30, 40, pid: self()), 10, "c1")
+      assert.(cond4(0, 10, t, 20, 0, 30, 40, pid: self()), 20, "c2")
+      assert.(cond4(0, 10, 0, 20, t, 30, 40, pid: self()), 30, "c3")
+      assert.(cond4(f, 10, 0, 20, 0, 30, 40, pid: self()), 40, "c4")
+    end
+
+    test "1 vectorized pred in the beginning" do
+      assert_equal(
+        cond4(Nx.vectorize(~V[0 1], :pred), 10, 0, 20, 0, 30, 40),
+        Nx.vectorize(~V[40 10], :pred)
+      )
+
+      assert_equal(
+        cond4(Nx.vectorize(~V[0 0], :pred), 10, 1, 20, 0, 30, 40),
+        Nx.vectorize(~V[20 20], :pred)
+      )
+
+      assert_equal(
+        cond4(Nx.vectorize(~V[0 0], :pred), 10, 0, 20, 1, 30, 40),
+        Nx.vectorize(~V[30 30], :pred)
+      )
+
+      assert_equal(
+        cond4(Nx.vectorize(~V[0 0], :pred), 10, 0, 20, 0, 30, 40),
+        Nx.vectorize(~V[40 40], :pred)
+      )
+    end
+
+    test "1 vectorized pred in the second but not last position" do
+      assert_equal(
+        cond4(0, 10, Nx.vectorize(~V[0 1], :pred), 20, 0, 30, 40),
+        Nx.vectorize(~V[40 20], :pred)
+      )
+
+      assert_equal(
+        cond4(1, 10, Nx.vectorize(~V[0 1], :pred), 20, 0, 30, 40),
+        Nx.vectorize(~V[10 10], :pred)
+      )
+
+      assert_equal(
+        cond4(0, 10, Nx.vectorize(~V[0 0], :pred), 20, 1, 30, 40),
+        Nx.vectorize(~V[30 30], :pred)
+      )
+
+      assert_equal(
+        cond4(0, 10, Nx.vectorize(~V[0 0], :pred), 20, 0, 30, 40),
+        Nx.vectorize(~V[40 40], :pred)
+      )
+    end
+
+    test "1 vectorized pred in the last position" do
+      assert_equal(
+        cond4(0, 10, 0, 20, Nx.vectorize(~V[0 1], :pred), 30, 40),
+        Nx.vectorize(~V[40 30], :pred)
+      )
+
+      assert_equal(
+        cond4(1, 10, 0, 20, Nx.vectorize(~V[0 1], :pred), 30, 40),
+        Nx.vectorize(~V[10 10], :pred)
+      )
+
+      assert_equal(
+        cond4(0, 10, 1, 20, Nx.vectorize(~V[0 1], :pred), 30, 40),
+        Nx.vectorize(~V[20 20], :pred)
+      )
+
+      assert_equal(
+        cond4(0, 10, 0, 20, Nx.vectorize(~V[0 0], :pred), 30, 40),
+        Nx.vectorize(~V[40 40], :pred)
+      )
+    end
+
+    test "2 vectorized preds with different axes" do
+      assert_equal(
+        cond4(Nx.vectorize(~V[0 1 0], :pred1), 10, Nx.vectorize(~V[1 0], :pred2), 20, 0, 30, 40),
+        Nx.vectorize(~M[
+              20 40
+              10 10
+              20 40
+            ], pred1: 3, pred2: 2)
+      )
+    end
+
+    test "2 vectorized preds with different axes + clauses that match either" do
+      assert_equal(
+        cond4(
+          Nx.vectorize(~V[0 1 0], :pred1),
+          Nx.vectorize(~V[10 100], :pred2),
+          Nx.vectorize(~V[1 0], :pred2),
+          Nx.vectorize(~V[20 200 2000], :pred1),
+          0,
+          30,
+          40
+        ),
+        Nx.vectorize(~M[
+              20 40
+              10 100
+              2000 40
+            ], pred1: 3, pred2: 2)
+      )
+    end
   end
 end

--- a/nx/lib/nx/tensor.ex
+++ b/nx/lib/nx/tensor.ex
@@ -93,11 +93,12 @@ defmodule Nx.Tensor do
     start = List.duplicate(0, offset) ++ start
     offset_shape = Keyword.values(vectorized_axes)
     lengths = offset_shape ++ lengths
+    strides = List.duplicate(1, rank + offset)
 
     tensor = Nx.devectorize(tensor)
 
     %{tensor | shape: List.to_tuple(lengths)}
-    |> impl.slice(tensor, start, lengths, List.duplicate(1, rank))
+    |> impl.slice(tensor, start, lengths, strides)
     |> Nx.vectorize(vectorized_axes)
     |> Nx.squeeze(axes: squeeze)
   end


### PR DESCRIPTION
This also adds sanity tests to EXLA and 1 skipped test that
shows that we still need to support vectorized indices in Access.Nx.Tensor