### PR TITLE
Add an uniq function to prepare to add one_hot_encoder feature

### DIFF
--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -8448,8 +8448,7 @@ defmodule Nx do
         ceil: {"ceil", &:math.ceil/1},
         round: {"round (away from zero)", &:erlang.round/1}
       ] do
-    [res1, res2, res3, res4] =
-      Enum.map([-1.5, -0.5, 0.5, 1.5], fn x -> fun.(x) * 1.0 end)
+    [res1, res2, res3, res4] = Enum.map([-1.5, -0.5, 0.5, 1.5], fn x -> fun.(x) * 1.0 end)
 
     @doc """
     Calculates the #{desc} of each element in the tensor.
@@ -16450,8 +16449,7 @@ defmodule Nx do
     apply_vectorized(tensor, fn tensor, offset ->
       shape = Nx.Shape.fft2(tensor.shape)
 
-      opts =
-        Keyword.validate!(opts, [:lengths, axes: [-2, -1], eps: 1.0e-10])
+      opts = Keyword.validate!(opts, [:lengths, axes: [-2, -1], eps: 1.0e-10])
 
       [ax1, ax2] =
         case opts[:axes] do
@@ -17270,5 +17268,33 @@ defmodule Nx do
     |> sum(axes: axes, keep_axes: keep_axes)
     |> log()
     |> add(max)
+  end
+
+  @doc """
+  Removes duplicate data from a single dimension tensor.
+
+  ## Examples
+
+      iex> Nx.uniq(Nx.tensor([1,2,3,3,4,5,5,6,7,8]))
+      #Nx.Tensor<
+        s64[8]
+        [1, 2, 3, 4, 5, 6, 7, 8]
+      >
+  """
+  @doc type: :creation
+  def uniq(tensor) do
+    rank_limit = 1
+
+    apply_vectorized(tensor, fn t ->
+      if rank(t) == rank_limit do
+        tensor
+        |> to_list()
+        |> Enum.uniq()
+        |> tensor(type: tensor.type, names: tensor.names)
+      else
+        raise ArgumentError,
+              "uniq/1 expects a tensor with 1 dimension, got: #{inspect(rank(t))}"
+      end
+    end)
   end
 end

--- a/nx/lib/nx/defn/compiler.ex
+++ b/nx/lib/nx/defn/compiler.ex
@@ -30,7 +30,7 @@ defmodule Nx.Defn.Compiler do
               key :: term,
               vars,
               fun :: (vars -> Nx.Container.t()),
-              args_list :: [[(-> Nx.Tensor.t())]],
+              args_list :: [[(() -> Nx.Tensor.t())]],
               opts :: keyword
             ) :: [Nx.Container.t()]
             when vars: [Nx.Container.t()]
@@ -74,7 +74,7 @@ defmodule Nx.Defn.Compiler do
               acc,
               vars,
               fun :: (vars -> {output, acc}),
-              args_list :: [[(-> Nx.t())]],
+              args_list :: [[(() -> Nx.t())]],
               opts :: keyword
             ) :: [Nx.Stream.t()]
             when input: Nx.Container.t(),

--- a/nx/lib/nx/defn/grad.ex
+++ b/nx/lib/nx/defn/grad.ex
@@ -7,8 +7,7 @@ defmodule Nx.Defn.Grad do
   def transform(to_grad, fun, transform) do
     {to_grad, ids} =
       Composite.traverse(to_grad, %{}, fn to_grad, ids ->
-        to_grad =
-          Expr.metadata(to_grad, %{__MODULE__ => :to_grad})
+        to_grad = Expr.metadata(to_grad, %{__MODULE__ => :to_grad})
 
         {to_grad, Map.put(ids, to_grad.data.id, :stop)}
       end)

--- a/nx/lib/nx/encoder.ex
+++ b/nx/lib/nx/encoder.ex
@@ -3,7 +3,7 @@ defmodule Nx.Encoder do
   Set of utilities to encode features.
   """
 
-  import Nx.Defn, only: [defn: 2]
+  # import Nx.Defn, only: [defn: 2]
 
   # TO-DO
   # defn one_hot_encoder(t) do

--- a/nx/lib/nx/encoder.ex
+++ b/nx/lib/nx/encoder.ex
@@ -6,7 +6,7 @@ defmodule Nx.Encoder do
   import Nx.Defn, only: [defn: 2]
 
   # TO-DO
-  defn one_hot_encoder(t) do
-    tensor = Nx.to_tensor(t)
-  end
+  # defn one_hot_encoder(t) do
+  #   tensor = Nx.to_tensor(t)
+  # end
 end

