### PR TITLE
Fix `Nx.Constants.smallest_positive_normal/2` documentation

### DIFF
--- a/nx/lib/nx/constants.ex
+++ b/nx/lib/nx/constants.ex
@@ -302,7 +302,7 @@ defmodule Nx.Constants do
   end
 
   @doc """
-  Returns a scalar tensor with the maximum finite value for the given type.
+  Returns a scalar tensor with the smallest positive value for the given type.
 
   ## Options
 


### PR DESCRIPTION
Fixes a small error in the documentation of `Nx.Constants.smallest_positive_normal/2`.