### PR TITLE
Bug fix: enforce type assumption

### DIFF
--- a/nx/lib/nx/defn/grad.ex
+++ b/nx/lib/nx/defn/grad.ex
@@ -239,6 +239,8 @@ defmodule Nx.Defn.Grad do
   end
 
   defp update_grads(:optional, [_call, expr], _ans, gs, _to_grad_ids, grads) do
+    gs = List.wrap(gs)
+
     {grads, []} =
       Composite.reduce(expr, {grads, gs}, fn child, {grads, [g | gs]} ->
         {Map.update(grads, child.data.id, [g], &[g | &1]), gs}


### PR DESCRIPTION
This call reduces a list of tensors before passing to `update_grads`

https://github.com/elixir-nx/nx/blob/main/nx/lib/nx/defn/grad.ex#L222 

Most of the other matches for `update_grads` account for this as needed, but the `:optional` one did not.  This change fixes that.