### PR TITLE
Make take_along_axis an optional callback

### DIFF
--- a/exla/lib/exla/backend.ex
+++ b/exla/lib/exla/backend.ex
@@ -325,7 +325,6 @@ defmodule EXLA.Backend do
       {:reverse, [:tensor, :axes], [:tensor]},
       {:dot, [:left, :c1, :b1, :right, :c2, :b2], [:left, :right]},
       {:clip, [:tensor, :min, :max], [:tensor, :min, :max]},
-      {:take_along_axis, [:tensor, :indices, :axis], [:tensor, :indices]},
       {:gather, [:input, :indices, :opts], [:input, :indices]},
       {:select, [:pred, :on_true, :on_false], [:pred, :on_true, :on_false]},
       {:conv, [:tensor, :kernel, :opts], [:tensor, :kernel]},

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -14312,7 +14312,14 @@ defmodule Nx do
 
     shape = Nx.Shape.take_along_axis(tensor.shape, indices.shape, axis)
 
-    result = impl!(tensor).take_along_axis(%{tensor | shape: shape}, tensor, indices, axis)
+    out = %{tensor | shape: shape}
+
+    result =
+      Nx.Shared.optional(:take_along_axis, [tensor, indices, axis], out, fn _tensor,
+                                                                            _indices,
+                                                                            _axis ->
+        out
+      end)
 
     vectorize(result, vectorized_axes)
   end

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -14329,9 +14329,7 @@ defmodule Nx do
           end)
           |> concatenate(axis: rank(indices))
 
-        out = gather(tensor, full_indices)
-
-        %{out | shape: shape}
+        gather(tensor, full_indices)
       end)
 
     vectorize(result, vectorized_axes)

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -14315,9 +14315,11 @@ defmodule Nx do
     out = %{tensor | shape: shape}
 
     result =
