### PR TITLE
Remove extraneous title in Nx.broadcast docs

### DIFF
--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -3516,8 +3516,6 @@ defmodule Nx do
 
   ### Without axes
 
-  ## Examples
-
       iex> Nx.broadcast(1, {1, 2, 3})
       #Nx.Tensor<
         s64[1][2][3]


### PR DESCRIPTION
There is already an h2 Examples heading