### PR TITLE
fix: randint producing numbers outside min,max range

### DIFF
--- a/exla/test/exla/random_test.exs
+++ b/exla/test/exla/random_test.exs
@@ -1,0 +1,42 @@
+defmodule EXLA.NxRandomTest do
+  use EXLA.Case, async: true
+
+  setup do
+    Nx.default_backend(EXLA.Backend)
+    :ok
+  end
+
+  describe "range" do
+    test "randint" do
+      key = Nx.Random.key(127)
+
+      assert_equal(
+        Nx.Random.randint_split(key, 0, 100, shape: {10})
+        |> Nx.less(0)
+        |> Nx.any(),
+        Nx.tensor(0, type: :u8)
+      )
+
+      assert_equal(
+        Nx.Random.randint_split(key, -100, 0, shape: {10})
+        |> Nx.less(-100)
+        |> Nx.any(),
+        Nx.tensor(0, type: :u8)
+      )
+
+      assert_equal(
+        Nx.Random.randint_split(key, 0, Nx.Constants.max(:s64), shape: {10})
+        |> Nx.less(0)
+        |> Nx.any(),
+        Nx.tensor(0, type: :u8)
+      )
+
+      assert_equal(
+        Nx.Random.randint_split(key, Nx.Constants.min(:s64), 0, shape: {10})
+        |> Nx.greater(0)
+        |> Nx.any(),
+        Nx.tensor(0, type: :u8)
+      )
+    end
+  end
+end

--- a/nx/lib/nx/random.ex
+++ b/nx/lib/nx/random.ex
@@ -358,7 +358,7 @@ defmodule Nx.Random do
     higher_bits = random_bits[0]
     lower_bits = random_bits[1]
 
-    span = max_val - min_val
+    span = Nx.as_type(max_val - min_val, {:u, nbits})
 
     multiplier =
       Nx.pow(2, Nx.quotient(nbits, 2))


### PR DESCRIPTION
## Problem

Right now if you use EXLA as the backend, using randint can sometimes return negative numbers even with a range like 0 -> 100

```elixir
Nx.default_backend(EXLA.Backend)
key = Nx.Random.key(127)
{randint, _new_key} = Nx.Random.randint(key, 0, 100, shape: {10})

randint
```

```
# output

tensor: #Nx.Tensor<
  s64[10]
  EXLA.Backend<host:0, 0.2110671721.1027997711.177152>
  [-14, 13, -10, -11, -72, -68, 9, -37, 96, -39]
>
```

But if you use the BinaryBackend, then it's fine

```elixir
Nx.default_backend(Nx.BinaryBackend)
key = Nx.Random.key(127)
{randint, new_key} = Nx.Random.randint(key, 0, 100, shape: {10})

randint
```

```
# output

tensor: #Nx.Tensor<
  u64[10]
  [42, 13, 62, 61, 0, 4, 25, 35, 12, 33]
>
```


## Why
In the beginning of the randint algorithm, it creates some random bits and a span variable. If there's no specified type for min, max, then 
- random_bits has u64 type 
- span has s64 type

These two variables are used in [Nx.remainder](https://github.com/elixir-nx/nx/blob/704001dcd421bbbe03965f4d8ef8a451d0a8a363/nx/lib/nx/random.ex#L352). However, XLA and BinaryBackend performs the remainder operation differently when x is u64 and y is s64.

### XLA Remainder Operation

Let's consider the operation: rem(random_bits, span) where random_bits is u64 and span is s64.


When random_bits is <= 9223372036854775807 (the max value of s64), XLA backend correctly computes the rem operation

```
Nx.default_backend(EXLA.Backend)
# Nx.default_backend(Nx.BinaryBackend)

x =
  Nx.Constants.max(:u64)
  |> Nx.right_shift(1)

x
|> Nx.to_binary()
|> IO.inspect(label: "x binary")

random_bits =
  Nx.tensor(x, type: {:u, 64})
  |> IO.inspect(label: "random_bits")

span =
  Nx.tensor(5, type: {:s, 64})
  |> IO.inspect(label: "span")

res =
  Nx.remainder(random_bits, span)
  |> IO.inspect(label: "res")
  |> Nx.to_binary()
  |> IO.inspect(label: "binary")
```

```
# output

x binary: <<255, 255, 255, 255, 255, 255, 255, 127>>
random_bits: #Nx.Tensor<
  u64
  EXLA.Backend<host:0, 0.1573389750.647888912.116075>
  9223372036854775807
>
span: #Nx.Tensor<
  s64
  EXLA.Backend<host:0, 0.1573389750.647888922.115694>
  5
>
res: #Nx.Tensor<
  s64
  EXLA.Backend<host:0, 0.1573389750.647888912.116076>
  2
>
binary: <<2, 0, 0, 0, 0, 0, 0, 0>>

```

But, when random_bits is > 9223372036854775807, the rem operation will return the answer in two's complement. 

```
x =
  Nx.Constants.max(:u64)
  |> Nx.right_shift(1)
  |> Nx.add(1)

x
|> Nx.to_binary()
|> IO.inspect(label: "x binary")

random_bits =
  Nx.tensor(x, type: {:u, 64})
  |> IO.inspect(label: "random_bits")

span =
  Nx.tensor(5, type: {:s, 64})
  |> IO.inspect(label: "span")

res =
  Nx.remainder(random_bits, span)
  |> IO.inspect(label: "res")
  |> Nx.to_binary()
  |> IO.inspect(label: "binary")
```

```
# output
 
x binary: <<0, 0, 0, 0, 0, 0, 0, 128>>
random_bits: #Nx.Tensor<
  u64
  EXLA.Backend<host:0, 0.1573389750.647888912.116084>
  9223372036854775808
>
span: #Nx.Tensor<
  s64
  EXLA.Backend<host:0, 0.1573389750.647888922.115740>
  5
>
res: #Nx.Tensor<
  s64
  EXLA.Backend<host:0, 0.1573389750.647888912.116085>
  -3
>
binary: <<253, 255, 255, 255, 255, 255, 255, 255>>

```

The answer should be 3. It seems like random_bits (once it has a 1 in the 63rd place), is viewed by XLA as a negative number or something to that effect.

According to XLA website
> When `Op` is `Rem`, the sign of the result is taken from the dividend, and the absolute value of the result is always less than the divisor's absolute value.
> - https://www.tensorflow.org/xla/operation_semantics

I believe JAX and Tensorflow doesn't allow rem operation to be performed with different tensor types. It may be related to this bug. not sure

```
 line 4678, in _check_same_dtypes

    raise TypeError(msg.format(name, ", ".join(map(str, types))))

TypeError: lax.rem requires arguments to have the same dtypes, got uint32, int32.
```

### Solution

Since random_bits is always going to be some u8-u64 type tensor, span should also be the same unsigned type. Then we can safely perform the rem operation.

This is also what [JAX](https://github.com/google/jax/blob/603eeb19017d50526a85e9c6c49f76330254bd47/jax/_src/random.py#L440) does.