### PR TITLE
Add square

### DIFF
--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -16782,7 +16782,7 @@ defmodule Nx do
       4
     >
 
-    iex> Nx.square(Nx.tensor([-1, 0, 1, 2, 3, 4])
+    iex> Nx.square(Nx.tensor([-1, 0, 1, 2, 3, 4]))
     #Nx.Tensor<
       s64[6]
       [1, 0, 1, 4, 9, 16]

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -398,7 +398,7 @@ defmodule Nx do
   """
 
   import Nx.Shared
-  import Nx.Defn.Kernel, only: [keyword!: 2, stop_grad: 1]
+  import Nx.Defn.Kernel, only: [keyword!: 2]
 
   alias Nx.Tensor, as: T
 
@@ -17170,10 +17170,7 @@ defmodule Nx do
     opts = keyword!(opts, [:axes, :exp_scaling_factor, :keep_axes])
     axes = opts[:axes]
     keep_axes = opts[:keep_axes]
-    # We can treat max as a constant
-    # and avoid differentiating through it
-    # https://github.com/google/jax/pull/2260
-    max = stop_grad(reduce_max(tensor, axes: axes, keep_axes: true))
+    max = reduce_max(tensor, axes: axes, keep_axes: true)
     infinity_mask = is_infinity(max)
     max = select(infinity_mask, Nx.tensor(0, type: type), max)
     exponentials = tensor |> subtract(max) |> exp()


### PR DESCRIPTION
Adding `square` that squares the elements of a tensor. I find it convenient to use with pipeline operator `|>` instead of `Nx.pow(2)`.