### PR TITLE
Add Nx.Defn.Compiler.to_backend/1

### DIFF
--- a/exla/lib/exla.ex
+++ b/exla/lib/exla.ex
@@ -443,4 +443,7 @@ defmodule EXLA do
 
   @impl true
   defdelegate __partitions_options__(opts), to: EXLA.Defn
+
+  @impl true
+  defdelegate __to_backend__(opts), to: EXLA.Defn
 end

--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -17,6 +17,18 @@ defmodule EXLA.Defn do
   end
 
   @doc false
+  def __to_backend__(options) do
+    client_name = Keyword.get_lazy(options, :client, &EXLA.Client.default_name/0)
+
+    device_id =
+      Keyword.get_lazy(options, :device_id, fn ->
+        EXLA.Client.fetch!(client_name).default_device_id
+      end)
+
+    {EXLA.Backend, [client: client_name, device_id: device_id]}
+  end
+
+  @doc false
   def __stream__(key, input, acc, vars, fun, [args], options) do
     {run_options, compile_options} = Keyword.pop(options, :run_options, [])
 

--- a/nx/lib/nx/defn.ex
+++ b/nx/lib/nx/defn.ex
@@ -263,6 +263,17 @@ defmodule Nx.Defn do
   end
 
   @doc """
+  Returns a backend corresponding to the compiler options.
+
+  The backend matches the backend used for outputs from computations
+  defined by the given compiler.
+  """
+  def to_backend(opts) do
+    opts = prepare_options(opts)
+    Nx.Defn.Compiler.__to_backend__(opts)
+  end
+
+  @doc """
   Compiles the given anonymous function with the given tensor shapes.
 
   While `jit/2` compiles a function just-in time based on the

--- a/nx/lib/nx/defn/compiler.ex
+++ b/nx/lib/nx/defn/compiler.ex
@@ -133,13 +133,8 @@ defmodule Nx.Defn.Compiler do
     Process.get(Nx.Defn, false)
   end
 
-  @doc """
-  Returns a backend corresponding to the compiler options.
-
-  The backend matches the backend used for outputs from computations
-  defined by the given compiler.
-  """
-  def to_backend(opts) do
+  @doc false
+  def __to_backend__(opts) do
     {compiler, opts} = Keyword.pop(opts, :compiler, Nx.Defn.Evaluator)
     compiler.__to_backend__(opts)
   end

--- a/nx/lib/nx/defn/compiler.ex
+++ b/nx/lib/nx/defn/compiler.ex
@@ -89,6 +89,15 @@ defmodule Nx.Defn.Compiler do
   """
   @callback __partitions_options__(keyword) :: [keyword]
 
+  @doc """
+  Receives a keyword list of compiler options and returns a backend
+  with options that corresponds to the same allocation.
+
+  The backend is expected to match what would be returned from a
+  computation defined by the compiler.
+  """
+  @callback __to_backend__(keyword) :: {module, keyword}
+
   # Modules allowed in defn
   @allowed_modules [Nx.Constants, Nx.Defn, Nx.Defn.Kernel, Nx.LinAlg, Nx.Type]
 
@@ -122,6 +131,17 @@ defmodule Nx.Defn.Compiler do
   """
   def defn?() do
     Process.get(Nx.Defn, false)
+  end
+
+  @doc """
+  Returns a backend corresponding to the compiler options.
+
+  The backend matches the backend used for outputs from computations
+  defined by the given compiler.
+  """
+  def to_backend(opts) do
+    {compiler, opts} = Keyword.pop(opts, :compiler, Nx.Defn.Evaluator)
+    compiler.__to_backend__(opts)
   end
 
   ## JIT/Stream

--- a/nx/lib/nx/defn/debug.ex
+++ b/nx/lib/nx/defn/debug.ex
@@ -7,6 +7,9 @@ defmodule Nx.Defn.Debug do
   def __partitions_options__(_), do: raise("not implemented")
 
   @impl true
+  def __to_backend__(_), do: raise("not implemented")
+
+  @impl true
   def __stream__(_, _, _, _, _, _, _), do: raise("not implemented")
 
   @impl true

--- a/nx/lib/nx/defn/evaluator.ex
+++ b/nx/lib/nx/defn/evaluator.ex
@@ -29,6 +29,11 @@ defmodule Nx.Defn.Evaluator do
   end
 
   @impl true
+  def __to_backend__(_opts) do
+    Nx.default_backend()
+  end
+
+  @impl true
   def __stream__(_key, input, acc, vars, fun, [args], opts) do
     count = Nx.Defn.Composite.count(input) + Nx.Defn.Composite.count(acc)
     rest_params = Enum.drop(args, count)


### PR DESCRIPTION
Partitioned servings receive defn options with respective device id and we may want to copy model params to each partitioned device. So far we've been doing `Nx.Defn.jit_apply(&Function.identity/1, [params], defn_options)`, however for EXLA this requires twice the params memory, because input and output use separate buffers.

This PR adds a function to infer backend from compiler options:

```elixir
# Assume :cuda is available

Nx.Defn.Compiler.to_backend(compiler: EXLA, device_id: 1)
# => {EXLA.Backend, [client: :cuda, device_id: 1]}
```