### PR TITLE
Provide new serialization format

### DIFF
--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -416,7 +416,7 @@ defmodule Nx do
   @type axes :: Nx.Tensor.axes()
   @type template :: Nx.Tensor.t(%Nx.TemplateBackend{})
 
-  @file_prefix ?n + ?x
+  @file_prefix <<?n, ?x>>
   @file_version 1
 
   @non_finite [:neg_infinity, :infinity, :nan]


### PR DESCRIPTION
In this format, the tensor metadata including its
binary offset and size are stored upfront with all
binaries at the end. This can allow us, in the future,
to deserialize using mmap or without reading all file
upfront.

Closes #1186.
