### PR TITLE
Add Nx.fill/2

### DIFF
--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -16879,8 +16879,15 @@ defmodule Nx do
   Replaces every value in `tensor` with `value`.
 
   The returned tensor has the same shape, names and vectorized axes
-  as the given one. The type defaults to the type of `tensor`, however
-  type promotions apply.
+  as the given one. The type will be computed based on the type of
+  `tensor` and `value`. You can also pass a `:type` option to change
+  this behaviour.
+
+  ## Options
+
+    * `:type` - sets the type of the returned tensor. If one is not
+      given, it is automatically inferred based on the inputs, with
+      type promotions
 
   ## Examples
 
@@ -16904,6 +16911,17 @@ defmodule Nx do
         ]
       >
 
+      iex> tensor = Nx.iota({2, 2})
+      iex> Nx.fill(tensor, 5, type: :u8)
+      #Nx.Tensor<
+        u8[2][2]
+        [
+          [5, 5],
+          [5, 5]
+        ]
+      >
+
+
   ### Type promotions
 
   Type promotions should happen automatically, with the resulting type being the combination
@@ -16921,9 +16939,10 @@ defmodule Nx do
 
   """
   @doc type: :element
-  def fill(tensor, value) do
-    type = binary_type(tensor, value)
+  def fill(tensor, value, opts \\ []) do
+    opts = Keyword.validate!(opts, [:type])
 
+    type = Nx.Type.normalize!(opts[:type] || binary_type(tensor, value))
     value = to_tensor(value)
 
     %{shape: shape, names: names, vectorized_axes: vectorized_axes} = devectorize(tensor)

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -16875,6 +16875,65 @@ defmodule Nx do
     divide(log(tensor), log(base))
   end
 
+  @doc """
+  Replaces every value in `tensor` with `value`.
+
+  The returned tensor has the same shape, names and vectorized axes
+  as the given one. The type defaults to the type of `tensor`, however
+  type promotions apply.
+
+  ## Examples
+
+      iex> tensor = Nx.iota({2, 2})
+      iex> Nx.fill(tensor, 5)
+      #Nx.Tensor<
+        s64[2][2]
+        [
+          [5, 5],
+          [5, 5]
+        ]
+      >
+
+      iex> tensor = Nx.iota({2, 2}) |> Nx.vectorize(:x)
+      iex> Nx.fill(tensor, 5)
+      #Nx.Tensor<
+        s64[x: 2][2]
+        [
+          [5, 5],
+          [5, 5]
+        ]
+      >
+
+  ### Type promotions
+
+  Type promotions should happen automatically, with the resulting type being the combination
+  of the `tensor` type and the `value` type.
+
+      iex> tensor = Nx.iota({2, 2})
+      iex> Nx.fill(tensor, 5.0)
+      #Nx.Tensor<
+        f32[2][2]
+        [
+          [5.0, 5.0],
+          [5.0, 5.0]
+        ]
+      >
+
+  """
+  @doc type: :element
+  def fill(tensor, value) do
+    type = binary_type(tensor, value)
+
+    value = to_tensor(value)
+
+    %{shape: shape, names: names, vectorized_axes: vectorized_axes} = devectorize(tensor)
+
+    value
+    |> as_type(type)
+    |> broadcast(shape, names: names)
+    |> vectorize(vectorized_axes)
+  end
+
   ## Sigils
 
   @doc """


### PR DESCRIPTION
Very much a subject to comments.

Let's say we want to create a zeroed tensor, shape-compatible with `tensor`. We can do this:

```elixir
Nx.tensor(0, type: Nx.type(tensor)) |> Nx.broadcast(Nx.shape(tensor))
```

We could make this `Nx.full(shape, value, type: type)`, but I am not sure it has enough value.

However, if we want to create a zeroed tensor to exactly match `tensor`, including names and vectorized axes, then it becomes much more cumbersome:

```elixir
[zeros, _] =
  Nx.broadcast_vectors([
    Nx.tensor(0, type: Nx.type(tensor)) |> Nx.broadcast(Nx.shape(tensor), names: Nx.names(tensor)),
    sample_template
  ])

# or

Nx.tensor(0, type: Nx.type(tensor))
|> Nx.broadcast(Nx.shape(Nx.devectorize(tensor)), names: Nx.names(tensor))
|> Nx.vectorize(sample_template.vectorized_axes)
```

To make it clear that we are getting tensor with the exact same shape characteristics, it's useful to think about this operation as replacing every element, or in other words filling the given tensor with a single value, hence `Nx.fill/2`. I am leaning towards tagging it as element-wise, rather than creation, for that exact reason.

There are [`numpy.ndarray.fill`](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.fill.html) and [`torch.Tensor.fill_`](https://pytorch.org/docs/stable/generated/torch.Tensor.fill_.html), both are methods on the tensor and mutate it.