### PR TITLE
fix piped softmax defn example

### DIFF
--- a/nx/lib/nx/defn.ex
+++ b/nx/lib/nx/defn.ex
@@ -31,7 +31,7 @@ defmodule Nx.Defn do
 
         defn softmax(t) do
           t
-          |> Nx.exp(t)
+          |> Nx.exp()
           |> then(& &1 / Nx.sum(&1))
         end
       end


### PR DESCRIPTION
tiny little fix, still showing pipeline usage inside defn 😺 