### PR TITLE
Fix building empty MLIR tuples

### DIFF
--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -540,13 +540,13 @@ defmodule EXLA.Defn do
 
     {token, result} =
       case state.builder do
-        %Function{} ->
+        %Function{} = function ->
           # for MLIR while, the return is variadic
           # like it would have come from Nx.Defn.Composite.flatten_list.
           # We need to collect the returned values into the nested tuples
           # that should have come from the while expr
           [token | results] = mod.while(pred, body, initial)
-          result = collect_container_results(results, initial_arg)
+          result = collect_container_results(function, results, initial_arg)
           {token, result}
 
         _ ->
@@ -617,9 +617,8 @@ defmodule EXLA.Defn do
     result =
       case state.builder do
         %Function{} ->
-          tensor
-          |> Value.top_k(opts[:k])
-          |> Value.tuple()
+          results = Value.top_k(tensor, opts[:k])
+          Value.tuple(state.builder, results)
 
         %EXLA.Builder{} ->
           EXLA.Op.top_k(tensor, opts[:k])
@@ -836,7 +835,7 @@ defmodule EXLA.Defn do
         EXLA.Op.tuple(state.builder, Tuple.to_list(op))
 
       op when is_tuple(op) ->
-        Value.tuple(Tuple.to_list(op))
+        Value.tuple(state.builder, Tuple.to_list(op))
     end
   end
 
@@ -2048,7 +2047,7 @@ defmodule EXLA.Defn do
     function = EXLA.Builder.new({module, name}, arg_shapes, expr, :mlir, false, true)
     [arg_token | arg_params] = EXLA.MLIR.Function.get_arguments(function)
 
-    arg_params = Value.tuple(arg_params)
+    arg_params = Value.tuple(function, arg_params)
 
     params = computation_arg_param({arg, arg_params})
 
@@ -2134,7 +2133,7 @@ defmodule EXLA.Defn do
     }
 
     {res, comp_cache} = recur_composite(expr, state, reset_token(cache, arg_token))
-    res = Value.tuple([arg_token, res])
+    res = Value.tuple(function, [arg_token, res])
 
     {EXLA.Builder.build(res), merge_outfeed(cache, comp_cache)}
   end
@@ -2231,7 +2230,7 @@ defmodule EXLA.Defn do
 
       tuple =
         case state.builder do
-          %Function{} -> Value.tuple(elements)
+          %Function{} = function -> Value.tuple(function, elements)
           builder -> EXLA.Op.tuple(builder, elements)
         end
 
@@ -2407,7 +2406,7 @@ defmodule EXLA.Defn do
       to_if_branch(false, on_false, false_ids, true_ids, state, cache)
 
     case builder do
-      %EXLA.MLIR.Function{} ->
+      %EXLA.MLIR.Function{} = function ->
         if_results =
           Value.if(
             pred_op,
@@ -2418,7 +2417,7 @@ defmodule EXLA.Defn do
             false_comp
           )
 
-        {collect_container_results(if_results, on_true), cache}
+        {collect_container_results(function, if_results, on_true), cache}
 
       _ ->
         {EXLA.Op.conditional(pred_op, true_args, true_comp, false_args, false_comp), cache}
@@ -2681,22 +2680,26 @@ defmodule EXLA.Defn do
     |> to_type(out.type)
   end
 
-  defp collect_container_results(flat_list, expected_container) do
-    {collected, []} = collect_container_results_unflatten(flat_list, expected_container)
+  defp collect_container_results(function, flat_list, expected_container) do
+    {collected, []} = collect_container_results_unflatten(function, flat_list, expected_container)
     collected
   end
 
-  defp collect_container_results_unflatten(list, tuple) when is_list(list) and is_tuple(tuple) do
+  defp collect_container_results_unflatten(function, list, tuple)
+       when is_list(list) and is_tuple(tuple) do
     {elements, list} = Enum.split(list, tuple_size(tuple))
-    {unnested, list} = Enum.map_reduce(elements, list, &collect_container_results_unflatten/2)
-    {Value.tuple(unnested), list}
+
+    {unnested, list} =
+      Enum.map_reduce(elements, list, &collect_container_results_unflatten(function, &1, &2))
+
+    {Value.tuple(function, unnested), list}
   end
 
-  defp collect_container_results_unflatten([%Value{} = value], _) do
+  defp collect_container_results_unflatten(_, [%Value{} = value], _) do
     {value, []}
   end
 
-  defp collect_container_results_unflatten(%Value{} = value, _) do
+  defp collect_container_results_unflatten(_, %Value{} = value, _) do
     {value, []}
   end
 

--- a/exla/lib/exla/mlir/value.ex
+++ b/exla/lib/exla/mlir/value.ex
@@ -76,8 +76,8 @@ defmodule EXLA.MLIR.Value do
     %Value{op | ref: ref}
   end
 
-  def tuple([%Value{function: %Function{} = func} | _rest] = vals) do
-    refs = Enum.map(vals, fn %Value{ref: ref, function: ^func} -> ref end)
+  def tuple(%Function{} = func, vals) when is_list(vals) do
+    refs = Enum.map(vals, fn %Value{ref: ref} -> ref end)
     ref = EXLA.NIF.mlir_tuple(func.ref, refs) |> unwrap!()
     %Value{ref: ref, function: func}
   end

--- a/exla/lib/exla/op.ex
+++ b/exla/lib/exla/op.ex
@@ -80,10 +80,8 @@ defmodule EXLA.Op do
     %Op{builder: builder, ref: ref}
   end
 
-  def tuple(%EXLA.MLIR.Function{}, elements) when is_list(elements) do
-    elements
-    |> List.flatten()
-    |> EXLA.MLIR.Value.tuple()
+  def tuple(%EXLA.MLIR.Function{} = function, elements) when is_list(elements) do
+    EXLA.MLIR.Value.tuple(function, List.flatten(elements))
   end
 
   @doc """

--- a/exla/test/exla/mlir/executable_feed_test.exs
+++ b/exla/test/exla/mlir/executable_feed_test.exs
@@ -25,7 +25,7 @@ defmodule EXLA.MLIR.ExecutableFeedTest do
               outfeed_val = Value.add(val, val)
 
               _outfeed_token = Value.outfeed(new_token, [outfeed_val])
-              Value.tuple([Value.add(outfeed_val, val)])
+              Value.tuple(b, [Value.add(outfeed_val, val)])
             end)
           end)
         end)


### PR DESCRIPTION
Currently we infer `%Function{}` from tuple arguments, but if we want to build empty tuple, there are none. And we even build such explicitly here:

https://github.com/elixir-nx/nx/blob/c5d91781b91f63cae4917e75e0dc77507852e608/exla/lib/exla/defn.ex#L721