### PR TITLE
Add executable serialization

### DIFF
--- a/exla/c_src/exla/exla.cc
+++ b/exla/c_src/exla/exla.cc
@@ -608,6 +608,24 @@ ERL_NIF_TERM start_log_sink(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     return exla::nif::error(env, "Bad argument count.");
   }
 
+  exla::ExlaExecutable** executable;
+
+  if (!exla::nif::get<exla::ExlaExecutable*>(env, argv[0], executable)) {
+    return exla::nif::error(env, "Unable to get executable.");
+  }
+
+  EXLA_ASSIGN_OR_RETURN_NIF(std::string serialized, (*executable)->Serialize(), env);
+
+  return exla::nif::ok(exla::nif::make(env, serialized));
+}
+
+// Serialization
+
+ERL_NIF_TERM start_log_sink(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
+  if (argc != 1) {
+    return exla::nif::error(env, "Bad argument count.");
+  }
+
   ErlNifPid logger_pid;
 
   if (!enif_get_local_pid(env, argv[0], &logger_pid)) {
@@ -880,6 +898,9 @@ static ErlNifFunc exla_funcs[] = {
     // Special
     {"optimization_barrier", 1, optimization_barrier},
     // Log Sink
-    {"start_log_sink", 1, start_log_sink}};
+    {"start_log_sink", 1, start_log_sink},
+    // Serialization
+    {"serialize_executable", 1, serialize_executable}
+  };
 
 ERL_NIF_INIT(Elixir.EXLA.NIF, exla_funcs, &load, NULL, NULL, NULL);

--- a/exla/c_src/exla/exla.cc
+++ b/exla/c_src/exla/exla.cc
@@ -614,9 +614,9 @@ ERL_NIF_TERM serialize_executable(ErlNifEnv* env, int argc, const ERL_NIF_TERM a
     return exla::nif::error(env, "Unable to get executable.");
   }
 
-  EXLA_ASSIGN_OR_RETURN_NIF(std::string serialized, (*executable)->Serialize(), env);
+  EXLA_ASSIGN_OR_RETURN_NIF(std::string serialized, (*executable)->SerializeExecutable(), env);
 
-  return exla::nif::ok(exla::nif::make(env, serialize));
+  return exla::nif::ok(env, exla::nif::make(env, serialized));
 }
 
 ERL_NIF_TERM deserialize_executable(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
@@ -635,7 +635,7 @@ ERL_NIF_TERM deserialize_executable(ErlNifEnv* env, int argc, const ERL_NIF_TERM
   }
 
   EXLA_ASSIGN_OR_RETURN_NIF(exla::ExlaExecutable * executable,
-    (*client)->DeserializeExecutable(serialized));
+    (*client)->DeserializeExecutable(serialized), env);
 
   return exla::nif::ok(env, exla::nif::make<exla::ExlaExecutable*>(env, executable));
 }
@@ -921,7 +921,8 @@ static ErlNifFunc exla_funcs[] = {
     // Log Sink
     {"start_log_sink", 1, start_log_sink},
     // Serialization
-    {"serialize_executable", 1, serialize_executable}
+    {"serialize_executable", 1, serialize_executable},
+    {"deserialize_executable", 2, deserialize_executable}
   };
 
 ERL_NIF_INIT(Elixir.EXLA.NIF, exla_funcs, &load, NULL, NULL, NULL);

--- a/exla/c_src/exla/exla.cc
+++ b/exla/c_src/exla/exla.cc
@@ -615,8 +615,11 @@ ERL_NIF_TERM serialize_executable(ErlNifEnv* env, int argc, const ERL_NIF_TERM a
   }
 
   EXLA_ASSIGN_OR_RETURN_NIF(std::string serialized, (*executable)->SerializeExecutable(), env);
+  ErlNifBinary raw;
+  enif_alloc_binary(serialized.size(), &raw);
+  std::memcpy((&raw)->data, serialized.data(), serialized.size());
 