--- a/nx/lib/nx/encoder.ex
+++ b/nx/lib/nx/encoder.ex
@@ -1,0 +1,12 @@
+defmodule Nx.Encoder do
+  @moduledoc """
+  Set of utilities to encode features.
+  """
+
+  import Nx.Defn, only: [defn: 2]
+
+  # TO-DO
+  defn one_hot_encoder(t) do
+    tensor = Nx.to_tensor(t)
+  end
+end

--- a/nx/lib/nx/lazy_container.ex
+++ b/nx/lib/nx/lazy_container.ex
@@ -34,7 +34,7 @@ defprotocol Nx.LazyContainer do
   be containers, you must call `Nx.LazyContainer.traverse/3`
   on said arguments so they are recursively traversed.
   """
-  @spec traverse(t(), acc, (Nx.template(), (-> Nx.Tensor.t()), acc -> {term(), acc})) ::
+  @spec traverse(t(), acc, (Nx.template(), (() -> Nx.Tensor.t()), acc -> {term(), acc})) ::
           {Nx.Container.t(), acc}
         when acc: term()
   def traverse(data, acc, fun)

--- a/nx/lib/nx/lin_alg/cholesky.ex
+++ b/nx/lib/nx/lin_alg/cholesky.ex
@@ -2,8 +2,7 @@ defmodule Nx.LinAlg.Cholesky do
   import Nx.Defn
 
   defn cholesky(a, opts \\ []) do
-    opts =
-      keyword!(opts, eps: 1.0e-10)
+    opts = keyword!(opts, eps: 1.0e-10)
 
     vectorized_axes = a.vectorized_axes
 

--- a/nx/lib/nx/lin_alg/eigh.ex
+++ b/nx/lib/nx/lin_alg/eigh.ex
@@ -4,8 +4,7 @@ defmodule Nx.LinAlg.Eigh do
   alias Nx.LinAlg.QR
 
   defn eigh(a, opts \\ []) do
-    opts =
-      keyword!(opts, eps: 1.0e-10, max_iter: 10_000)
+    opts = keyword!(opts, eps: 1.0e-10, max_iter: 10_000)
 
     a
     |> Nx.revectorize([collapsed_axes: :auto],

--- a/nx/lib/nx/lin_alg/qr.ex
+++ b/nx/lib/nx/lin_alg/qr.ex
@@ -2,8 +2,7 @@ defmodule Nx.LinAlg.QR do
   import Nx.Defn
 
   defn qr(a, opts \\ []) do
-    opts =
-      keyword!(opts, eps: 1.0e-10, mode: :reduced)
+    opts = keyword!(opts, eps: 1.0e-10, mode: :reduced)
 
     vectorized_axes = a.vectorized_axes
 

--- a/nx/lib/nx/serving.ex
+++ b/nx/lib/nx/serving.ex
@@ -426,7 +426,7 @@ defmodule Nx.Serving do
   separate process.
   """
   @callback handle_batch(Nx.Batch.t(), partition :: non_neg_integer(), state) ::
-              {:execute, (-> {Nx.Container.t(), metadata()}), state}
+              {:execute, (() -> {Nx.Container.t(), metadata()}), state}
             when state: term()
 
   @doc """

--- a/nx/test/nx_test.exs
+++ b/nx/test/nx_test.exs
@@ -3259,4 +3259,22 @@ defmodule NxTest do
                ])
     end
   end
+
+  describe "uniq/1" do
+    test "removes duplicate data" do
+      tensor = Nx.tensor([1, 2, 3, 3, 4, 5, 5, 6, 7, 8], names: [:x], type: {:f, 32})
+      expected = Nx.tensor([1, 2, 3, 4, 5, 6, 7, 8], names: [:x], type: {:f, 32})
+      assert ^expected = Nx.uniq(tensor)
+    end
+
+    test "raises exception when tensor rank is greater than one" do
+      tensor = Nx.tensor([[1, 2, 3], [4, 5, 6]])
+
+      assert_raise ArgumentError,
+                   "uniq/1 expects a tensor with 1 dimension, got: 2",
+                   fn ->
+                     Nx.uniq(tensor)
+                   end
+    end
+  end
 end


### PR DESCRIPTION
Hi Folks, I noticed Nx does not provide a way to do one_hot_encoder or label_encoder, so I though to add those features. I decided to start by adding a function to remove duplicate elements from a vector given we usually want to encode data with a vector of features/labels. 

Do those functions make sense here? 