### PR TITLE
refactor: change default for :align_ranks

### DIFF
--- a/nx/lib/nx/defn/expr.ex
+++ b/nx/lib/nx/defn/expr.ex
@@ -141,7 +141,7 @@ defmodule Nx.Defn.Expr do
       # We reshape_vectors to ensure that all predicate vectorized axes are encountered
       # in the same order throughout the clauses. the zip_with below ensures that only
       # the vectorized predicates are pushed through with this new order
-      reshaped_preds = Nx.reshape_vectors(preds)
+      reshaped_preds = Nx.reshape_vectors(preds, align_ranks: true)
 
       clauses =
         Enum.zip_with([preds, reshaped_preds, exprs], fn
@@ -232,7 +232,8 @@ defmodule Nx.Defn.Expr do
   end
 
   defp broadcast_clause([type = last | expr_types = exprs]) do
-    [%{vectorized_axes: vectorized_axes} = last | exprs] = Nx.reshape_vectors([last | exprs])
+    [%{vectorized_axes: vectorized_axes} = last | exprs] =
+      Nx.reshape_vectors([last | exprs], align_ranks: true)
 
     [%{shape: shape, names: names} = last | exprs] = Enum.map([last | exprs], &Nx.devectorize/1)
 
@@ -663,7 +664,7 @@ defmodule Nx.Defn.Expr do
 
     Composite.traverse(initial, nil, fn leaf, _ ->
       # broadcast and pull common axes to the front
-      [_, leaf] = Nx.broadcast_vectors([target, leaf])
+      [_, leaf] = Nx.broadcast_vectors([target, leaf], align_ranks: true)
 
       %{vectorized_axes: leaf_axes} = leaf
 

--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -582,7 +582,7 @@ defmodule Nx.LinAlg do
     end
 
     [%T{vectorized_axes: vectorized_axes, shape: a_shape} = a, %T{shape: b_shape} = b] =
-      Nx.broadcast_vectors([a, b], align_ranks: false)
+      Nx.broadcast_vectors([a, b])
 
     :ok = Nx.Shape.triangular_solve(a_shape, b_shape, opts[:left_side])
     output_type = binary_type(a, b) |> Nx.Type.to_floating()
@@ -685,8 +685,7 @@ defmodule Nx.LinAlg do
   # optional needs to work on the actual backend.
   @doc from_backend: false
   def solve(a, b) do
-    [%T{vectorized_axes: vectorized_axes} = a, b] =
-      Nx.broadcast_vectors([a, b], align_ranks: false)
+    [%T{vectorized_axes: vectorized_axes} = a, b] = Nx.broadcast_vectors([a, b])
 
     a = Nx.devectorize(a)
     b = Nx.devectorize(b)

--- a/nx/lib/nx/lin_alg/svd.ex
+++ b/nx/lib/nx/lin_alg/svd.ex
@@ -80,7 +80,7 @@ defmodule Nx.LinAlg.SVD do
 
     s = Nx.broadcast(Nx.tensor(0, type: Nx.type(a)), {k})
 
-    [s, _] = Nx.broadcast_vectors([s, a], align_ranks: false)
+    [s, _] = Nx.broadcast_vectors([s, a])
 
     u = Nx.eye({m, u_cols}, vectorized_axes: a.vectorized_axes, type: Nx.type(a))
     v = Nx.eye({v_rows, n}, vectorized_axes: a.vectorized_axes, type: Nx.type(a))

--- a/nx/test/nx_test.exs
+++ b/nx/test/nx_test.exs
@@ -2764,23 +2764,26 @@ defmodule NxTest do
       xy = Nx.iota({1, 2}, vectorized_axes: [x: 1, y: 2])
       x2 = Nx.iota({1, 2, 3}, vectorized_axes: [x: 2])
 
-      assert [
-               Nx.iota({1, 1, 1}, vectorized_axes: [x: 2, y: 2]),
-               Nx.iota({1, 1, 2}, vectorized_axes: [x: 2, y: 2]),
-               Nx.iota({1, 2, 3}, vectorized_axes: [x: 2, y: 2])
-             ] == Nx.broadcast_vectors([x, xy, x2])
+      result = [
+        Nx.iota({1}, vectorized_axes: [x: 2, y: 2]),
+        Nx.iota({1, 2}, vectorized_axes: [x: 2, y: 2]),
+        Nx.iota({1, 2, 3}, vectorized_axes: [x: 2, y: 2])
+      ]
+
+      assert result == Nx.broadcast_vectors([x, xy, x2])
+      assert result == Nx.broadcast_vectors([x, xy, x2], align_ranks: false)
     end
 
-    test "returns correct axes' order and shape for align_ranks: false" do
+    test "returns correct axes' order and shape for align_ranks: true" do
       x = Nx.iota({1}, vectorized_axes: [x: 1])
       xy = Nx.iota({1, 2}, vectorized_axes: [x: 1, y: 2])
       x2 = Nx.iota({1, 2, 3}, vectorized_axes: [x: 2])
 
       assert [
-               Nx.iota({1}, vectorized_axes: [x: 2, y: 2]),
-               Nx.iota({1, 2}, vectorized_axes: [x: 2, y: 2]),
+               Nx.iota({1, 1, 1}, vectorized_axes: [x: 2, y: 2]),
+               Nx.iota({1, 1, 2}, vectorized_axes: [x: 2, y: 2]),
                Nx.iota({1, 2, 3}, vectorized_axes: [x: 2, y: 2])
-             ] == Nx.broadcast_vectors([x, xy, x2], align_ranks: false)
+             ] == Nx.broadcast_vectors([x, xy, x2], align_ranks: true)
     end
   end
 


### PR DESCRIPTION
While writing some vectorized code as an user I noticed
that it was far more common to want the align_ranks option
to be false. Also I found it confusing to see an axis pop
up out of nowhere 'til I remembered align_ranks existed.

We can also see this in Nx.LinAlg