### PR TITLE
Exercises 1-20

### DIFF
--- a/nx/exercises/exercises-1-20.livemd
+++ b/nx/exercises/exercises-1-20.livemd
@@ -12,40 +12,40 @@ https://www.kaggle.com/code/utsav15/100-numpy-exercises/notebook
 
 ## 1-10
 
-1. Install Nx in a Livebook (★☆☆)
+**1. Install Nx in a Livebook (★☆☆)**
 
 ```elixir
 Mix.install([{:nx, "~> 0.6"}])
 ```
 
-1. Create a 1-D tensor of 10 zeros (★☆☆)
+**2. Create a 1-D tensor of 10 zeros (★☆☆)**
 
 ```elixir
 Nx.broadcast(0, {10})
 ```
 
-1. How to find the number of elements in a tensor (★☆☆)
+**3. How to find the number of elements in a tensor (★☆☆)**
 
 ```elixir
 Nx.tensor([[1, 2, 3], [4, 5, 6]])
 |> Nx.size()
 ```
 
-1. How to find the memory size of any tensor (★☆☆)
+**4. How to find the memory size of any tensor (★☆☆)**
 
 ```elixir
 Nx.tensor([[1, 2, 3], [4, 5, 6]])
 |> Nx.byte_size()
 ```
 
-1. How to get the documentation of the `add/2` function from the command line? (★☆☆)
+**5. How to get the documentation of the `add/2` function from the command line? (★☆☆)**
 
 ```elixir
 # I don't know if this is possible.
 # iex> h Nx.add
 ```
 
-1. Create a tensor of zeros of size 10 but the fifth value which is 1 (★☆☆)
+**6. Create a tensor of zeros of size 10 but the fifth value which is 1 (★☆☆)**
 
 ```elixir
 zeros = Nx.broadcast(0, {10})
@@ -53,26 +53,26 @@ index = Nx.tensor([4])
 Nx.indexed_put(zeros, index, 1)
 ```
 
-1. Create a tensor with values ranging from 10 to 49 (★☆☆)
+**7. Create a tensor with values ranging from 10 to 49 (★☆☆)**
 
 ```elixir
 Nx.linspace(10, 49, n: 39, type: :s8)
 ```
 
-1. Reverse a tensor (first element becomes last) (★☆☆)
+**8. Reverse a tensor (first element becomes last) (★☆☆)**
 
 ```elixir
 Nx.iota({10})
 |> Nx.reverse()
 ```
 
-1. Create a 3x3 tensor with values ranging from 0 to 8 (★☆☆)
+**9. Create a 3x3 tensor with values ranging from 0 to 8 (★☆☆)**
 
 ```elixir
 Nx.iota({3, 3})
 ```
 
-1. Find indices of non-zero elements from [1,2,0,0,4,0] (★☆☆)
+**10. Find indices of non-zero elements from [1,2,0,0,4,0] (★☆☆)**
 
 ```elixir
 Nx.tensor([1, 2, 0, 0, 4, 0])
@@ -81,13 +81,13 @@ Nx.tensor([1, 2, 0, 0, 4, 0])
 
 ## 11-20
 
-1. Create a 3x3 identity tensor (★☆☆)
+**11. Create a 3x3 identity tensor (★☆☆)**
 
 ```elixir
 Nx.eye(3)
 ```
 
-1. Create a 3x3x3 tensor with random values (★☆☆)
+**12. Create a 3x3x3 tensor with random values (★☆☆)**
 
 ```elixir
 key = Nx.Random.key(0)
@@ -95,7 +95,7 @@ key = Nx.Random.key(0)
 random
 ```
 
-1. Create a 10x10 tensor with random values and find the minimum and maximum values (★☆☆)
+**13. Create a 10x10 tensor with random values and find the minimum and maximum values (★☆☆)**
 
 ```elixir
 # This felt a little awkward. Is there a better way?
@@ -110,7 +110,7 @@ r |> IO.inspect()
 }
 ```
 
-1. Create a random 1D tensor of size 30 and find the mean value (★☆☆)
+**14. Create a random 1D tensor of size 30 and find the mean value (★☆☆)**
 
 ```elixir
 key = Nx.Random.key(0)
@@ -118,21 +118,21 @@ key = Nx.Random.key(0)
 Nx.mean(r)
 ```
 
-1. Create a 5x5 tensor with 1 on the border and 0 inside (★☆☆)
+**15. Create a 5x5 tensor with 1 on the border and 0 inside (★☆☆)**
 
 ```elixir
 Nx.broadcast(0, {3, 3})
 |> Nx.pad(1, [{1, 1, 0}, {1, 1, 0}])
 ```
 
-1. How to add a border (filled with 0's) around an existing array? (★☆☆)
+**16. How to add a border (filled with 0's) around an existing array? (★☆☆)**
 
 ```elixir
 Nx.broadcast(1, {3, 3})
 |> Nx.pad(0, [{1, 1, 0}, {1, 1, 0}])
 ```
 
-1. What are the results of the following expressions? (★☆☆)
+**17. What are the results of the following expressions? (★☆☆)**
 
 ```elixir
 nan = Nx.Constants.nan()
@@ -142,20 +142,20 @@ IO.inspect(Nx.greater(nan, nan))
 IO.inspect(Nx.subtract(nan, nan))
 ```
 
-1. Create a 5x5 tensor with values 1,2,3,4 just below the diagonal (★☆☆)
+**18. Create a 5x5 tensor with values 1,2,3,4 just below the diagonal (★☆☆)**
 
 ```elixir
 Nx.make_diagonal(Nx.tensor([1, 2, 3, 4]), offset: -1)
 ```
 
-1. Create a 8x8 tensor of 0 and 1 in a checkerboard pattern with 0 as the first element (★☆☆)
+**19. Create a 8x8 tensor of 0 and 1 in a checkerboard pattern with 0 as the first element (★☆☆)**
 
 ```elixir
 Nx.tensor([[0, 1], [1, 0]])
 |> Nx.tile([4, 4])
 ```
 
-1. What is the index (x,y,z) of the 100th element of a 6x7x8 tensor?
+**20. What is the index (x,y,z) of the 100th element of a 6x7x8 tensor?**
 
 ```elixir
 # The numpy solution is to use `unravel_index`. I didn't see an equivalent.

--- a/nx/exercises/exercises-1-20.livemd
+++ b/nx/exercises/exercises-1-20.livemd
@@ -138,8 +138,6 @@ IO.inspect(Nx.multiply(0, nan))
 IO.inspect(Nx.equal(nan, nan))
 IO.inspect(Nx.greater(nan, nan))
 IO.inspect(Nx.subtract(nan, nan))
-IO.inspect(Enum.member?(MapSet.new([nan]), nan))
-IO.inspect(0.3 == 3 * 0.1)
 ```
 
 1. Create a 5x5 tensor with values 1,2,3,4 just below the diagonal (★☆☆)

--- a/nx/exercises/exercises-1-20.livemd
+++ b/nx/exercises/exercises-1-20.livemd
@@ -442,7 +442,7 @@ Nx.subtract(nan, nan)
 
 <!-- livebook:{"break_markdown":true} -->
 
-**19. Create a 8x8 tensor of 0 and 1 in a checkerboard pattern with 0 as the first element. (★☆☆)**
+**19. Create a 8x8 tensor of 0 and 1 in a checkerboard pattern with 0 as the first element using [`Nx.tile`](https://hexdocs.pm/nx/Nx.html#tile/2). (★☆☆)**
 
 ```elixir
 # Add your solution here.
@@ -462,34 +462,38 @@ Nx.subtract(nan, nan)
 
 <!-- livebook:{"break_markdown":true} -->
 
