### PR TITLE
Fixes the reshape example in intro Livebook.

### DIFF
--- a/nx/guides/intro-to-nx.livemd
+++ b/nx/guides/intro-to-nx.livemd
@@ -212,7 +212,7 @@ Nx.shape(tensor)
 We can also create a new tensor with a new shape using  `Nx.reshape/2`:
 
 ```elixir
-Nx.reshape(tensor, {1, 9}, names: [:batches, :values])
+Nx.reshape(tensor, {1, 4}, names: [:batches, :values])
 ```
 
 This operation reuses all of the tensor data and simply


### PR DESCRIPTION
The `tensor` should be `{2, 2}`.

<img width="953" alt="image" src="https://github.com/elixir-nx/nx/assets/214616/1fd48b41-3228-4f01-9de7-68c0e158171d">
 