### PR TITLE
Add weight option to Nx.Serving for static load balancing

### DIFF
--- a/nx/lib/nx/serving.ex
+++ b/nx/lib/nx/serving.ex
@@ -882,8 +882,8 @@ defmodule Nx.Serving do
     * `:distribution_weight` - weight used for load balancing when running
       a distributed serving. Defaults to `1`.
       If it is set to a higher number `w`, the serving process will receive,
-      on average, `w` times the number of requests compared to a process that
-      uses `weight: 1`. Note that the weight is multiplied with the number of
+      on average, `w` times the number of requests compared to the
+      default. Note that the weight is multiplied with the number of
       partitions, if partitioning is enabled.
 
     * `:shutdown` - the maximum time for the serving to shutdown. This will
@@ -914,7 +914,7 @@ defmodule Nx.Serving do
     partitions = Keyword.get(opts, :partitions, false)
     batch_keys = Keyword.get(opts, :batch_keys, [:default])
     batch_timeout = Keyword.get(opts, :batch_timeout, 100)
-    weight = opts |> Keyword.get(:distribution_weight, 1)
+    weight = Keyword.get(opts, :distribution_weight, 1)
     process_options = Keyword.take(opts, [:name, :hibernate_after, :spawn_opt])
 
     unless is_integer(weight) do

--- a/nx/lib/nx/serving.ex
+++ b/nx/lib/nx/serving.ex
@@ -1323,7 +1323,7 @@ defmodule Nx.Serving do
       }
     )
 
-    serving_weight = max(1, weight) * partitions_count
+    serving_weight = max(1, weight * partitions_count)
     :pg.join(Nx.Serving.PG, __MODULE__, List.duplicate(self(), serving_weight))
 
     for batch_key <- batch_keys do


### PR DESCRIPTION
This adds a simple weight option to `Nx.Serving` that is factored into how many times the serving joins the process group, similar to `partition_count`, thereby making the randomized load balancing weighted.

Addresses https://github.com/elixir-nx/nx/issues/1346, at least in regard to static load balancing.

