### PR TITLE
docs: fix first nx serving example

### DIFF
--- a/nx/lib/nx/serving.ex
+++ b/nx/lib/nx/serving.ex
@@ -18,7 +18,7 @@ defmodule Nx.Serving do
       defmodule MyDefn do
         import Nx.Defn
 
-        defnp print_and_multiply(x) do
+        defn print_and_multiply(x) do
           x = print_value(x, label: "debug")
           x * 2
         end


### PR DESCRIPTION
Hello, i was reading the `Nx.Serving` docs and notice the private function,  i guess should be a public function the `MyDefn.print_and_multiply/1`.

before
<img width="791" alt="Screenshot 2023-12-08 at 08 03 38" src="https://github.com/elixir-nx/nx/assets/2263551/6c3db143-a4eb-4b5c-87d3-631dcea6375c">

after
<img width="569" alt="Screenshot 2023-12-08 at 08 04 08" src="https://github.com/elixir-nx/nx/assets/2263551/cda2f133-c171-45dc-ad4e-c5a10b1adad4">