-      Nx.Shared.optional(:take_along_axis, [tensor, indices, axis], out, fn tensor,
-                                                                            indices,
-                                                                            axis ->
+      Nx.Shared.optional(:take_along_axis, [tensor, indices, [axis: axis]], out, fn tensor,
+                                                                                    indices,
+                                                                                    opts ->
+        axis = opts[:axis]
+
         axes_range = axes(indices)
         new_axis_shape = Tuple.append(shape(indices), 1)
 

--- a/nx/lib/nx/backend.ex
+++ b/nx/lib/nx/backend.ex
@@ -158,7 +158,7 @@ defmodule Nx.Backend do
   @callback all_close(out :: tensor, tensor, tensor, keyword) :: tensor
   @callback top_k(out :: tensor, tensor, keyword) :: tensor
   @callback take(out :: tensor, input :: tensor, indices :: tensor, keyword) :: tensor
-  @callback take_along_axis(out :: tensor, input :: tensor, indices :: tensor, axis) :: tensor
+  @callback take_along_axis(out :: tensor, input :: tensor, indices :: tensor, keyword) :: tensor
 
   @optional_callbacks [
     optional: 3,

--- a/nx/lib/nx/backend.ex
+++ b/nx/lib/nx/backend.ex
@@ -73,7 +73,6 @@ defmodule Nx.Backend do
   @callback clip(out :: tensor, tensor, min :: tensor, max :: tensor) :: tensor
   @callback slice(out :: tensor, tensor, list, list, list) :: tensor
   @callback put_slice(out :: tensor, tensor, tensor, list) :: tensor
-  @callback take_along_axis(out :: tensor, input :: tensor, indices :: tensor, axis) :: tensor
   @callback gather(out :: tensor, input :: tensor, indices :: tensor, keyword) :: tensor
   @callback concatenate(out :: tensor, tensor, axis) :: tensor
   @callback select(out :: tensor, tensor, tensor, tensor) :: tensor
@@ -159,6 +158,7 @@ defmodule Nx.Backend do
   @callback all_close(out :: tensor, tensor, tensor, keyword) :: tensor
   @callback top_k(out :: tensor, tensor, keyword) :: tensor
   @callback take(out :: tensor, input :: tensor, indices :: tensor, keyword) :: tensor
+  @callback take_along_axis(out :: tensor, input :: tensor, indices :: tensor, axis) :: tensor
 
   @optional_callbacks [
     optional: 3,
@@ -178,7 +178,8 @@ defmodule Nx.Backend do
     qr: 3,
     cholesky: 2,
     eigh: 3,
-    take: 4
+    take: 4,
+    take_along_axis: 4
   ]
 
   ## Inspect implementation

--- a/nx/lib/nx/defn/expr.ex
+++ b/nx/lib/nx/defn/expr.ex
@@ -1184,12 +1184,6 @@ defmodule Nx.Defn.Expr do
   end
 
   @impl true
-  def take_along_axis(out, tensor, indices, axis) do
-    {[tensor, indices], context} = to_exprs([tensor, indices])
-    expr(out, context, :take_along_axis, [tensor, indices, axis])
-  end
-
-  @impl true
   def gather(out, tensor, indices, opts) do
     {[tensor, indices], context} = to_exprs([tensor, indices])
     expr(out, context, :gather, [tensor, indices, opts])

--- a/nx/lib/nx/defn/grad.ex
+++ b/nx/lib/nx/defn/grad.ex
@@ -150,9 +150,6 @@ defmodule Nx.Defn.Grad do
   defp reduce_args(:put_slice, %{data: %{args: [arg, _, update | _]}}, acc, fun),
     do: fun.(arg, fun.(update, acc))
 
-  defp reduce_args(:take_along_axis, %{data: %{args: [arg | _]}}, acc, fun),
-    do: fun.(arg, acc)
-
   defp reduce_args(:gather, %{data: %{args: [arg | _]}}, acc, fun),
     do: fun.(arg, acc)
 
@@ -660,44 +657,6 @@ defmodule Nx.Defn.Grad do
     idx = Nx.argsort(t, opts)
     take_along_opts = Keyword.take(opts, [:axis])
     g = Nx.take_along_axis(g, idx, take_along_opts)
-    [{t, g}]
-  end
-
-  defp grad(:take_along_axis, [t, i, axis], _ans, g) do
-    num_elements = i |> Nx.shape() |> Tuple.product()
-
-    # Convert `i`, the take_along_axis indices, to a list of
-    # fully qualified (i.e. [0, 2, 1] for a {_, _, _}-shaped tensor)
-    # indices
-
-    indices =
-      0..(Nx.rank(g) - 1)//1
-      |> Enum.map(fn
-        # For the axis of interest, we'll use the actual take_along_axis indices
-        ^axis ->
-          Nx.reshape(i, {num_elements, 1})
-
-        axis ->
-          i
-          |> Nx.shape()
-          |> Nx.iota(axis: axis)
-          |> Nx.reshape({num_elements, 1})
-      end)
-      |> Nx.concatenate(axis: 1)
-
-    # Since g is produced through the given indices,
-    # we can reshape g to be a {num_elements} shaped tensor
-    # which will directly correspond to each of the reshaped
-    # indices above
-    updates = Nx.reshape(g, {num_elements})
-
-    # The intuition for this grad is that for each index taken, we'll
-    # add the corresponding result grad to the original
-    g =
-      t
-      |> Expr.broadcast(0, Nx.shape(t), Nx.axes(t))
-      |> Nx.indexed_add(indices, updates)
-
     [{t, g}]
   end
 

--- a/torchx/lib/torchx/backend.ex
+++ b/torchx/lib/torchx/backend.ex
@@ -425,12 +425,12 @@ defmodule Torchx.Backend do
   end
 
   @impl true
-  def take_along_axis(out, tensor, idx, axis) do
+  def take_along_axis(out, tensor, idx, opts) do
     idx_tx = idx |> from_nx() |> Torchx.to_type(:long)
 
     tensor
     |> from_nx()
-    |> Torchx.gather(idx_tx, axis)
+    |> Torchx.gather(idx_tx, opts[:axis])
     |> to_nx(out)
   end
 


### PR DESCRIPTION
Makes take_along_axis an optional callback, using the default
implementation for BinaryBackend and EXLA, and a custom one for
Torchx.

Closes #1366.
