### PR TITLE
Fix Nx.linspace/3 so that it returns elements with proper :f64 precision

### DIFF
--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -15486,7 +15486,8 @@ defmodule Nx do
     opts = keyword!(opts, [:n, :name, type: {:f, 32}, endpoint: true])
 
     [%{vectorized_axes: vectorized_axes} = start, stop] = reshape_vectors([start, stop])
-
+    start = Nx.as_type(start, opts[:type])
+    stop = Nx.as_type(stop, opts[:type])
     n = opts[:n]
 
     unless is_integer(n) and n > 0 do

--- a/nx/test/nx_test.exs
+++ b/nx/test/nx_test.exs
@@ -2700,6 +2700,14 @@ defmodule NxTest do
     end
   end
 
+  describe "linspace/3" do
+    test "works for :f64 (bug fix: https://github.com/elixir-nx/nx/issues/1222)" do
+      linear = Nx.linspace(0.0, 0.5, n: 6, type: :f64)
+      expected_linear = Nx.tensor([0.0, 0.1, 0.2, 0.3, 0.4, 0.5], type: :f64)
+      assert_all_close(linear, expected_linear, atol: 1.0e-15, rtol: 1.0e-15)
+    end
+  end
+
   describe "reflect/2" do
     test "reflects over axes of size 1" do
       assert Nx.tensor([1, 1, 1, 1]) == Nx.reflect(Nx.tensor([1]), padding_config: [{2, 1}])


### PR DESCRIPTION
A fix for this issue:

https://github.com/elixir-nx/nx/issues/1222

Thanks!

-- Greg