-  return exla::nif::ok(env, exla::nif::make(env, serialized));
+  return exla::nif::ok(env, exla::nif::make(env, raw));
 }
 
 ERL_NIF_TERM deserialize_executable(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
@@ -624,8 +627,8 @@ ERL_NIF_TERM deserialize_executable(ErlNifEnv* env, int argc, const ERL_NIF_TERM
     return exla::nif::error(env, "Bad argument count.");
   }
 
-  std::string serialized;
   exla::ExlaClient** client;
+  std::string serialized;
 
   if (!exla::nif::get<exla::ExlaClient*>(env, argv[0], client)) {
     return exla::nif::error(env, "Unable to get client.");

--- a/exla/c_src/exla/exla.cc
+++ b/exla/c_src/exla/exla.cc
@@ -601,9 +601,9 @@ ERL_NIF_TERM run(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
   return term;
 }
 
-// Logging Functions
+// Serialization Functions
 
-ERL_NIF_TERM start_log_sink(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
+ERL_NIF_TERM serialize_executable(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
   if (argc != 1) {
     return exla::nif::error(env, "Bad argument count.");
   }
@@ -616,7 +616,7 @@ ERL_NIF_TERM start_log_sink(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 
   EXLA_ASSIGN_OR_RETURN_NIF(std::string serialized, (*executable)->Serialize(), env);
 
-  return exla::nif::ok(exla::nif::make(env, serialized));
+  return exla::nif::ok(exla::nif::make(env, serialize));
 }
 
 // Serialization

--- a/exla/c_src/exla/exla.cc
+++ b/exla/c_src/exla/exla.cc
@@ -619,7 +619,28 @@ ERL_NIF_TERM serialize_executable(ErlNifEnv* env, int argc, const ERL_NIF_TERM a
   return exla::nif::ok(exla::nif::make(env, serialize));
 }
 
-// Serialization
+ERL_NIF_TERM deserialize_executable(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
+  if (argc != 2) {
+    return exla::nif::error(env, "Bad argument count.");
+  }
+
+  std::string serialized;
+  exla::ExlaClient** client;
+
+  if (!exla::nif::get<exla::ExlaClient*>(env, argv[0], client)) {
+    return exla::nif::error(env, "Unable to get client.");
+  }
+  if (!exla::nif::get(env, argv[1], serialized)) {
+    return exla::nif::error(env, "Unable to get executable.");
+  }
+
+  EXLA_ASSIGN_OR_RETURN_NIF(exla::ExlaExecutable * executable,
+    (*client)->DeserializeExecutable(serialized));
+
+  return exla::nif::ok(env, exla::nif::make<exla::ExlaExecutable*>(env, executable));
+}
+
+// Logging
 
 ERL_NIF_TERM start_log_sink(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
   if (argc != 1) {

--- a/exla/c_src/exla/exla_client.cc
+++ b/exla/c_src/exla/exla_client.cc
@@ -379,6 +379,15 @@ xla::StatusOr<ExlaExecutable*> ExlaClient::Compile(const xla::XlaComputation& co
   return new ExlaExecutable(std::move(executable), std::move(fingerprint), this);
 }
 
+xla::StatusOr<ExlaExecutable*> ExlaClient::DeserializeExecutable(std::string deserialized_executable) {
+  EXLA_ASSIGN_OR_RETURN(std::unique_ptr<xla::PjRtLoadedExecutable> executable,
+    client_->DeserializeExecutable(executable));
+  EXLA_ASSIGN_OR_RETURN(absl::optional<std::string> fingerprint,
+    ExecutableFingerprint(executable));
+
+  return new ExlaExecutable(std::move(executable), std::move(fingerprint), this);
+}
+
 xla::StatusOr<ExlaExecutable*> ExlaClient::Compile(const mlir::OwningOpRef<mlir::ModuleOp>& module,
                                                    std::vector<xla::Shape*> argument_layouts,
                                                    xla::ExecutableBuildOptions& options,

--- a/exla/c_src/exla/exla_client.cc
+++ b/exla/c_src/exla/exla_client.cc
@@ -381,7 +381,8 @@ xla::StatusOr<ExlaExecutable*> ExlaClient::Compile(const xla::XlaComputation& co
 
 xla::StatusOr<ExlaExecutable*> ExlaClient::DeserializeExecutable(std::string deserialized_executable) {
   EXLA_ASSIGN_OR_RETURN(std::unique_ptr<xla::PjRtLoadedExecutable> executable,
-    client_->DeserializeExecutable(executable));
+    client_->DeserializeExecutable(deserialized_executable, std::nullopt));
+
   EXLA_ASSIGN_OR_RETURN(absl::optional<std::string> fingerprint,
     ExecutableFingerprint(executable));
 

--- a/exla/c_src/exla/exla_client.h
+++ b/exla/c_src/exla/exla_client.h
@@ -55,7 +55,7 @@ class ExlaExecutable {
                                   ERL_NIF_TERM arguments,
                                   int device_id);
 
-  xla::StatusOr<std::string> Serialize() { return executable_->Serialize(); }
+  xla::StatusOr<std::string> SerializeExecutable() { return executable_->SerializeExecutable(); }
 
  private:
   std::unique_ptr<xla::PjRtLoadedExecutable> executable_;

--- a/exla/c_src/exla/exla_client.h
+++ b/exla/c_src/exla/exla_client.h
@@ -87,6 +87,8 @@ class ExlaClient {
                                               xla::Shape& shape,
                                               int device_id);
 
+  xla::StatusOr<ExlaExecutable*> DeserializeExecutable(std::string serialized_executable);
+
   // TODO(seanmor5): This is device logic and should be refactored
   xla::Status TransferToInfeed(ErlNifEnv* env,
                                ERL_NIF_TERM data,

--- a/exla/c_src/exla/exla_client.h
+++ b/exla/c_src/exla/exla_client.h
@@ -55,6 +55,8 @@ class ExlaExecutable {
                                   ERL_NIF_TERM arguments,
                                   int device_id);
 
+  xla::StatusOr<std::string> Serialize() { return executable_->Serialize(); }
+
  private:
   std::unique_ptr<xla::PjRtLoadedExecutable> executable_;
   absl::optional<std::string> fingerprint_;

--- a/exla/lib/exla/executable.ex
+++ b/exla/lib/exla/executable.ex
@@ -21,6 +21,18 @@ defmodule EXLA.Executable do
     end
   end
 
+  def serialize(%Executable{ref: executable}) do
+    executable
+    |> EXLA.NIF.serialize_executable()
+    |> unwrap!()
+  end
+
+  def deserialize(client, binary) do
+    binary
+    |> then(&EXLA.NIF.deserialize_executable(client.ref, &1))
+    |> unwrap!()
+  end
+
   defp run(client, ref, device_id, inputs, _options) do
     inputs =
       for subinputs <- inputs do

--- a/exla/lib/exla/executable.ex
+++ b/exla/lib/exla/executable.ex
@@ -54,7 +54,6 @@ defmodule EXLA.Executable do
           |> then(&EXLA.NIF.deserialize_executable(client.ref, &1))
           |> unwrap!()
 
-
         exec_data
         |> Map.put(:ref, ref)
         |> Map.put(:client, client)

--- a/exla/lib/exla/executable.ex
+++ b/exla/lib/exla/executable.ex
@@ -21,16 +21,49 @@ defmodule EXLA.Executable do
     end
   end
 
-  def serialize(%Executable{ref: executable}) do
-    executable
-    |> EXLA.NIF.serialize_executable()
-    |> unwrap!()
+  def serialize(%Executable{
+        ref: executable,
+        output_shape: out_shape,
+        num_replicas: num_replicas,
+        num_partitions: num_partitions,
+        device_id: device_id
+      }) do
+    serialized_exec =
+      executable
+      |> EXLA.NIF.serialize_executable()
+      |> unwrap!()
+      |> IO.iodata_to_binary()
+
+    stripped_shape = strip_shape(out_shape)
+
+    %{
+      serialized: serialized_exec,
+      output_shape: stripped_shape,
+      num_replicas: num_replicas,
+      num_partitions: num_partitions,
+      device_id: device_id
+    }
+    |> :erlang.term_to_binary()
   end
 
   def deserialize(client, binary) do
-    binary
-    |> then(&EXLA.NIF.deserialize_executable(client.ref, &1))
-    |> unwrap!()
+    case :erlang.binary_to_term(binary) do
+      %{serialized: serialized_exec} = exec_data ->
+        ref =
+          serialized_exec
+          |> then(&EXLA.NIF.deserialize_executable(client.ref, &1))
+          |> unwrap!()
+
+
+        exec_data
+        |> Map.put(:ref, ref)
+        |> Map.put(:client, client)
+        |> Map.update!(:output_shape, &reconstruct_shapes/1)
+        |> then(&struct(__MODULE__, &1))
+
+      _other ->
+        raise "invalid serialized executable"
+    end
   end
 
   defp run(client, ref, device_id, inputs, _options) do
@@ -61,6 +94,22 @@ defmodule EXLA.Executable do
       buf, subshape when is_binary(buf) ->
         BinaryBuffer.from_binary(buf, subshape)
     end)
+  end
+
+  defp strip_shape(%Shape{dtype: {:tuple, shapes}}) do
+    subshapes = Enum.map(shapes, &strip_shape/1)
+    %{dtype: {:tuple, subshapes}, dims: {length(subshapes)}}
+  end
+
+  defp strip_shape(%Shape{dtype: dtype, dims: dims}), do: %{dtype: dtype, dims: dims}
+
+  defp reconstruct_shapes(%{dtype: {:tuple, shapes}}) do
+    subshapes = Enum.map(shapes, &reconstruct_shapes/1)
+    EXLA.Shape.make_tuple_shape(subshapes)
+  end
+
+  defp reconstruct_shapes(%{dtype: dtype, dims: dims}) do
+    EXLA.Shape.make_shape(dtype, dims)
   end
 
   defp unwrap!(:ok), do: :ok

--- a/exla/lib/exla/nif.ex
+++ b/exla/lib/exla/nif.ex
@@ -428,6 +428,9 @@ defmodule EXLA.NIF do
       ),
       do: :erlang.nif_error(:undef)
 
+  def serialize(_executable), do: :erlang.nif_error(:undef)
+  def deserialize(_client, _string), do: :erlang.nif_error(:undef)
+
   def run_cpu(
         _client,
         _executable,

--- a/exla/lib/exla/nif.ex
+++ b/exla/lib/exla/nif.ex
@@ -428,8 +428,8 @@ defmodule EXLA.NIF do
       ),
       do: :erlang.nif_error(:undef)
 
-  def serialize(_executable), do: :erlang.nif_error(:undef)
-  def deserialize(_client, _string), do: :erlang.nif_error(:undef)
+  def serialize_executable(_executable), do: :erlang.nif_error(:undef)
+  def deserialize_executable(_client, _string), do: :erlang.nif_error(:undef)
 
   def run_cpu(
         _client,


### PR DESCRIPTION
To make cold starts faster we can save JIT compiled functions to disk. This should help FLAME cold starts.

Not sure what the API should look like for Nx as this may not work across backends/compilers. Maybe `Nx.Defn.load/save` ?