-**20. Find the (x,y,z) index ([row major](https://en.wikipedia.org/wiki/Row-_and_column-major_order)) of the 100th element of a 6x7x8 tensor. (★★☆)**
+**20. Produce the same checkerboard pattern from exercise 19, but _without_ using `Nx.tile`. (★☆☆)**
 
 ```elixir
 # Add your solution here.
+# Hint: try using `Nx.iota` in combination with `Nx.remainder`.
 ```
 
 <details style="margin-left: 32px">
-  <summary style="cursor: pointer; font-weight: bold;">Example solution</summary>
+  <summary style="cursor: pointer; font-weight: bold;">Example solution 1</summary>
   <div style="padding-top: 8px">
 
   ```elixir
-  defmodule Exercise20 do
-    import Nx.Defn
+  t = Nx.iota({8, 1})
 
-    deftransform solve(shape, target) do
-      dims = Tuple.to_list(shape)
-      
-      dims
-      |> Enum.map_reduce({target, Enum.product(dims)}, fn dim, {remaining, step_size} ->
-        step_size = div(step_size, dim)
-        num_steps = div(remaining, step_size)
-        {num_steps, {remaining - num_steps * step_size, step_size}}
-      end)
-      |> then(fn {indices, {0, 1}} -> indices end)
-    end
-  end
+  Nx.transpose(t)
+  |> Nx.add(t)
+  |> Nx.remainder(2)
+  ```
 
-  Exercise20.solve({6, 7, 8}, 100)
+  </div>
+</details>
+
+<!-- livebook:{"break_markdown":true} -->
+
+<details style="margin-left: 32px">
+  <summary style="cursor: pointer; font-weight: bold;">Example solution 2</summary>
+  <div style="padding-top: 8px">
+
+  ```elixir
+  Nx.iota({9, 9})
+  |> Nx.remainder(2)
+  |> Nx.slice([0, 0], [8, 8])
   ```
 
   </div>

--- a/nx/exercises/exercises-1-20.livemd
+++ b/nx/exercises/exercises-1-20.livemd
@@ -12,168 +12,479 @@ https://www.kaggle.com/code/utsav15/100-numpy-exercises/notebook
 
 ## 1-10
 
-**1. Install Nx in a Livebook (★☆☆)**
+**1. Install `Nx` in a Livebook. (★☆☆)**
 
 ```elixir
-Mix.install([{:nx, "~> 0.6"}])
+# Add your solution here.
+:ok
 ```
 
-**2. Create a 1-D tensor of 10 zeros (★☆☆)**
+<details class="rounded-lg border-2 border-green-bright-300 p-2">
+  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
+  <div class="p-2">
+
+  ```elixir
+  Mix.install([{:nx, "~> 0.6"}])
+  ```
+
+  </div>
+</details>
+
+<!-- livebook:{"break_markdown":true} -->
+
+**2. Create a 1-D tensor of 10 zeros. (★☆☆)**
 
 ```elixir
-Nx.broadcast(0, {10})
+# Add your solution here.
+:ok
 ```
 
-**3. How to find the number of elements in a tensor (★☆☆)**
+<details class="rounded-lg border-2 border-green-bright-300 p-2">
+  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
+  <div class="p-2">
+
+  ```elixir
+  Nx.broadcast(0, {10})
+  ```
+
+  </div>
+</details>
+
+<!-- livebook:{"break_markdown":true} -->
+
+**3. Find the number of elements in `tensor_03`. (★☆☆)**
 
 ```elixir
-Nx.tensor([[1, 2, 3], [4, 5, 6]])
-|> Nx.size()
+tensor_03 = Nx.tensor([[1, 2, 3], [4, 5, 6]])
+# Add your solution here.
+:ok
 ```
 
-**4. How to find the memory size of any tensor (★☆☆)**
+<details class="rounded-lg border-2 border-green-bright-300 p-2">
+  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
+  <div class="p-2">
+
+  ```elixir
+  Nx.size(tensor_03)
+  ```
+
+  </div>
+</details>
+
+<!-- livebook:{"break_markdown":true} -->
+
+**4. Find the number of bytes of memory in `tensor_04`. (★☆☆)**
 
 ```elixir
-Nx.tensor([[1, 2, 3], [4, 5, 6]])
-|> Nx.byte_size()
+tensor_04 = Nx.tensor([[1, 2, 3], [4, 5, 6]])
+# Add your solution here.
+:ok
 ```
 
-**5. How to get the documentation of the `add/2` function from the command line? (★☆☆)**
+<details class="rounded-lg border-2 border-green-bright-300 p-2">
+  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
+  <div class="p-2">
+
+  ```elixir
+  Nx.byte_size(tensor_04)
+  ```
+
+  </div>
+</details>
+
+<!-- livebook:{"break_markdown":true} -->
+
+**5. Use `IEx.Helpers` to print the documentation of the `Nx.add/2` function. (★☆☆)**
 
 ```elixir
-import IEx.Helpers
-h(Nx.add())
+# Add your solution here.
+:ok
 ```
 
-**6. Create a tensor of zeros of size 10 but the fifth value which is 1 (★☆☆)**
+<details class="rounded-lg border-2 border-green-bright-300 p-2">
+  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
+  <div class="p-2">
+
+  ```elixir
+  import IEx.Helpers
+  h Nx.add
+  ```
+
+  </div>
+</details>
+
+<!-- livebook:{"break_markdown":true} -->
+
+**6. Create a tensor of zeros of size 10 but where the fifth value is 1. (★☆☆)**
 
 ```elixir
-zeros = Nx.broadcast(0, {10})
-index = Nx.tensor([4])
-Nx.indexed_put(zeros, index, 1)
+# Add your solution here.
+:ok
 ```
 
-**7. Create a tensor with values ranging from 10 to 49 (★☆☆)**
+<details class="rounded-lg border-2 border-green-bright-300 p-2">
+  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
+  <div class="p-2">
+
+  ```elixir
+  zeros = Nx.broadcast(0, {10})
+  index = Nx.tensor([4])
+  Nx.indexed_put(zeros, index, 1)
+  ```
+
+  </div>
+</details>
+
+<!-- livebook:{"break_markdown":true} -->
+
+**7. Create a tensor with values ranging from 10 to 49. (★☆☆)**
 
 ```elixir
-Nx.linspace(10, 49, n: 39, type: :s8)
+# Add your solution here.
+:ok
 ```
 
-**8. Reverse a tensor (first element becomes last) (★☆☆)**
+<details class="rounded-lg border-2 border-green-bright-300 p-2">
+  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
+  <div class="p-2">
+
+  ```elixir
+  Nx.linspace(10, 49, n: 39, type: :s8)
+  ```
+
+  </div>
+</details>
+
+<!-- livebook:{"break_markdown":true} -->
+
+**8. Reverse `tensor_08` (first element becomes last). (★☆☆)**
 
 ```elixir
-Nx.iota({10})
-|> Nx.reverse()
+tensor_08 = Nx.tensor([2, 4, 6, 8])
+# Add your solution here.
+:ok
 ```
 
-**9. Create a 3x3 tensor with values ranging from 0 to 8 (★☆☆)**
+<details class="rounded-lg border-2 border-green-bright-300 p-2">
+  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
+  <div class="p-2">
+
+  ```elixir
+  Nx.reverse(tensor_08)
+  ```
+
+  </div>
+</details>
+
+<!-- livebook:{"break_markdown":true} -->
+
+**9. Create a 3x3 tensor with values ranging from 0 to 8. (★☆☆)**
 
 ```elixir
-Nx.iota({3, 3})
+# Add your solution here.
+:ok
 ```
+
+<details class="rounded-lg border-2 border-green-bright-300 p-2">
+  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
+  <div class="p-2">
+
+  ```elixir
+  Nx.iota({3, 3})
+  ```
+
+  </div>
+</details>
+
+<!-- livebook:{"break_markdown":true} -->
 
 **10a. Given an initial `tensor_10`, build a "mask" of non-zero elements. That is, build a second tensor with the same shape as the original, but that has a 1 wherever the original has a non-zero element and a 0 elsewhere. (★☆☆)**
 
 ```elixir
 tensor_10 = Nx.tensor([1, 2, 0, 0, 4, 0])
-
-mask = Nx.not_equal(tensor_10, 0)
+# Add your solution here.
+:ok
 ```
+
+<details class="rounded-lg border-2 border-green-bright-300 p-2">
+  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
+  <div class="p-2">
+
+  ```elixir
+  mask = Nx.not_equal(tensor_10, 0)
+  ```
+
+  </div>
+</details>
+
+<!-- livebook:{"break_markdown":true} -->
 
 **10b. Use the mask from 10a to replace each 0 from `tensor_10` with -1. (★☆☆)**
 
 ```elixir
-Nx.select(mask, tensor_10, -1)
+# Add your solution here.
+:ok
 ```
+
+<details class="rounded-lg border-2 border-green-bright-300 p-2">
+  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
+  <div class="p-2">
+
+  ```elixir
+  Nx.select(mask, tensor_10, -1)
+  ```
+
+  </div>
+</details>
 
 ## 11-20
 
-**11. Create a 3x3 identity tensor (★☆☆)**
+**11. Create a 3x3 identity tensor. (★☆☆)**
 
 ```elixir
-Nx.eye(3)
+# Add your solution here.
+:ok
 ```
 
-**12. Create a 3x3x3 tensor with random values (★☆☆)**
+<details class="rounded-lg border-2 border-green-bright-300 p-2">
+  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
+  <div class="p-2">
+
+  ```elixir
+  Nx.eye(3)
+  ```
+
+  </div>
+</details>
+
+<!-- livebook:{"break_markdown":true} -->
+
+**12. Create a 3x3x3 tensor with random values. (★☆☆)**
 
 ```elixir
-key = Nx.Random.key(0)
-{random, _} = Nx.Random.normal(key, shape: {3, 3, 3})
-random
+# Add your solution here.
+:ok
 ```
 
-**13. Create a 10x10 tensor with random values and find the minimum and maximum values (★☆☆)**
+<details class="rounded-lg border-2 border-green-bright-300 p-2">
+  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
+  <div class="p-2">
+
+  ```elixir
+  key = Nx.Random.key(0)
+  {random, _} = Nx.Random.normal(key, shape: {3, 3, 3})
+  random
+  ```
+
+  </div>
+</details>
+
+<!-- livebook:{"break_markdown":true} -->
+
+**13. Create a random 10x10 tensor then find its minimum and maximum values. (★☆☆)**
 
 ```elixir
-key = Nx.Random.key(0)
-{r, _} = Nx.Random.normal(key, shape: {10, 10})
-r |> IO.inspect()
-
-%{
-  min: Nx.reduce_min(r),
-  max: Nx.reduce_max(r)
-}
+# Add your solution here.
+:ok
 ```
 
-**14. Create a random 1D tensor of size 30 and find the mean value (★☆☆)**
+<details class="rounded-lg border-2 border-green-bright-300 p-2">
+  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
+  <div class="p-2">
+
+  ```elixir
+  key = Nx.Random.key(0)
+  {tensor_13, _} = Nx.Random.normal(key, shape: {10, 10})
+
+  %{
+    min: Nx.reduce_min(tensor_13),
+    max: Nx.reduce_max(tensor_13)
+  }
+  ```
+
+  </div>
+</details>
+
+<!-- livebook:{"break_markdown":true} -->
+
+**14. Create a 1D tensor of size 30 then find its mean. (★☆☆)**
 
 ```elixir
-key = Nx.Random.key(0)
-{r, _} = Nx.Random.normal(key, shape: {30})
-Nx.mean(r)
+# Add your solution here.
+:ok
 ```
 
-**15. Create a 5x5 tensor with 1 on the border and 0 inside (★☆☆)**
+<details class="rounded-lg border-2 border-green-bright-300 p-2">
+  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
+  <div class="p-2">
+
+  ```elixir
+  key = Nx.Random.key(0)
+  {tensor_14, _} = Nx.Random.normal(key, shape: {30})
+
+  Nx.mean(tensor_14)
+  ```
+
+  </div>
+</details>
+
+<!-- livebook:{"break_markdown":true} -->
+
+**15. Create a 4x4 tensor with 1 on the border and 0 inside. (★☆☆)**
 
 ```elixir
-Nx.broadcast(0, {3, 3})
-|> Nx.pad(1, [{1, 1, 0}, {1, 1, 0}])
+# Add your solution here.
+:ok
 ```
 
-**16. How to add a border (filled with 0's) around an existing array? (★☆☆)**
+<details class="rounded-lg border-2 border-green-bright-300 p-2">
+  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
+  <div class="p-2">
+
+  ```elixir
+  Nx.broadcast(1, {4, 4})
+  |> Nx.put_slice([1, 1], Nx.broadcast(0, {2, 2}))
+  ```
+
+  </div>
+</details>
+
+<!-- livebook:{"break_markdown":true} -->
+
+**16. Add a border of 0 around `tensor_16` (end result will be a 5x5 tensor). (★☆☆)**
 
 ```elixir
-Nx.broadcast(1, {3, 3})
-|> Nx.pad(0, [{1, 1, 0}, {1, 1, 0}])
+tensor_16 = Nx.broadcast(1, {3, 3})
+# Add your solution here.
+:ok
 ```
 
-**17. What are the results of the following expressions? (★☆☆)**
+<details class="rounded-lg border-2 border-green-bright-300 p-2">
+  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
+  <div class="p-2">
+
+  ```elixir
+  Nx.pad(tensor_16, 0, [{1, 1, 0}, {1, 1, 0}])
+  ```
+
+  </div>
+</details>
+
+<!-- livebook:{"break_markdown":true} -->
+
+**17. Determine the results of the following expressions. (★☆☆)**
 
 ```elixir
 nan = Nx.Constants.nan()
-IO.inspect(Nx.multiply(0, nan))
-IO.inspect(Nx.equal(nan, nan))
-IO.inspect(Nx.greater(nan, nan))
-IO.inspect(Nx.subtract(nan, nan))
+Nx.multiply(0, nan)
+Nx.equal(nan, nan)
+Nx.greater(nan, nan)
+Nx.subtract(nan, nan)
+
+# Add your solution here.
+:ok
 ```
 
-**18. Create a 5x5 tensor with values 1,2,3,4 just below the diagonal (★☆☆)**
+<details class="rounded-lg border-2 border-green-bright-300 p-2">
+  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
+  <div class="p-2">
+
+  ```
+  #Nx.Tensor<
+    f32
+    NaN
+  >
+  #Nx.Tensor<
+    u8
+    0
+  >
+  #Nx.Tensor<
+    u8
+    0
+  >
+  #Nx.Tensor<
+    f32
+    NaN
+  >
+  ```
+
+  </div>
+</details>
+
+<!-- livebook:{"break_markdown":true} -->
+
+**18. Create a 5x5 tensor with values 1,2,3,4 just below the diagonal. (★☆☆)**
 
 ```elixir
-Nx.make_diagonal(Nx.tensor([1, 2, 3, 4]), offset: -1)
+# Add your solution here.
+:ok
 ```
 
-**19. Create a 8x8 tensor of 0 and 1 in a checkerboard pattern with 0 as the first element (★☆☆)**
+<details class="rounded-lg border-2 border-green-bright-300 p-2">
+  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
+  <div class="p-2">
+
+  ```elixir
+  Nx.tensor([1, 2, 3, 4])
+  |> Nx.make_diagonal(offset: -1)
+  ```
+
+  </div>
+</details>
+
+<!-- livebook:{"break_markdown":true} -->
+
+**19. Create a 8x8 tensor of 0 and 1 in a checkerboard pattern with 0 as the first element. (★☆☆)**
 
 ```elixir
-Nx.tensor([[0, 1], [1, 0]])
-|> Nx.tile([4, 4])
+# Add your solution here.
+:ok
 ```
 
-**20. What is the index (x,y,z) of the 100th element of a 6x7x8 tensor?**
+<details class="rounded-lg border-2 border-green-bright-300 p-2">
+  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
+  <div class="p-2">
+
+  ```elixir
+  Nx.tensor([[0, 1], [1, 0]])
+  |> Nx.tile([4, 4])
+  ```
+
+  </div>
+</details>
+
+<!-- livebook:{"break_markdown":true} -->
+
+**20. Find the (x,y,z) index ([row major](https://en.wikipedia.org/wiki/Row-_and_column-major_order)) of the 100th element of a 6x7x8 tensor. (★★☆)**
 
 ```elixir
-# The numpy solution is to use `unravel_index`. I didn't see an equivalent.
-# https://numpy.org/doc/stable/reference/generated/numpy.unravel_index.html
-dims = [6, 7, 8]
-target = 100
-
-# This is how I'd do it with Enum.
-dims
-|> Enum.map_reduce({target, Enum.product(dims)}, fn dim, {remaining, step_size} ->
-  step_size = div(step_size, dim)
-  num_steps = div(remaining, step_size)
-  {num_steps, {remaining - num_steps * step_size, step_size}}
-end)
-|> then(fn {indices, {0, 1}} -> indices end)
+# Add your solution here.
+:ok
 ```
+
+<details class="rounded-lg border-2 border-green-bright-300 p-2">
+  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
+  <div class="p-2">
+
+  ```elixir
+  defmodule Exercise20 do
+    import Nx.Defn
+
+    deftransform solve(shape, target) do
+      dims = Tuple.to_list(shape)
+      
+      dims
+      |> Enum.map_reduce({target, Enum.product(dims)}, fn dim, {remaining, step_size} ->
+        step_size = div(step_size, dim)
+        num_steps = div(remaining, step_size)
+        {num_steps, {remaining - num_steps * step_size, step_size}}
+      end)
+      |> then(fn {indices, {0, 1}} -> indices end)
+    end
+  end
+
+  Exercise20.solve({6, 7, 8}, 100)
+  ```
+
+  </div>
+</details>

--- a/nx/exercises/exercises-1-20.livemd
+++ b/nx/exercises/exercises-1-20.livemd
@@ -88,7 +88,27 @@ tensor = Nx.tensor([[1, 2, 3], [4, 5, 6]])
 
 <!-- livebook:{"break_markdown":true} -->
 
-**5. Use `IEx.Helpers` to print the documentation of the `Nx.add/2` function. (★☆☆)**
+**5a. Use `Nx.sum/2` to find the sum of all elements of `tensor`. (★☆☆)**
+
+```elixir
+tensor = Nx.tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+# Add your solution here.
+```
+
+<details class="rounded-lg border-2 border-green-bright-300 p-2">
+  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
+  <div class="p-2">
+
+  ```elixir
+  Nx.sum(tensor)
+  ```
+
+  </div>
+</details>
+
+<!-- livebook:{"break_markdown":true} -->
+
+**5b. Read the [documentation for `Nx.sum/2`](https://hexdocs.pm/nx/Nx.html#sum/2) then provide the correct option to sum across the _rows_. (★☆☆)**
 
 ```elixir
 # Add your solution here.
@@ -99,9 +119,18 @@ tensor = Nx.tensor([[1, 2, 3], [4, 5, 6]])
   <div class="p-2">
 
   ```elixir
-  import IEx.Helpers
-  h Nx.add
+  Nx.sum(tensor, axes: [1])
   ```
+
+  <div class="mt-4">
+    <div class="bg-blue-600 text-white font-bold rounded-t-lg px-4 py-2">
+      <span class="mr-1"><i class="ri-lightbulb-line"></i></span>
+      <span>Tip</span>
+    </div>
+    <div class="border border-t-0 border-blue-600 rounded-b-lg px-4">
+      <p>In Livebook, you can also hover over a function to display its documentation.</p>
+    </div>
+  </div>
 
   </div>
 </details>

--- a/nx/exercises/exercises-1-20.livemd
+++ b/nx/exercises/exercises-1-20.livemd
@@ -99,7 +99,7 @@ random
 # This felt a little awkward. Is there a better way?
 
 key = Nx.Random.key(0)
-{r, _} = Nx.Random.normal(key, shape: {3, 3})
+{r, _} = Nx.Random.normal(key, shape: {10, 10})
 r |> IO.inspect()
 
 %{

--- a/nx/exercises/exercises-1-20.livemd
+++ b/nx/exercises/exercises-1-20.livemd
@@ -146,7 +146,7 @@ IO.inspect(Nx.subtract(nan, nan))
 Nx.make_diagonal(Nx.tensor([1, 2, 3, 4]), offset: -1)
 ```
 
-1. Create a 8x8 tensor of 0s and 1s in a checkerboard pattern with 0 as the first element (★☆☆)
+1. Create a 8x8 tensor of 0 and 1 in a checkerboard pattern with 0 as the first element (★☆☆)
 
 ```elixir
 Nx.tensor([0, 0, 0, 0])

--- a/nx/exercises/exercises-1-20.livemd
+++ b/nx/exercises/exercises-1-20.livemd
@@ -108,11 +108,10 @@ random
 key = Nx.Random.key(0)
 {r, _} = Nx.Random.normal(key, shape: {3, 3})
 r |> IO.inspect()
-r_1d = Nx.reshape(r, {:auto})
 
 %{
-  min: Nx.to_number(r_1d[Nx.argmin(r)]),
-  max: Nx.to_number(r_1d[Nx.argmax(r)])
+  min: Nx.reduce_min(r),
+  max: Nx.reduce_max(r)
 }
 ```
 
@@ -121,7 +120,7 @@ r_1d = Nx.reshape(r, {:auto})
 ```elixir
 key = Nx.Random.key(0)
 {r, _} = Nx.Random.normal(key, shape: {30})
-r |> Nx.mean() |> Nx.to_number()
+Nx.mean(r)
 ```
 
 1. Create a 5x5 tensor with 1 on the border and 0 inside (★☆☆)

--- a/nx/exercises/exercises-1-20.livemd
+++ b/nx/exercises/exercises-1-20.livemd
@@ -152,7 +152,7 @@ tensor = Nx.tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
 
 <!-- livebook:{"break_markdown":true} -->
 
-**7. Create a tensor with values ranging from 10 to 49. (★☆☆)**
+**7. Create a 3x3 tensor with values ranging from 0 to 8. (★☆☆)**
 
 ```elixir
 # Add your solution here.
@@ -163,7 +163,7 @@ tensor = Nx.tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
   <div style="padding-top: 8px">
 
   ```elixir
-  Nx.linspace(10, 49, n: 39, type: :s8)
+  Nx.iota({3, 3})
   ```
 
   </div>
@@ -171,7 +171,40 @@ tensor = Nx.tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
 
 <!-- livebook:{"break_markdown":true} -->
 
-**8. Reverse `tensor` (first element becomes last). (★☆☆)**
+**8. Create a tensor with values ranging from 10 to 49. (★☆☆)**
+
+```elixir
+# Add your solution here.
+```
+
+<details style="margin-left: 32px">
+  <summary style="cursor: pointer; font-weight: bold;">Example solution 1</summary>
+  <div style="padding-top: 8px">
+
+  ```elixir
+  Nx.iota({39})
+  |> Nx.add(10)
+  ```
+
+  </div>
+</details>
+
+<!-- livebook:{"break_markdown":true} -->
+
+<details style="margin-left: 32px">
+  <summary style="cursor: pointer; font-weight: bold;">Example solution 2</summary>
+  <div style="padding-top: 8px">
+
+  ```elixir
+  Nx.linspace(10, 49, n: 39, type: :s64)
+  ```
+
+  </div>
+</details>
+
+<!-- livebook:{"break_markdown":true} -->
+
+**9. Reverse `tensor` (first element becomes last). (★☆☆)**
 
 ```elixir
 tensor = Nx.tensor([2, 4, 6, 8])
@@ -184,25 +217,6 @@ tensor = Nx.tensor([2, 4, 6, 8])
 
   ```elixir
   Nx.reverse(tensor)
-  ```
-
-  </div>
-</details>
-
-<!-- livebook:{"break_markdown":true} -->
-
-**9. Create a 3x3 tensor with values ranging from 0 to 8. (★☆☆)**
-
-```elixir
-# Add your solution here.
-```
-
-<details style="margin-left: 32px">
-  <summary style="cursor: pointer; font-weight: bold;">Example solution</summary>
-  <div style="padding-top: 8px">
-
-  ```elixir
-  Nx.iota({3, 3})
   ```
 
   </div>

--- a/nx/exercises/exercises-1-20.livemd
+++ b/nx/exercises/exercises-1-20.livemd
@@ -307,7 +307,7 @@ tensor_10 = Nx.tensor([1, 2, 0, 0, 4, 0])
 
 <!-- livebook:{"break_markdown":true} -->
 
-**14. Create a 1D tensor of size 30 then find its mean. (★☆☆)**
+**14. Create a random 1D tensor of size 30 then find its mean. (★☆☆)**
 
 ```elixir
 # Add your solution here.

--- a/nx/exercises/exercises-1-20.livemd
+++ b/nx/exercises/exercises-1-20.livemd
@@ -48,10 +48,10 @@ Inspired by the Python notebook [100 Numpy Exercises](https://www.kaggle.com/cod
 
 <!-- livebook:{"break_markdown":true} -->
 
-**3. Find the number of elements in `tensor_03`. (★☆☆)**
+**3. Find the number of elements in `tensor`. (★☆☆)**
 
 ```elixir
-tensor_03 = Nx.tensor([[1, 2, 3], [4, 5, 6]])
+tensor = Nx.tensor([[1, 2, 3], [4, 5, 6]])
 # Add your solution here.
 ```
 
@@ -60,7 +60,7 @@ tensor_03 = Nx.tensor([[1, 2, 3], [4, 5, 6]])
   <div class="p-2">
 
   ```elixir
-  Nx.size(tensor_03)
+  Nx.size(tensor)
   ```
 
   </div>
@@ -68,10 +68,10 @@ tensor_03 = Nx.tensor([[1, 2, 3], [4, 5, 6]])
 
 <!-- livebook:{"break_markdown":true} -->
 
-**4. Find the number of bytes of memory in `tensor_04`. (★☆☆)**
+**4. Find the number of bytes of memory in `tensor`. (★☆☆)**
 
 ```elixir
-tensor_04 = Nx.tensor([[1, 2, 3], [4, 5, 6]])
+tensor = Nx.tensor([[1, 2, 3], [4, 5, 6]])
 # Add your solution here.
 ```
 
@@ -80,7 +80,7 @@ tensor_04 = Nx.tensor([[1, 2, 3], [4, 5, 6]])
   <div class="p-2">
 
   ```elixir
-  Nx.byte_size(tensor_04)
+  Nx.byte_size(tensor)
   ```
 
   </div>
@@ -148,10 +148,10 @@ tensor_04 = Nx.tensor([[1, 2, 3], [4, 5, 6]])
 
 <!-- livebook:{"break_markdown":true} -->
 
-**8. Reverse `tensor_08` (first element becomes last). (★☆☆)**
+**8. Reverse `tensor` (first element becomes last). (★☆☆)**
 
 ```elixir
-tensor_08 = Nx.tensor([2, 4, 6, 8])
+tensor = Nx.tensor([2, 4, 6, 8])
 # Add your solution here.
 ```
 
@@ -160,7 +160,7 @@ tensor_08 = Nx.tensor([2, 4, 6, 8])
   <div class="p-2">
 
   ```elixir
-  Nx.reverse(tensor_08)
+  Nx.reverse(tensor)
   ```
 
   </div>
@@ -187,10 +187,10 @@ tensor_08 = Nx.tensor([2, 4, 6, 8])
 
 <!-- livebook:{"break_markdown":true} -->
 
-**10a. Given an initial `tensor_10`, build a "mask" of non-zero elements. That is, build a second tensor with the same shape as the original, but that has a 1 wherever the original has a non-zero element and a 0 elsewhere. (★☆☆)**
+**10a. Given an initial `tensor`, build a "mask" of non-zero elements. That is, build a second tensor with the same shape as the original, but that has a 1 wherever the original has a non-zero element and a 0 elsewhere. (★☆☆)**
 
 ```elixir
-tensor_10 = Nx.tensor([1, 2, 0, 0, 4, 0])
+tensor = Nx.tensor([1, 2, 0, 0, 4, 0])
 # Add your solution here.
 ```
 
@@ -199,7 +199,7 @@ tensor_10 = Nx.tensor([1, 2, 0, 0, 4, 0])
   <div class="p-2">
 
   ```elixir
-  mask = Nx.not_equal(tensor_10, 0)
+  mask = Nx.not_equal(tensor, 0)
   ```
 
   </div>
@@ -207,7 +207,7 @@ tensor_10 = Nx.tensor([1, 2, 0, 0, 4, 0])
 
 <!-- livebook:{"break_markdown":true} -->
 
-**10b. Use the mask from 10a to replace each 0 from `tensor_10` with -1. (★☆☆)**
+**10b. Use the mask from 10a to replace each 0 from `tensor` with -1. (★☆☆)**
 
 ```elixir
 # Add your solution here.
@@ -218,7 +218,7 @@ tensor_10 = Nx.tensor([1, 2, 0, 0, 4, 0])
   <div class="p-2">
 
   ```elixir
-  Nx.select(mask, tensor_10, -1)
+  Nx.select(mask, tensor, -1)
   ```
 
   </div>
@@ -278,11 +278,11 @@ tensor_10 = Nx.tensor([1, 2, 0, 0, 4, 0])
 
   ```elixir
   key = Nx.Random.key(0)
-  {tensor_13, _} = Nx.Random.normal(key, shape: {10, 10})
+  {tensor, _} = Nx.Random.normal(key, shape: {10, 10})
 
   %{
-    min: Nx.reduce_min(tensor_13),
-    max: Nx.reduce_max(tensor_13)
+    min: Nx.reduce_min(tensor),
+    max: Nx.reduce_max(tensor)
   }
   ```
 
@@ -303,9 +303,9 @@ tensor_10 = Nx.tensor([1, 2, 0, 0, 4, 0])
 
   ```elixir
   key = Nx.Random.key(0)
-  {tensor_14, _} = Nx.Random.normal(key, shape: {30})
+  {tensor, _} = Nx.Random.normal(key, shape: {30})
 
-  Nx.mean(tensor_14)
+  Nx.mean(tensor)
   ```
 
   </div>
@@ -333,10 +333,10 @@ tensor_10 = Nx.tensor([1, 2, 0, 0, 4, 0])
 
 <!-- livebook:{"break_markdown":true} -->
 
-**16. Add a border of 0 around `tensor_16` (end result will be a 5x5 tensor). (★☆☆)**
+**16. Add a border of 0 around `tensor` (end result will be a 5x5 tensor). (★☆☆)**
 
 ```elixir
-tensor_16 = Nx.broadcast(1, {3, 3})
+tensor = Nx.broadcast(1, {3, 3})
 # Add your solution here.
 ```
 
@@ -345,7 +345,7 @@ tensor_16 = Nx.broadcast(1, {3, 3})
   <div class="p-2">
 
   ```elixir
-  Nx.pad(tensor_16, 0, [{1, 1, 0}, {1, 1, 0}])
+  Nx.pad(tensor, 0, [{1, 1, 0}, {1, 1, 0}])
   ```
 
   </div>

--- a/nx/exercises/exercises-1-20.livemd
+++ b/nx/exercises/exercises-1-20.livemd
@@ -72,11 +72,18 @@ Nx.iota({10})
 Nx.iota({3, 3})
 ```
 
-**10. Find indices of non-zero elements from [1,2,0,0,4,0] (★☆☆)**
+**10a. Given an initial `tensor_10`, build a "mask" of non-zero elements. That is, build a second tensor with the same shape as the original, but that has a 1 wherever the original has a non-zero element and a 0 elsewhere. (★☆☆)**
 
 ```elixir
-Nx.tensor([1, 2, 0, 0, 4, 0])
-|> Nx.not_equal(0)
+tensor_10 = Nx.tensor([1, 2, 0, 0, 4, 0])
+
+mask = Nx.not_equal(tensor_10, 0)
+```
+
+**10b. Use the mask from 10a to replace each 0 from `tensor_10` with -1. (★☆☆)**
+
+```elixir
+Nx.select(mask, tensor_10, -1)
 ```
 
 ## 11-20

--- a/nx/exercises/exercises-1-20.livemd
+++ b/nx/exercises/exercises-1-20.livemd
@@ -14,7 +14,6 @@ Inspired by the Python notebook [100 Numpy Exercises](https://www.kaggle.com/cod
 
 ```elixir
 # Add your solution here.
-:ok
 ```
 
 <details class="rounded-lg border-2 border-green-bright-300 p-2">
@@ -34,7 +33,6 @@ Inspired by the Python notebook [100 Numpy Exercises](https://www.kaggle.com/cod
 
 ```elixir
 # Add your solution here.
-:ok
 ```
 
 <details class="rounded-lg border-2 border-green-bright-300 p-2">
@@ -55,7 +53,6 @@ Inspired by the Python notebook [100 Numpy Exercises](https://www.kaggle.com/cod
 ```elixir
 tensor_03 = Nx.tensor([[1, 2, 3], [4, 5, 6]])
 # Add your solution here.
-:ok
 ```
 
 <details class="rounded-lg border-2 border-green-bright-300 p-2">
@@ -76,7 +73,6 @@ tensor_03 = Nx.tensor([[1, 2, 3], [4, 5, 6]])
 ```elixir
 tensor_04 = Nx.tensor([[1, 2, 3], [4, 5, 6]])
 # Add your solution here.
-:ok
 ```
 
 <details class="rounded-lg border-2 border-green-bright-300 p-2">
@@ -96,7 +92,6 @@ tensor_04 = Nx.tensor([[1, 2, 3], [4, 5, 6]])
 
 ```elixir
 # Add your solution here.
-:ok
 ```
 
 <details class="rounded-lg border-2 border-green-bright-300 p-2">
@@ -117,7 +112,6 @@ tensor_04 = Nx.tensor([[1, 2, 3], [4, 5, 6]])
 
 ```elixir
 # Add your solution here.
-:ok
 ```
 
 <details class="rounded-lg border-2 border-green-bright-300 p-2">
@@ -139,7 +133,6 @@ tensor_04 = Nx.tensor([[1, 2, 3], [4, 5, 6]])
 
 ```elixir
 # Add your solution here.
-:ok
 ```
 
 <details class="rounded-lg border-2 border-green-bright-300 p-2">
@@ -160,7 +153,6 @@ tensor_04 = Nx.tensor([[1, 2, 3], [4, 5, 6]])
 ```elixir
 tensor_08 = Nx.tensor([2, 4, 6, 8])
 # Add your solution here.
-:ok
 ```
 
 <details class="rounded-lg border-2 border-green-bright-300 p-2">
@@ -180,7 +172,6 @@ tensor_08 = Nx.tensor([2, 4, 6, 8])
 
 ```elixir
 # Add your solution here.
-:ok
 ```
 
 <details class="rounded-lg border-2 border-green-bright-300 p-2">
@@ -201,7 +192,6 @@ tensor_08 = Nx.tensor([2, 4, 6, 8])
 ```elixir
 tensor_10 = Nx.tensor([1, 2, 0, 0, 4, 0])
 # Add your solution here.
-:ok
 ```
 
 <details class="rounded-lg border-2 border-green-bright-300 p-2">
@@ -221,7 +211,6 @@ tensor_10 = Nx.tensor([1, 2, 0, 0, 4, 0])
 
 ```elixir
 # Add your solution here.
-:ok
 ```
 
 <details class="rounded-lg border-2 border-green-bright-300 p-2">
@@ -241,7 +230,6 @@ tensor_10 = Nx.tensor([1, 2, 0, 0, 4, 0])
 
 ```elixir
 # Add your solution here.
-:ok
 ```
 
 <details class="rounded-lg border-2 border-green-bright-300 p-2">
@@ -261,7 +249,6 @@ tensor_10 = Nx.tensor([1, 2, 0, 0, 4, 0])
 
 ```elixir
 # Add your solution here.
-:ok
 ```
 
 <details class="rounded-lg border-2 border-green-bright-300 p-2">
@@ -283,7 +270,6 @@ tensor_10 = Nx.tensor([1, 2, 0, 0, 4, 0])
 
 ```elixir
 # Add your solution here.
-:ok
 ```
 
 <details class="rounded-lg border-2 border-green-bright-300 p-2">
@@ -309,7 +295,6 @@ tensor_10 = Nx.tensor([1, 2, 0, 0, 4, 0])
 
 ```elixir
 # Add your solution here.
-:ok
 ```
 
 <details class="rounded-lg border-2 border-green-bright-300 p-2">
@@ -332,7 +317,6 @@ tensor_10 = Nx.tensor([1, 2, 0, 0, 4, 0])
 
 ```elixir
 # Add your solution here.
-:ok
 ```
 
 <details class="rounded-lg border-2 border-green-bright-300 p-2">
@@ -354,7 +338,6 @@ tensor_10 = Nx.tensor([1, 2, 0, 0, 4, 0])
 ```elixir
 tensor_16 = Nx.broadcast(1, {3, 3})
 # Add your solution here.
-:ok
 ```
 
 <details class="rounded-lg border-2 border-green-bright-300 p-2">
@@ -380,7 +363,6 @@ Nx.greater(nan, nan)
 Nx.subtract(nan, nan)
 
 # Add your solution here.
-:ok
 ```
 
 <details class="rounded-lg border-2 border-green-bright-300 p-2">
@@ -415,7 +397,6 @@ Nx.subtract(nan, nan)
 
 ```elixir
 # Add your solution here.
-:ok
 ```
 
 <details class="rounded-lg border-2 border-green-bright-300 p-2">
@@ -436,7 +417,6 @@ Nx.subtract(nan, nan)
 
 ```elixir
 # Add your solution here.
-:ok
 ```
 
 <details class="rounded-lg border-2 border-green-bright-300 p-2">
@@ -457,7 +437,6 @@ Nx.subtract(nan, nan)
 
 ```elixir
 # Add your solution here.
-:ok
 ```
 
 <details class="rounded-lg border-2 border-green-bright-300 p-2">

--- a/nx/exercises/exercises-1-20.livemd
+++ b/nx/exercises/exercises-1-20.livemd
@@ -24,10 +24,18 @@ Mix.install([{:nx, "~> 0.6"}])
 Nx.broadcast(0, {10})
 ```
 
+1. How to find the number of elements in a tensor (★☆☆)
+
+```elixir
+Nx.tensor([[1, 2, 3], [4, 5, 6]])
+|> Nx.size()
+```
+
 1. How to find the memory size of any tensor (★☆☆)
 
 ```elixir
-Nx.byte_size(Nx.tensor([[1, 2, 3], [4, 5, 6]]))
+Nx.tensor([[1, 2, 3], [4, 5, 6]])
+|> Nx.byte_size()
 ```
 
 1. How to get the documentation of the `add/2` function from the command line? (★☆☆)

--- a/nx/exercises/exercises-1-20.livemd
+++ b/nx/exercises/exercises-1-20.livemd
@@ -149,9 +149,8 @@ Nx.make_diagonal(Nx.tensor([1, 2, 3, 4]), offset: -1)
 1. Create a 8x8 tensor of 0 and 1 in a checkerboard pattern with 0 as the first element (★☆☆)
 
 ```elixir
-Nx.tensor([0, 0, 0, 0])
-|> Nx.make_diagonal()
-|> Nx.pad(1, [{0, 0, 1}, {0, 0, 1}])
+Nx.tensor([[0, 1], [1, 0]])
+|> Nx.tile([4, 4])
 ```
 
 1. What is the index (x,y,z) of the 100th element of a 6x7x8 tensor?

--- a/nx/exercises/exercises-1-20.livemd
+++ b/nx/exercises/exercises-1-20.livemd
@@ -18,14 +18,14 @@ https://www.kaggle.com/code/utsav15/100-numpy-exercises/notebook
 Mix.install([{:nx, github: "elixir-nx/nx", sparse: "nx"}])
 ```
 
-2. Print the Nx version and the configuration (★☆☆)
+1. Print the Nx version and the configuration (★☆☆)
 
 ```elixir
 version = Application.spec(:nx, :vsn)
 # I'm not sure if there's an equivalent for "configuration"
 ```
 
-3. Create a 1-D tensor of 10 zeros (★☆☆)
+1. Create a 1-D tensor of 10 zeros (★☆☆)
 
 ```elixir
 # I'm not sure what the best way to do this is.
@@ -44,20 +44,20 @@ version = Application.spec(:nx, :vsn)
 0 |> List.duplicate(10) |> Nx.tensor()
 ```
 
-4. How to find the memory size of any tensor (★☆☆)
+1. How to find the memory size of any tensor (★☆☆)
 
 ```elixir
 Nx.byte_size(Nx.tensor([[1, 2, 3], [4, 5, 6]]))
 ```
 
-5. How to get the documentation of the `add/2` function from the command line? (★☆☆)
+1. How to get the documentation of the `add/2` function from the command line? (★☆☆)
 
 ```elixir
 # I don't know if this is possible.
 # iex> h Nx.add
 ```
 
-6. Create a tensor of zeros of size 10 but the fifth value which is 1 (★☆☆)
+1. Create a tensor of zeros of size 10 but the fifth value which is 1 (★☆☆)
 
 ```elixir
 zeros = 0 |> List.duplicate(10) |> Nx.tensor()
@@ -65,7 +65,7 @@ index = Nx.tensor([4])
 Nx.indexed_put(zeros, index, 1)
 ```
 
-7. Create a tensor with values ranging from 10 to 49 (★☆☆)
+1. Create a tensor with values ranging from 10 to 49 (★☆☆)
 
 ```elixir
 # 1.
@@ -77,20 +77,20 @@ Nx.indexed_put(zeros, index, 1)
 Nx.linspace(10, 49, n: 39, type: :s8)
 ```
 
-8. Reverse a tensor (first element becomes last) (★☆☆)
+1. Reverse a tensor (first element becomes last) (★☆☆)
 
 ```elixir
 Nx.iota({10})
 |> Nx.reverse()
 ```
 
-9. Create a 3x3 tensor with values ranging from 0 to 8 (★☆☆)
+1. Create a 3x3 tensor with values ranging from 0 to 8 (★☆☆)
 
 ```elixir
 Nx.iota({3, 3})
 ```
 
-10. Find indices of non-zero elements from [1,2,0,0,4,0] (★☆☆)
+1. Find indices of non-zero elements from [1,2,0,0,4,0] (★☆☆)
 
 ```elixir
 Nx.tensor([1, 2, 0, 0, 4, 0])
@@ -99,13 +99,13 @@ Nx.tensor([1, 2, 0, 0, 4, 0])
 
 ## 11-20
 
-11. Create a 3x3 identity tensor (★☆☆)
+1. Create a 3x3 identity tensor (★☆☆)
 
 ```elixir
 Nx.eye(3)
 ```
 
-12. Create a 3x3x3 tensor with random values (★☆☆)
+1. Create a 3x3x3 tensor with random values (★☆☆)
 
 ```elixir
 key = Nx.Random.key(0)
@@ -113,7 +113,7 @@ key = Nx.Random.key(0)
 random
 ```
 
-13. Create a 10x10 tensor with random values and find the minimum and maximum values (★☆☆)
+1. Create a 10x10 tensor with random values and find the minimum and maximum values (★☆☆)
 
 ```elixir
 # This felt a little awkward. Is there a better way?
@@ -129,7 +129,7 @@ r_1d = Nx.reshape(r, {:auto})
 }
 ```
 
-14. Create a random 1D tensor of size 30 and find the mean value (★☆☆)
+1. Create a random 1D tensor of size 30 and find the mean value (★☆☆)
 
 ```elixir
 key = Nx.Random.key(0)
@@ -137,21 +137,21 @@ key = Nx.Random.key(0)
 r |> Nx.mean() |> Nx.to_number()
 ```
 
-15. Create a 5x5 tensor with 1 on the border and 0 inside (★☆☆)
+1. Create a 5x5 tensor with 1 on the border and 0 inside (★☆☆)
 
 ```elixir
 zeros_3x3 = Nx.make_diagonal(Nx.tensor([0, 0, 0]))
 Nx.pad(zeros_3x3, 1, [{1, 1, 0}, {1, 1, 0}])
 ```
 
-16. How to add a border (filled with 0's) around an existing array? (★☆☆)
+1. How to add a border (filled with 0's) around an existing array? (★☆☆)
 
 ```elixir
 ones_3x3 = 1 |> List.duplicate(9) |> Nx.tensor() |> Nx.reshape({3, 3})
 Nx.pad(ones_3x3, 0, [{1, 1, 0}, {1, 1, 0}])
 ```
 
-17. What are the results of the following expressions? (★☆☆)
+1. What are the results of the following expressions? (★☆☆)
 
 ```elixir
 nan = Nx.Constants.nan()
@@ -163,13 +163,13 @@ IO.inspect(Enum.member?(MapSet.new([nan]), nan))
 IO.inspect(0.3 == 3 * 0.1)
 ```
 
-18. Create a 5x5 tensor with values 1,2,3,4 just below the diagonal (★☆☆)
+1. Create a 5x5 tensor with values 1,2,3,4 just below the diagonal (★☆☆)
 
 ```elixir
 Nx.make_diagonal(Nx.tensor([1, 2, 3, 4]), offset: -1)
 ```
 
-19. Create a 8x8 tensor of 0s and 1s in a checkerboard pattern with 0 as the first element (★☆☆)
+1. Create a 8x8 tensor of 0s and 1s in a checkerboard pattern with 0 as the first element (★☆☆)
 
 ```elixir
 Nx.tensor([0, 0, 0, 0])
@@ -177,7 +177,7 @@ Nx.tensor([0, 0, 0, 0])
 |> Nx.pad(1, [{0, 0, 1}, {0, 0, 1}])
 ```
 
-20. What is the index (x,y,z) of the 100th element of a 6x7x8 tensor?
+1. What is the index (x,y,z) of the 100th element of a 6x7x8 tensor?
 
 ```elixir
 # The numpy solution is to use `unravel_index`. I didn't see an equivalent.

--- a/nx/exercises/exercises-1-20.livemd
+++ b/nx/exercises/exercises-1-20.livemd
@@ -16,9 +16,9 @@ Inspired by the Python notebook [100 Numpy Exercises](https://www.kaggle.com/cod
 # Add your solution here.
 ```
 
-<details class="rounded-lg border-2 border-green-bright-300 p-2">
-  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
-  <div class="p-2">
+<details style="margin-left: 32px">
+  <summary style="cursor: pointer; font-weight: bold;">Example solution</summary>
+  <div style="padding-top: 8px">
 
   ```elixir
   Mix.install([{:nx, "~> 0.6"}])
@@ -35,9 +35,9 @@ Inspired by the Python notebook [100 Numpy Exercises](https://www.kaggle.com/cod
 # Add your solution here.
 ```
 
-<details class="rounded-lg border-2 border-green-bright-300 p-2">
-  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
-  <div class="p-2">
+<details style="margin-left: 32px">
+  <summary style="cursor: pointer; font-weight: bold;">Example solution</summary>
+  <div style="padding-top: 8px">
 
   ```elixir
   Nx.broadcast(0, {10})
@@ -55,9 +55,9 @@ tensor = Nx.tensor([[1, 2, 3], [4, 5, 6]])
 # Add your solution here.
 ```
 
-<details class="rounded-lg border-2 border-green-bright-300 p-2">
-  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
-  <div class="p-2">
+<details style="margin-left: 32px">
+  <summary style="cursor: pointer; font-weight: bold;">Example solution</summary>
+  <div style="padding-top: 8px">
 
   ```elixir
   Nx.size(tensor)
@@ -75,9 +75,9 @@ tensor = Nx.tensor([[1, 2, 3], [4, 5, 6]])
 # Add your solution here.
 ```
 
-<details class="rounded-lg border-2 border-green-bright-300 p-2">
-  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
-  <div class="p-2">
+<details style="margin-left: 32px">
+  <summary style="cursor: pointer; font-weight: bold;">Example solution</summary>
+  <div style="padding-top: 8px">
 
   ```elixir
   Nx.byte_size(tensor)
@@ -95,9 +95,9 @@ tensor = Nx.tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
 # Add your solution here.
 ```
 
-<details class="rounded-lg border-2 border-green-bright-300 p-2">
-  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
-  <div class="p-2">
+<details style="margin-left: 32px">
+  <summary style="cursor: pointer; font-weight: bold;">Example solution</summary>
+  <div style="padding-top: 8px">
 
   ```elixir
   Nx.sum(tensor)
@@ -114,20 +114,20 @@ tensor = Nx.tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
 # Add your solution here.
 ```
 
-<details class="rounded-lg border-2 border-green-bright-300 p-2">
-  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
-  <div class="p-2">
+<details style="margin-left: 32px">
+  <summary style="cursor: pointer; font-weight: bold;">Example solution</summary>
+  <div style="padding-top: 8px">
 
   ```elixir
   Nx.sum(tensor, axes: [1])
   ```
 
-  <div class="mt-4">
-    <div class="bg-blue-600 text-white font-bold rounded-t-lg px-4 py-2">
-      <span class="mr-1"><i class="ri-lightbulb-line"></i></span>
+  <div style="padding-top: 16px">
+    <div style="background-color: rgb(62 100 255); color: white; font-weight: bold; border-top-left-radius: 8px; border-top-right-radius: 8px; padding: 8px 16px;">
+      <span style="padding-right: 4px"><i class="ri-lightbulb-line"></i></span>
       <span>Tip</span>
     </div>
-    <div class="border border-t-0 border-blue-600 rounded-b-lg px-4">
+    <div style="border-width: 1px; border-color: rgb(62 100 255); border-bottom-left-radius: 8px; border-bottom-right-radius: 8px; padding: 0px 16px;">
       <p>In Livebook, you can also hover over a function to display its documentation.</p>
     </div>
   </div>
@@ -143,9 +143,9 @@ tensor = Nx.tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
 # Add your solution here.
 ```
 
-<details class="rounded-lg border-2 border-green-bright-300 p-2">
-  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
-  <div class="p-2">
+<details style="margin-left: 32px">
+  <summary style="cursor: pointer; font-weight: bold;">Example solution</summary>
+  <div style="padding-top: 8px">
 
   ```elixir
   zeros = Nx.broadcast(0, {10})
@@ -164,9 +164,9 @@ tensor = Nx.tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
 # Add your solution here.
 ```
 
-<details class="rounded-lg border-2 border-green-bright-300 p-2">
-  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
-  <div class="p-2">
+<details style="margin-left: 32px">
+  <summary style="cursor: pointer; font-weight: bold;">Example solution</summary>
+  <div style="padding-top: 8px">
 
   ```elixir
   Nx.linspace(10, 49, n: 39, type: :s8)
@@ -184,9 +184,9 @@ tensor = Nx.tensor([2, 4, 6, 8])
 # Add your solution here.
 ```
 
-<details class="rounded-lg border-2 border-green-bright-300 p-2">
-  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
-  <div class="p-2">
+<details style="margin-left: 32px">
+  <summary style="cursor: pointer; font-weight: bold;">Example solution</summary>
+  <div style="padding-top: 8px">
 
   ```elixir
   Nx.reverse(tensor)
@@ -203,9 +203,9 @@ tensor = Nx.tensor([2, 4, 6, 8])
 # Add your solution here.
 ```
 
-<details class="rounded-lg border-2 border-green-bright-300 p-2">
-  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
-  <div class="p-2">
+<details style="margin-left: 32px">
+  <summary style="cursor: pointer; font-weight: bold;">Example solution</summary>
+  <div style="padding-top: 8px">
 
   ```elixir
   Nx.iota({3, 3})
@@ -223,9 +223,9 @@ tensor = Nx.tensor([1, 2, 0, 0, 4, 0])
 # Add your solution here.
 ```
 
-<details class="rounded-lg border-2 border-green-bright-300 p-2">
-  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
-  <div class="p-2">
+<details style="margin-left: 32px">
+  <summary style="cursor: pointer; font-weight: bold;">Example solution</summary>
+  <div style="padding-top: 8px">
 
   ```elixir
   mask = Nx.not_equal(tensor, 0)
@@ -242,9 +242,9 @@ tensor = Nx.tensor([1, 2, 0, 0, 4, 0])
 # Add your solution here.
 ```
 
-<details class="rounded-lg border-2 border-green-bright-300 p-2">
-  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
-  <div class="p-2">
+<details style="margin-left: 32px">
+  <summary style="cursor: pointer; font-weight: bold;">Example solution</summary>
+  <div style="padding-top: 8px">
 
   ```elixir
   Nx.select(mask, tensor, -1)
@@ -261,9 +261,9 @@ tensor = Nx.tensor([1, 2, 0, 0, 4, 0])
 # Add your solution here.
 ```
 
-<details class="rounded-lg border-2 border-green-bright-300 p-2">
-  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
-  <div class="p-2">
+<details style="margin-left: 32px">
+  <summary style="cursor: pointer; font-weight: bold;">Example solution</summary>
+  <div style="padding-top: 8px">
 
   ```elixir
   Nx.eye(3)
@@ -280,9 +280,9 @@ tensor = Nx.tensor([1, 2, 0, 0, 4, 0])
 # Add your solution here.
 ```
 
-<details class="rounded-lg border-2 border-green-bright-300 p-2">
-  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
-  <div class="p-2">
+<details style="margin-left: 32px">
+  <summary style="cursor: pointer; font-weight: bold;">Example solution</summary>
+  <div style="padding-top: 8px">
 
   ```elixir
   key = Nx.Random.key(0)
@@ -301,9 +301,9 @@ tensor = Nx.tensor([1, 2, 0, 0, 4, 0])
 # Add your solution here.
 ```
 
-<details class="rounded-lg border-2 border-green-bright-300 p-2">
-  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
-  <div class="p-2">
+<details style="margin-left: 32px">
+  <summary style="cursor: pointer; font-weight: bold;">Example solution</summary>
+  <div style="padding-top: 8px">
 
   ```elixir
   key = Nx.Random.key(0)
@@ -326,9 +326,9 @@ tensor = Nx.tensor([1, 2, 0, 0, 4, 0])
 # Add your solution here.
 ```
 
-<details class="rounded-lg border-2 border-green-bright-300 p-2">
-  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
-  <div class="p-2">
+<details style="margin-left: 32px">
+  <summary style="cursor: pointer; font-weight: bold;">Example solution</summary>
+  <div style="padding-top: 8px">
 
   ```elixir
   key = Nx.Random.key(0)
@@ -348,9 +348,9 @@ tensor = Nx.tensor([1, 2, 0, 0, 4, 0])
 # Add your solution here.
 ```
 
-<details class="rounded-lg border-2 border-green-bright-300 p-2">
-  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
-  <div class="p-2">
+<details style="margin-left: 32px">
+  <summary style="cursor: pointer; font-weight: bold;">Example solution</summary>
+  <div style="padding-top: 8px">
 
   ```elixir
   Nx.broadcast(1, {4, 4})
@@ -369,9 +369,9 @@ tensor = Nx.broadcast(1, {3, 3})
 # Add your solution here.
 ```
 
-<details class="rounded-lg border-2 border-green-bright-300 p-2">
-  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
-  <div class="p-2">
+<details style="margin-left: 32px">
+  <summary style="cursor: pointer; font-weight: bold;">Example solution</summary>
+  <div style="padding-top: 8px">
 
   ```elixir
   Nx.pad(tensor, 0, [{1, 1, 0}, {1, 1, 0}])
@@ -394,9 +394,9 @@ Nx.subtract(nan, nan)
 # Add your solution here.
 ```
 
-<details class="rounded-lg border-2 border-green-bright-300 p-2">
-  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
-  <div class="p-2">
+<details style="margin-left: 32px">
+  <summary style="cursor: pointer; font-weight: bold;">Example solution</summary>
+  <div style="padding-top: 8px">
 
   ```
   #Nx.Tensor<
@@ -428,9 +428,9 @@ Nx.subtract(nan, nan)
 # Add your solution here.
 ```
 
-<details class="rounded-lg border-2 border-green-bright-300 p-2">
-  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
-  <div class="p-2">
+<details style="margin-left: 32px">
+  <summary style="cursor: pointer; font-weight: bold;">Example solution</summary>
+  <div style="padding-top: 8px">
 
   ```elixir
   Nx.tensor([1, 2, 3, 4])
@@ -448,9 +448,9 @@ Nx.subtract(nan, nan)
 # Add your solution here.
 ```
 
-<details class="rounded-lg border-2 border-green-bright-300 p-2">
-  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
-  <div class="p-2">
+<details style="margin-left: 32px">
+  <summary style="cursor: pointer; font-weight: bold;">Example solution</summary>
+  <div style="padding-top: 8px">
 
   ```elixir
   Nx.tensor([[0, 1], [1, 0]])
@@ -468,9 +468,9 @@ Nx.subtract(nan, nan)
 # Add your solution here.
 ```
 
-<details class="rounded-lg border-2 border-green-bright-300 p-2">
-  <summary class="cursor-pointer font-bold mx-2">Example solution</summary>
-  <div class="p-2">
+<details style="margin-left: 32px">
+  <summary style="cursor: pointer; font-weight: bold;">Example solution</summary>
+  <div style="padding-top: 8px">
 
   ```elixir
   defmodule Exercise20 do

--- a/nx/exercises/exercises-1-20.livemd
+++ b/nx/exercises/exercises-1-20.livemd
@@ -6,9 +6,7 @@ Mix.install([{:nx, "~> 0.6"}])
 
 ## Introduction
 
-Inspired by the Python notebook _100 Numpy Exercises_:
-
-https://www.kaggle.com/code/utsav15/100-numpy-exercises/notebook
+Inspired by the Python notebook [100 Numpy Exercises](https://www.kaggle.com/code/utsav15/100-numpy-exercises/notebook).
 
 ## 1-10
 

--- a/nx/exercises/exercises-1-20.livemd
+++ b/nx/exercises/exercises-1-20.livemd
@@ -28,20 +28,7 @@ version = Application.spec(:nx, :vsn)
 1. Create a 1-D tensor of 10 zeros (★☆☆)
 
 ```elixir
-# I'm not sure what the best way to do this is.
-# I think Nx could use a function like: `Nx.fill(value, shape)`
-
-# 1.
-#    0 |> List.duplicate(10) |> Nx.tensor()
-
-# 2.
-#    [0] |> Nx.tensor() |> Nx.tile([10])
-
-# 3.
-#    i = Nx.iota({10})
-#    Nx.subtract(i, i)
-
-0 |> List.duplicate(10) |> Nx.tensor()
+Nx.broadcast(0, {10})
 ```
 
 1. How to find the memory size of any tensor (★☆☆)
@@ -60,7 +47,7 @@ Nx.byte_size(Nx.tensor([[1, 2, 3], [4, 5, 6]]))
 1. Create a tensor of zeros of size 10 but the fifth value which is 1 (★☆☆)
 
 ```elixir
-zeros = 0 |> List.duplicate(10) |> Nx.tensor()
+zeros = Nx.broadcast(0, {10})
 index = Nx.tensor([4])
 Nx.indexed_put(zeros, index, 1)
 ```
@@ -140,15 +127,15 @@ r |> Nx.mean() |> Nx.to_number()
 1. Create a 5x5 tensor with 1 on the border and 0 inside (★☆☆)
 
 ```elixir
-zeros_3x3 = Nx.make_diagonal(Nx.tensor([0, 0, 0]))
-Nx.pad(zeros_3x3, 1, [{1, 1, 0}, {1, 1, 0}])
+Nx.broadcast(0, {3, 3})
+|> Nx.pad(1, [{1, 1, 0}, {1, 1, 0}])
 ```
 
 1. How to add a border (filled with 0's) around an existing array? (★☆☆)
 
 ```elixir
-ones_3x3 = 1 |> List.duplicate(9) |> Nx.tensor() |> Nx.reshape({3, 3})
-Nx.pad(ones_3x3, 0, [{1, 1, 0}, {1, 1, 0}])
+Nx.broadcast(1, {3, 3})
+|> Nx.pad(0, [{1, 1, 0}, {1, 1, 0}])
 ```
 
 1. What are the results of the following expressions? (★☆☆)

--- a/nx/exercises/exercises-1-20.livemd
+++ b/nx/exercises/exercises-1-20.livemd
@@ -41,8 +41,8 @@ Nx.tensor([[1, 2, 3], [4, 5, 6]])
 **5. How to get the documentation of the `add/2` function from the command line? (★☆☆)**
 
 ```elixir
-# I don't know if this is possible.
-# iex> h Nx.add
+import IEx.Helpers
+h(Nx.add())
 ```
 
 **6. Create a tensor of zeros of size 10 but the fifth value which is 1 (★☆☆)**

--- a/nx/exercises/exercises-1-20.livemd
+++ b/nx/exercises/exercises-1-20.livemd
@@ -123,13 +123,7 @@ tensor = Nx.tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
   ```
 
   <div style="padding-top: 16px">
-    <div style="background-color: rgb(62 100 255); color: white; font-weight: bold; border-top-left-radius: 8px; border-top-right-radius: 8px; padding: 8px 16px;">
-      <span style="padding-right: 4px"><i class="ri-lightbulb-line"></i></span>
-      <span>Tip</span>
-    </div>
-    <div style="border-width: 1px; border-color: rgb(62 100 255); border-bottom-left-radius: 8px; border-bottom-right-radius: 8px; padding: 0px 16px;">
-      <p>In Livebook, you can also hover over a function to display its documentation.</p>
-    </div>
+    <i>Tip:</i> You can also hover over a function inside Livebook code cells to display its documentation.
   </div>
 
   </div>

--- a/nx/exercises/exercises-1-20.livemd
+++ b/nx/exercises/exercises-1-20.livemd
@@ -1,0 +1,196 @@
+# Exercises: 1-20
+
+```elixir
+Mix.install([{:nx, github: "elixir-nx/nx", sparse: "nx"}])
+```
+
+## Introduction
+
+Inspired by the Python notebook _100 Numpy Exercises_:
+
+https://www.kaggle.com/code/utsav15/100-numpy-exercises/notebook
+
+## 1-10
+
+1. Install Nx in a Livebook (★☆☆)
+
+```elixir
+Mix.install([{:nx, github: "elixir-nx/nx", sparse: "nx"}])
+```
+
+2. Print the Nx version and the configuration (★☆☆)
+
+```elixir
+version = Application.spec(:nx, :vsn)
+# I'm not sure if there's an equivalent for "configuration"
+```
+
+3. Create a 1-D tensor of 10 zeros (★☆☆)
+
+```elixir
+# I'm not sure what the best way to do this is.
+# I think Nx could use a function like: `Nx.fill(value, shape)`
+
+# 1.
+#    0 |> List.duplicate(10) |> Nx.tensor()
+
+# 2.
+#    [0] |> Nx.tensor() |> Nx.tile([10])
+
+# 3.
+#    i = Nx.iota({10})
+#    Nx.subtract(i, i)
+
+0 |> List.duplicate(10) |> Nx.tensor()
+```
+
+4. How to find the memory size of any tensor (★☆☆)
+
+```elixir
+Nx.byte_size(Nx.tensor([[1, 2, 3], [4, 5, 6]]))
+```
+
+5. How to get the documentation of the `add/2` function from the command line? (★☆☆)
+
+```elixir
+# I don't know if this is possible.
+# iex> h Nx.add
+```
+
+6. Create a tensor of zeros of size 10 but the fifth value which is 1 (★☆☆)
+
+```elixir
+zeros = 0 |> List.duplicate(10) |> Nx.tensor()
+index = Nx.tensor([4])
+Nx.indexed_put(zeros, index, 1)
+```
+
+7. Create a tensor with values ranging from 10 to 49 (★☆☆)
+
+```elixir
+# 1.
+#    Nx.iota({40}) |> Nx.add(10)
+
+# 2.
+#    Nx.linspace(10, 49, n: 39, type: :s8)
+
+Nx.linspace(10, 49, n: 39, type: :s8)
+```
+
+8. Reverse a tensor (first element becomes last) (★☆☆)
+
+```elixir
+Nx.iota({10})
+|> Nx.reverse()
+```
+
+9. Create a 3x3 tensor with values ranging from 0 to 8 (★☆☆)
+
+```elixir
+Nx.iota({3, 3})
+```
+
+10. Find indices of non-zero elements from [1,2,0,0,4,0] (★☆☆)
+
+```elixir
+Nx.tensor([1, 2, 0, 0, 4, 0])
+|> Nx.not_equal(0)
+```
+
+## 11-20
+
+11. Create a 3x3 identity tensor (★☆☆)
+
+```elixir
+Nx.eye(3)
+```
+
+12. Create a 3x3x3 tensor with random values (★☆☆)
+
+```elixir
+key = Nx.Random.key(0)
+{random, _} = Nx.Random.normal(key, shape: {3, 3})
+random
+```
+
+13. Create a 10x10 tensor with random values and find the minimum and maximum values (★☆☆)
+
+```elixir
+# This felt a little awkward. Is there a better way?
+
+key = Nx.Random.key(0)
+{r, _} = Nx.Random.normal(key, shape: {3, 3})
+r |> IO.inspect()
+r_1d = Nx.reshape(r, {:auto})
+
+%{
+  min: Nx.to_number(r_1d[Nx.argmin(r)]),
+  max: Nx.to_number(r_1d[Nx.argmax(r)])
+}
+```
+
+14. Create a random 1D tensor of size 30 and find the mean value (★☆☆)
+
+```elixir
+key = Nx.Random.key(0)
+{r, _} = Nx.Random.normal(key, shape: {30})
+r |> Nx.mean() |> Nx.to_number()
+```
+
+15. Create a 5x5 tensor with 1 on the border and 0 inside (★☆☆)
+
+```elixir
+zeros_3x3 = Nx.make_diagonal(Nx.tensor([0, 0, 0]))
+Nx.pad(zeros_3x3, 1, [{1, 1, 0}, {1, 1, 0}])
+```
+
+16. How to add a border (filled with 0's) around an existing array? (★☆☆)
+
+```elixir
+ones_3x3 = 1 |> List.duplicate(9) |> Nx.tensor() |> Nx.reshape({3, 3})
+Nx.pad(ones_3x3, 0, [{1, 1, 0}, {1, 1, 0}])
+```
+
+17. What are the results of the following expressions? (★☆☆)
+
+```elixir
+nan = Nx.Constants.nan()
+IO.inspect(Nx.multiply(0, nan))
+IO.inspect(Nx.equal(nan, nan))
+IO.inspect(Nx.greater(nan, nan))
+IO.inspect(Nx.subtract(nan, nan))
+IO.inspect(Enum.member?(MapSet.new([nan]), nan))
+IO.inspect(0.3 == 3 * 0.1)
+```
+
+18. Create a 5x5 tensor with values 1,2,3,4 just below the diagonal (★☆☆)
+
+```elixir
+Nx.make_diagonal(Nx.tensor([1, 2, 3, 4]), offset: -1)
+```
+
+19. Create a 8x8 tensor of 0s and 1s in a checkerboard pattern with 0 as the first element (★☆☆)
+
+```elixir
+Nx.tensor([0, 0, 0, 0])
+|> Nx.make_diagonal()
+|> Nx.pad(1, [{0, 0, 1}, {0, 0, 1}])
+```
+
+20. What is the index (x,y,z) of the 100th element of a 6x7x8 tensor?
+
+```elixir
+# The numpy solution is to use `unravel_index`. I didn't see an equivalent.
+# https://numpy.org/doc/stable/reference/generated/numpy.unravel_index.html
+dims = [6, 7, 8]
+target = 100
+
+# This is how I'd do it with Enum.
+dims
+|> Enum.map_reduce({target, Enum.product(dims)}, fn dim, {remaining, step_size} ->
+  step_size = div(step_size, dim)
+  num_steps = div(remaining, step_size)
+  {num_steps, {remaining - num_steps * step_size, step_size}}
+end)
+|> then(fn {indices, {0, 1}} -> indices end)
+```

--- a/nx/exercises/exercises-1-20.livemd
+++ b/nx/exercises/exercises-1-20.livemd
@@ -98,8 +98,6 @@ random
 **13. Create a 10x10 tensor with random values and find the minimum and maximum values (★☆☆)**
 
 ```elixir
-# This felt a little awkward. Is there a better way?
-
 key = Nx.Random.key(0)
 {r, _} = Nx.Random.normal(key, shape: {10, 10})
 r |> IO.inspect()

--- a/nx/exercises/exercises-1-20.livemd
+++ b/nx/exercises/exercises-1-20.livemd
@@ -1,7 +1,7 @@
 # Exercises: 1-20
 
 ```elixir
-Mix.install([{:nx, github: "elixir-nx/nx", sparse: "nx"}])
+Mix.install([{:nx, "~> 0.6"}])
 ```
 
 ## Introduction
@@ -15,13 +15,7 @@ https://www.kaggle.com/code/utsav15/100-numpy-exercises/notebook
 1. Install Nx in a Livebook (★☆☆)
 
 ```elixir
-Mix.install([{:nx, github: "elixir-nx/nx", sparse: "nx"}])
-```
-
-1. Print the Nx version and the configuration (★☆☆)
-
-```elixir
-version = Application.spec(:nx, :vsn)
+Mix.install([{:nx, "~> 0.6"}])
 ```
 
 1. Create a 1-D tensor of 10 zeros (★☆☆)

--- a/nx/exercises/exercises-1-20.livemd
+++ b/nx/exercises/exercises-1-20.livemd
@@ -89,7 +89,7 @@ Nx.eye(3)
 
 ```elixir
 key = Nx.Random.key(0)
-{random, _} = Nx.Random.normal(key, shape: {3, 3})
+{random, _} = Nx.Random.normal(key, shape: {3, 3, 3})
 random
 ```
 

--- a/nx/exercises/exercises-1-20.livemd
+++ b/nx/exercises/exercises-1-20.livemd
@@ -22,7 +22,6 @@ Mix.install([{:nx, github: "elixir-nx/nx", sparse: "nx"}])
 
 ```elixir
 version = Application.spec(:nx, :vsn)
-# I'm not sure if there's an equivalent for "configuration"
 ```
 
 1. Create a 1-D tensor of 10 zeros (★☆☆)
@@ -55,12 +54,6 @@ Nx.indexed_put(zeros, index, 1)
 1. Create a tensor with values ranging from 10 to 49 (★☆☆)
 
 ```elixir
-# 1.
-#    Nx.iota({40}) |> Nx.add(10)
-
-# 2.
-#    Nx.linspace(10, 49, n: 39, type: :s8)
-
 Nx.linspace(10, 49, n: 39, type: :s8)
 ```
 

--- a/nx/mix.exs
+++ b/nx/mix.exs
@@ -60,6 +60,7 @@ defmodule Nx.MixProject do
       source_url_pattern: "#{@source_url}/blob/v#{@version}/nx/%{path}#L%{line}",
       before_closing_body_tag: &before_closing_body_tag/1,
       extras: [
+        "exercises/exercises-1-20.livemd",
         "guides/intro-to-nx.livemd",
         "guides/vectorization.livemd",
         "CHANGELOG.md"
@@ -112,6 +113,10 @@ defmodule Nx.MixProject do
           Nx.Defn.Token,
           Nx.Defn.Tree
         ]
+      ],
+      groups_for_extras: [
+        Exercises: ~r"exercises/",
+        Guides: ~r"guides/"
       ]
     ]
   end


### PR DESCRIPTION
## Description

As discussed in [Slack](https://the-eef.slack.com/archives/C01PU0RDJ8L/p1699644171094749), this PR adds a translation of the first 20 exercises from the Python notebook _100 Numpy Exercises_:

https://www.kaggle.com/code/utsav15/100-numpy-exercises/notebook

## Changes

* Adds `exercises-1-20.livemd` file
* Tweaks the doc grouping in `mix.exs`
    <img width="450" alt="Screen Shot 2023-11-10 at 5 01 14 PM" src="https://github.com/elixir-nx/nx/assets/10274508/c1599603-9572-4b5d-b338-7026e16da67f">

## Notes

* Most of these first 20 translate 1-1. There were a few that didn't. I left comments (which we'll want to remove before merging).
* Going forward, not all of the exercises are going to make sense for Nx. This is (hopefully) more a jumping off point for community-curated exercises.