### PR TITLE
feat(mlir): initial infeed/outfeed support

### DIFF
--- a/exla/c_src/exla/mlir/builder.cc
+++ b/exla/c_src/exla/mlir/builder.cc
@@ -1063,6 +1063,9 @@ ERL_NIF_TERM ConstantOpImpl(mlir::OpBuilder *builder, mlir::Type type, ErlNifEnv
 ERL_NIF_TERM MLIRFunction::ConstantOp(mlir::Type type, ErlNifEnv *env, ERL_NIF_TERM term, std::optional<std::vector<int64_t>> dims) {
   module_->builder()->setInsertionPointToEnd(&func_->getBody().back());
 
+  if (type.isSignlessInteger(1)) {
+    return ConstantOpImpl<exla::uint8>(module_->builder(), type, env, term, dims);
+  }
   if (type.isUnsignedInteger(8)) {
     return ConstantOpImpl<exla::uint8>(module_->builder(), type, env, term, dims);
   }

--- a/exla/lib/exla/builder.ex
+++ b/exla/lib/exla/builder.ex
@@ -17,6 +17,7 @@ defmodule EXLA.Builder do
   end
 
   def new(module_and_name, inputs, outputs, :mlir, sub?, variadic_return?) do
+    # TO-DO(mlir): this module shouldn't have to know about Nx
     {_arg_names, arg_shapes} = Enum.unzip(inputs)
 
     {module, name, is_public} =

--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -137,7 +137,153 @@ defmodule EXLA.Defn do
          client,
          input_length,
          acc_length,
-         builder,
+         %Function{} = builder,
+         expr,
+         used_shapes,
+         outfeed,
+         options
+       ) do
+    %{token: root_token, infeeds: []} = outfeed
+    %{platform: platform} = client
+
+    {input_shapes, used_shapes} = Enum.split_while(used_shapes, fn {i, _} -> i < input_length end)
+
+    # Get all input indexes and shape
+    input_indexes = Enum.map(input_shapes, &elem(&1, 0))
+    input_shape = EXLA.Shape.make_tuple_shape(Enum.map(input_shapes, &elem(&1, 1)))
+
+    # Drop all accumulator entries from used_shapes as we will handle it separately.
+    {acc_shapes, used_shapes} = Enum.split(used_shapes, acc_length)
+
+    # The stream loop will be a three element tuple:
+    #
+    #   The result of calling infeed.
+    #   The looping accumulator.
+    #   The looping constants.
+    #
+    # The input will be read as part of the infeed.
+    acc_shapes_l = Enum.map(acc_shapes, &elem(&1, 1))
+    acc_shape = List.to_tuple(acc_shapes_l)
+
+    constant_shapes_l = Enum.map(used_shapes, &elem(&1, 1))
+    constant_shape = List.to_tuple(constant_shapes_l)
+
+    flag_shape = %{type: {:pred, 8}, shape: {}}
+    token_shape = %{type: :token}
+    infeed_shape = {flag_shape, token_shape}
+
+    arg_shapes =
+      {infeed_shape, acc_shape, constant_shape}
+      |> while_arg_shape()
+      |> Enum.with_index(fn shape, i -> {"p#{i}", shape} end)
+
+    %{module: module, name: name} = subbuilder(builder, "while-pred")
+    pred_fun = EXLA.Builder.new({module, name}, arg_shapes, expr, :mlir, false, true)
+
+    [flag | _] = EXLA.MLIR.Function.get_arguments(pred_fun)
+
+    r0 = Value.constant_r0(pred_fun, 1, {:pred, 8})
+
+    pred_op = Value.equal(pred_fun, flag, r0)
+
+    pred = EXLA.Builder.build(pred_op)
+
+    %{module: module, name: name} = subbuilder(builder, "while-body")
+
+    body_fun = EXLA.Builder.new({module, name}, arg_shapes, expr, :mlir, false, true)
+
+    [_flag, token | args] = EXLA.MLIR.Function.get_arguments(body_fun)
+
+    body_args = collect_container_results(body_fun, args, {acc_shape, constant_shape})
+
+    acc = Value.get_tuple_element(body_args, 0)
+    constant = Value.get_tuple_element(body_args, 1)
+
+    # EXLA on host does not support tuples, so we emit multiple infeed operations.
+    {input_params, token} =
+      if platform == :host do
+        Enum.map_reduce(input_shapes, token, fn {pos, shape}, token ->
+          infeed = Value.infeed(token, shape)
+          {{pos, Value.get_tuple_element(infeed, 0)}, Value.get_tuple_element(infeed, 1)}
+        end)
+      else
+        infeed = Value.infeed(token, input_shape)
+        input = Value.get_tuple_element(infeed, 0)
+        token = Value.get_tuple_element(infeed, 1)
+
+        {Enum.with_index(input_shapes, fn {pos, _shape}, i ->
+           {pos, Value.get_tuple_element(input, i)}
+         end), token}
+      end
+
+    {%Outfeed{token: token} = outfeed, acc} =
+      case expr do
+        {output_expr, acc_expr} ->
+          acc_params =
+            Enum.map(acc_shapes, fn {pos, _shape} ->
+              {pos, Value.get_tuple_element(acc, pos - input_length)}
+            end)
+
+          constant_params =
+            Enum.with_index(used_shapes, fn {pos, _shape}, index ->
+              {pos, Value.get_tuple_element(constant, index)}
+            end)
+
+          state = %{
+            precision: Keyword.get(options, :precision, :default),
+            builder: body_fun,
+            params: Map.new(input_params ++ acc_params ++ constant_params),
+            scope_ids: Tree.scope_ids(expr)
+          }
+
+          outfeed = Outfeed.with_token(outfeed, token)
+          {output, cache} = recur_flatten(output_expr, state, new_cache(outfeed))
+          {acc, cache} = recur_flatten(acc_expr, state, cache)
+          outfeed = cache |> get_outfeed() |> Outfeed.add_stream_hook(body_fun, output)
+          {outfeed, acc}
+
+        _ ->
+          raise "expected the function given to Nx.stream/3 to return a two-element tuple, got: " <>
+                  inspect(expr)
+      end
+
+    flag_shape = EXLA.Shape.make_shape(flag_shape.type, flag_shape.shape)
+
+    # Emit the stream hook to signal loop output
+    [%{function: body} | _] =
+      Value.variadic_return(
+        [
+          Value.infeed(token, flag_shape),
+          acc,
+          constant
+        ],
+        true
+      )
+
+    [acc] = EXLA.MLIR.Function.get_arguments(builder)
+
+    init =
+      Value.tuple(builder, [
+        Value.infeed(root_token, flag_shape),
+        acc,
+        # TO-DO: figure out the proper constant init
+        Value.tuple(builder, [])
+      ])
+
+    [_flag, token | results] = Value.while(pred, body, init)
+    while = collect_container_results(builder, results, {acc_shape, constant_shape})
+
+    acc = Value.get_tuple_element(while, 0)
+    outfeed = outfeed |> Outfeed.with_token(token) |> Outfeed.close(builder)
+
+    {EXLA.Builder.build(acc), {input_shape, input_indexes}, outfeed}
+  end
+
+  defp to_stream_computation(
+         client,
+         input_length,
+         acc_length,
+         %EXLA.Builder{} = builder,
          expr,
          used_shapes,
          outfeed,
@@ -439,7 +585,15 @@ defmodule EXLA.Defn do
 
           inputs_and_shapes = Enum.reverse(reverse_inputs_and_shapes)
           mode = options[:compiler_mode] || :xla
-          builder = EXLA.Builder.new(inspect(key), inputs_and_shapes, outputs, mode)
+
+          comp_arg_shapes =
+            if mode == :mlir do
+              for {i, _shape} = item <- inputs_and_shapes, i >= used_buffers, do: item
+            else
+              inputs_and_shapes
+            end
+
+          builder = EXLA.Builder.new(inspect(key), comp_arg_shapes, outputs, mode)
 
           mod =
             case mode do
@@ -460,6 +614,7 @@ defmodule EXLA.Defn do
           {xla_time, executable} =
             :timer.tc(fn ->
               shapes = for {i, shape} <- inputs_and_shapes, i >= used_buffers, do: shape
+
               EXLA.Computation.compile(computation, client, shapes, options)
             end)
 
@@ -1058,7 +1213,7 @@ defmodule EXLA.Defn do
 
         one
         |> Value.broadcast_in_dim(Value.get_shape(op), List.to_tuple(Nx.axes(shape)))
-        |> Value.min(op)
+        |> then(&Value.min(state.builder, &1, op))
 
       _ ->
         Value.sign(op)
@@ -1067,18 +1222,18 @@ defmodule EXLA.Defn do
 
   defp to_operator(:sign, [op], %{type: type}, state) do
     case type do
-      {:u, _} -> EXLA.Op.min(op, EXLA.Op.constant_r0(state.builder, 1, type))
+      {:u, _} -> EXLA.Op.min(state.builder, op, EXLA.Op.constant_r0(state.builder, 1, type))
       _ -> EXLA.Op.sign(op)
     end
   end
 
-  defp to_operator(:right_shift, [%Value{} = left, %Value{} = right], out, _state) do
+  defp to_operator(:right_shift, [%Value{} = left, %Value{} = right], out, state) do
     op =
       if match?({:u, _}, out.type),
         do: :right_shift_logical,
         else: :right_shift_arithmetic
 
-    apply_mlir_broadcasted_bin_op(op, out, left, right)
+    apply_mlir_broadcasted_bin_op(state.builder, op, out, left, right)
   end
 
   defp to_operator(:right_shift, [left, right], %{type: type}, _state) do
@@ -1095,9 +1250,9 @@ defmodule EXLA.Defn do
   @bin_op [:add, :subtract, :multiply, :min, :max, :remainder, :pow, :divide, :atan2] ++
             [:bitwise_and, :bitwise_or, :bitwise_xor, :left_shift]
 
-  defp to_operator(op, [%Value{} = left, %Value{} = right], out, _state)
+  defp to_operator(op, [%Value{} = left, %Value{} = right], out, state)
        when op in @bin_op do
-    apply_mlir_broadcasted_bin_op(op, out, left, right)
+    apply_mlir_broadcasted_bin_op(state.builder, op, out, left, right)
   end
 
   defp to_operator(op, [left, right], %{type: type}, _state) when op in @bin_op do
@@ -1111,9 +1266,9 @@ defmodule EXLA.Defn do
 
   @bin_comp_op [:equal, :not_equal, :greater, :less, :greater_equal, :less_equal]
 
-  defp to_operator(op, [%Value{} = left, %Value{} = right], ans, _state)
+  defp to_operator(op, [%Value{} = left, %Value{} = right], ans, state)
        when op in @bin_comp_op do
-    apply_mlir_broadcasted_bin_op(op, ans, left, right)
+    apply_mlir_broadcasted_bin_op(state.builder, op, ans, left, right)
   end
 
   defp to_operator(op, [left, right], _ans, _state) when op in @bin_comp_op do
@@ -1129,8 +1284,9 @@ defmodule EXLA.Defn do
   @bin_pred_op [logical_and: :bitwise_and, logical_or: :bitwise_or, logical_xor: :bitwise_xor]
 
   for {logical, bitwise} <- @bin_pred_op do
-    defp to_operator(unquote(logical), [%Value{} = left, %Value{} = right], ans, _state) do
+    defp to_operator(unquote(logical), [%Value{} = left, %Value{} = right], ans, state) do
       apply_mlir_broadcasted_bin_op(
+        state.builder,
         unquote(bitwise),
         ans,
         to_mlir_logical(left),
@@ -1909,15 +2065,15 @@ defmodule EXLA.Defn do
     op =
       cond do
         Nx.Type.integer?(type) ->
-          apply(Value, op, [lhs, rhs])
+          apply(Value, op, [builder, lhs, rhs])
 
         op == :less ->
           is_nan = Value.is_nan(rhs)
-          Value.bitwise_or(is_nan, Value.less(lhs, rhs))
+          Value.bitwise_or(builder, is_nan, Value.less(builder, lhs, rhs))
 
         op == :greater ->
           is_nan = Value.is_nan(lhs)
-          Value.bitwise_or(is_nan, Value.greater(lhs, rhs))
+          Value.bitwise_or(builder, is_nan, Value.greater(builder, lhs, rhs))
       end
 
     EXLA.Builder.build(op)
@@ -2184,6 +2340,8 @@ defmodule EXLA.Defn do
 
     {op, keys}
   end
+
+  defp while_arg_shape(%EXLA.Shape{} = shape), do: shape
 
   defp while_arg_shape(%{type: type, shape: shape}) do
     EXLA.Shape.make_shape(type, shape)
@@ -2653,7 +2811,7 @@ defmodule EXLA.Defn do
     left ++ Enum.drop(right, length)
   end
 
-  defp apply_mlir_broadcasted_bin_op(op, out, left, right) do
+  defp apply_mlir_broadcasted_bin_op(function, op, out, left, right) do
     left_shape = Value.get_shape(left)
     right_shape = Value.get_shape(right)
     out_shape = EXLA.Shape.make_shape(out.type, out.shape)
@@ -2682,31 +2840,24 @@ defmodule EXLA.Defn do
       end
 
     Value
-    |> apply(op, [left, right])
+    |> apply(op, [function, left, right])
     |> to_type(out.type)
   end
 
   defp collect_container_results(function, flat_list, expected_container) do
-    {collected, []} = collect_container_results_unflatten(function, flat_list, expected_container)
+    {collected, []} = collect_container_results_unflatten(function, expected_container, flat_list)
     collected
   end
 
-  defp collect_container_results_unflatten(function, list, tuple)
-       when is_list(list) and is_tuple(tuple) do
-    {elements, list} = Enum.split(list, tuple_size(tuple))
-
-    {unnested, list} =
-      Enum.map_reduce(elements, list, &collect_container_results_unflatten(function, &1, &2))
-
-    {Value.tuple(function, unnested), list}
+  defp collect_container_results_unflatten(function, tuple, acc) when is_tuple(tuple) do
+    tuple
+    |> Tuple.to_list()
+    |> Enum.map_reduce(acc, &collect_container_results_unflatten(function, &1, &2))
+    |> then(fn {list, acc} -> {Value.tuple(function, list), acc} end)
   end
 
-  defp collect_container_results_unflatten(_, [%Value{} = value], _) do
-    {value, []}
-  end
-
-  defp collect_container_results_unflatten(_, %Value{} = value, _) do
-    {value, []}
+  defp collect_container_results_unflatten(_, _, [%Value{} = value | list]) do
+    {value, list}
   end
 
   defp to_mlir_logical(%Value{} = value) do

--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -1222,7 +1222,7 @@ defmodule EXLA.Defn do
 
   defp to_operator(:sign, [op], %{type: type}, state) do
     case type do
-      {:u, _} -> EXLA.Op.min(state.builder, op, EXLA.Op.constant_r0(state.builder, 1, type))
+      {:u, _} -> EXLA.Op.min(op, EXLA.Op.constant_r0(state.builder, 1, type))
       _ -> EXLA.Op.sign(op)
     end
   end

--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -480,6 +480,7 @@ defmodule EXLA.Defn do
 
     {res, cache} = recur_flatten(expr, state, new_cache(outfeed))
     outfeed = cache |> get_outfeed() |> Outfeed.close(builder)
+
     {EXLA.Builder.build(res), :ok, outfeed}
   end
 
@@ -597,7 +598,7 @@ defmodule EXLA.Defn do
               inputs_and_shapes
             end
 
-          builder = EXLA.Builder.new(inspect(key), comp_arg_shapes, outputs, mode)
+          builder = EXLA.Builder.new(inspect(key), comp_arg_shapes, Nx.devectorize(outputs), mode)
 
           mod =
             case mode do
@@ -2311,7 +2312,7 @@ defmodule EXLA.Defn do
     }
 
     {res, comp_cache} = recur_composite(expr, state, reset_token(cache, arg_token))
-    res = Value.tuple(function, [arg_token, res])
+    res = Value.tuple(function, [get_token(comp_cache), res])
 
     {EXLA.Builder.build(res), merge_outfeed(cache, comp_cache)}
   end

--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -2272,7 +2272,7 @@ defmodule EXLA.Defn do
 
     res =
       if type == :with_token do
-        EXLA.Op.tuple(subbuilder, [arg_token, res])
+        EXLA.Op.tuple(subbuilder, [get_token(comp_cache), res])
       else
         to_type(res, type)
       end

--- a/exla/lib/exla/defn/outfeed.ex
+++ b/exla/lib/exla/defn/outfeed.ex
@@ -124,15 +124,16 @@ defmodule EXLA.Defn.Outfeed do
         next_flag = next_hook(compiled_hooks)
         compiled_hooks = Map.put(compiled_hooks, next_flag, {:infeed, pos, shape})
 
-        case builder do
-          %EXLA.MLIR.Function{} -> raise "add_infeeds is not supported in MLIR yet"
-          _ -> nil
-        end
+        mod =
+          case builder do
+            %Function{} -> Value
+            _ -> EXLA.Op
+          end
 
-        token = EXLA.Op.outfeed(EXLA.Op.constant_r0(builder, next_flag, {:u, 16}), token)
-        infeed = EXLA.Op.infeed(token, shape)
-        input = EXLA.Op.get_tuple_element(infeed, 0)
-        token = EXLA.Op.get_tuple_element(infeed, 1)
+        token = mod.outfeed(mod.constant_r0(builder, next_flag, {:u, 16}), token)
+        infeed = mod.infeed(token, shape)
+        input = mod.get_tuple_element(infeed, 0)
+        token = mod.get_tuple_element(infeed, 1)
 
         {{pos, input}, {compiled_hooks, token}}
       end)

--- a/exla/lib/exla/lib.ex
+++ b/exla/lib/exla/lib.ex
@@ -159,8 +159,8 @@ defmodule EXLA.Lib do
 
     cmp =
       if is_min?,
-        do: Value.less_equal(lhs_value, rhs_value),
-        else: Value.greater_equal(lhs_value, rhs_value)
+        do: Value.less_equal(function, lhs_value, rhs_value),
+        else: Value.greater_equal(function, lhs_value, rhs_value)
 
     max = Value.select(cmp, lhs_value, rhs_value)
     arg_max = Value.select(cmp, lhs_index, rhs_index)
@@ -168,13 +168,13 @@ defmodule EXLA.Lib do
     arg_max =
       case tie_break do
         :low ->
-          eq? = Value.equal(lhs_value, rhs_value)
-          id = Value.min(lhs_index, rhs_index)
+          eq? = Value.equal(function, lhs_value, rhs_value)
+          id = Value.min(function, lhs_index, rhs_index)
           Value.select(eq?, id, arg_max)
 
         :high ->
-          eq? = Value.equal(lhs_value, rhs_value)
-          id = Value.max(lhs_index, rhs_index)
+          eq? = Value.equal(function, lhs_value, rhs_value)
+          id = Value.max(function, lhs_index, rhs_index)
           Value.select(eq?, id, arg_max)
       end
 

--- a/exla/lib/exla/mlir/value.ex
+++ b/exla/lib/exla/mlir/value.ex
@@ -655,6 +655,8 @@ defmodule EXLA.MLIR.Value do
         []
 
       %{dtype: {:tuple, _}, dims: {n}} ->
+        # TO-DO(mlir): maybe we can avoid building tuples altogether.
+        # Nx should be returning all tuples as flattened anyway.
         Enum.flat_map(0..(n - 1), fn i -> val |> get_tuple_element(i) |> flatten_tuples() end)
 
       _ ->

--- a/exla/lib/exla/mlir/value.ex
+++ b/exla/lib/exla/mlir/value.ex
@@ -21,8 +21,9 @@ defmodule EXLA.MLIR.Value do
     mlir_op = :"mlir_#{op}"
 
     def unquote(op)(
-          %Value{ref: lhs, function: %Function{} = func},
-          %Value{ref: rhs, function: %Function{} = func}
+          func,
+          %Value{ref: lhs},
+          %Value{ref: rhs}
         ) do
       ref = EXLA.NIF.unquote(mlir_op)(func.ref, lhs, rhs) |> unwrap!()
       %Value{ref: ref, function: func}
@@ -203,7 +204,12 @@ defmodule EXLA.MLIR.Value do
       end
 
     ref =
-      EXLA.NIF.mlir_constant_r0(func.ref, value, EXLA.Shape.dtype_to_charlist(type)) |> unwrap!()
+      EXLA.NIF.mlir_constant_r0(
+        func.ref,
+        value,
+        EXLA.Shape.dtype_to_charlist(type)
+      )
+      |> unwrap!()
 
     %Value{ref: ref, function: func}
   end
@@ -582,7 +588,9 @@ defmodule EXLA.MLIR.Value do
     %Value{token | ref: ref}
   end
 
-  def outfeed(%Value{function: function} = token, inputs) do
+  def outfeed(%Value{} = input, token), do: outfeed([input], token)
+
+  def outfeed(inputs, %Value{function: function} = token) do
     input_refs = Enum.map(inputs, & &1.ref)
     ref = EXLA.NIF.mlir_outfeed(function.ref, token.ref, input_refs) |> unwrap!()
     %{token | ref: ref}
@@ -643,6 +651,9 @@ defmodule EXLA.MLIR.Value do
 
   defp flatten_tuples(val) do
     case get_shape(val) do
+      %{dtype: {:tuple, _}, dims: {0}} ->
+        []
+
       %{dtype: {:tuple, _}, dims: {n}} ->
         Enum.flat_map(0..(n - 1), fn i -> val |> get_tuple_element(i) |> flatten_tuples() end)
 

--- a/exla/test/exla/backend_test.exs
+++ b/exla/test/exla/backend_test.exs
@@ -166,7 +166,6 @@ defmodule EXLA.BackendTest do
     assert_equal(result, Nx.tensor([0, 1, 1, 0]))
   end
 
-  @tag :mlir_linalg_nor_supported_yet
   test "Nx.LinAlg.svd/2" do
     t = Nx.iota({4, 4})
     assert {u, s, vt} = Nx.LinAlg.svd(t, max_iter: 10_000)

--- a/exla/test/exla/defn/api_test.exs
+++ b/exla/test/exla/defn/api_test.exs
@@ -371,7 +371,6 @@ defmodule EXLA.Defn.APITest do
       end
     end
 
-    @tag :mlir_token_error
     test "executes hook within cond" do
       assert_equal(
         EXLA.jit(&hook_cond/2, hooks: %{cond: send_to_self(:tag)}).(1, 4),

--- a/exla/test/exla/defn/api_test.exs
+++ b/exla/test/exla/defn/api_test.exs
@@ -371,6 +371,7 @@ defmodule EXLA.Defn.APITest do
       end
     end
 
+    @tag :mlir_cond_error
     test "executes hook within cond" do
       assert_equal(
         EXLA.jit(&hook_cond/2, hooks: %{cond: send_to_self(:tag)}).(1, 4),

--- a/exla/test/exla/defn/api_test.exs
+++ b/exla/test/exla/defn/api_test.exs
@@ -17,7 +17,6 @@ defmodule EXLA.Defn.APITest do
       )
     end
 
-    @tag :mlir_token_error
     test "converts from host to separate client through lazy transfers" do
       a = Nx.tensor(1, backend: {EXLA.Backend, client: :host})
       b = Nx.tensor(2, backend: {EXLA.Backend, client: :host})
@@ -169,7 +168,6 @@ defmodule EXLA.Defn.APITest do
       {{{a, b}, c}, {a, {b, c}}}
     end
 
-    @tag :mlir_token_error
     test "send/recv with composite types" do
       %_{} = stream = EXLA.stream(&stream_composite/2, [0, {0, {1, 2}}])
       assert Nx.Stream.send(stream, 1) == :ok
@@ -196,7 +194,6 @@ defmodule EXLA.Defn.APITest do
 
     defn stream_empty_acc(i, {}), do: {i * i, {}}
 
-    @tag :mlir_token_error
     test "send/recv with empty acc" do
       %_{} = stream = EXLA.stream(&stream_empty_acc/2, [0, {}])
       assert Nx.Stream.send(stream, 1) == :ok
@@ -255,7 +252,6 @@ defmodule EXLA.Defn.APITest do
       {%{elem | a: a + b}, %{acc | b: a + b}}
     end
 
-    @tag :mlir_token_error
     test "container in and out" do
       args = [%Container{a: 0, b: 0, c: :reset, d: :elem}, %Container{a: 0, b: 0, d: :acc}]
       %_{} = stream = EXLA.stream(&container_stream/2, args)
@@ -351,7 +347,6 @@ defmodule EXLA.Defn.APITest do
       factorial
     end
 
-    @tag :mlir_token_error
     test "executes hook within while" do
       assert_equal(
         EXLA.jit(&hook_factorial/1, hooks: %{factorial: send_to_self(:tag)}).(5),

--- a/exla/test/exla/defn/api_test.exs
+++ b/exla/test/exla/defn/api_test.exs
@@ -190,14 +190,14 @@ defmodule EXLA.Defn.APITest do
 
     @tag :mlir_token_error
     test "send/recv with empty outfeed" do
-      %_{} = stream = EXLA.stream(&stream_empty_outfeed/2, [0, 0])
+      %_{} = stream = EXLA.stream(&stream_empty_outfeed/2, [0, 0.0])
       assert Nx.Stream.send(stream, 1) == :ok
       assert Nx.Stream.recv(stream) == {}
 
       assert Nx.Stream.send(stream, 2) == :ok
       assert Nx.Stream.recv(stream) == {}
 
-      assert_equal(Nx.Stream.done(stream), Nx.tensor(3))
+      assert_equal(Nx.Stream.done(stream), Nx.tensor(3.0))
     end
 
     defn stream_empty_acc(i, {}), do: {i * i, {}}

--- a/exla/test/exla/defn/api_test.exs
+++ b/exla/test/exla/defn/api_test.exs
@@ -7,7 +7,6 @@ defmodule EXLA.Defn.APITest do
   defn add_two(a, b), do: a + b
 
   describe "multi-client" do
-    @tag :mlir_token_error
     test "converts from host to separate client" do
       a = Nx.tensor(1, backend: {EXLA.Backend, client: :host})
       b = Nx.tensor(2, backend: {EXLA.Backend, client: :host})
@@ -31,7 +30,6 @@ defmodule EXLA.Defn.APITest do
   end
 
   describe "options" do
-    @tag :mlir_token_error
     test "logs when debugging" do
       logs =
         capture_log(fn ->
@@ -132,7 +130,6 @@ defmodule EXLA.Defn.APITest do
   describe "stream" do
     defn defn_sum(entry, acc), do: {acc, entry + acc}
 
-    @tag :mlir_token_error
     test "immediately done" do
       stream = EXLA.stream(&defn_sum/2, [0, 0])
       assert %Nx.Tensor{data: %EXLA.Backend{}} = done = Nx.Stream.done(stream)
@@ -143,7 +140,6 @@ defmodule EXLA.Defn.APITest do
       assert_equal(Nx.backend_transfer(done), Nx.tensor(2))
     end
 
-    @tag :mlir_token_error
     test "send/recv" do
       %_{} = stream = EXLA.stream(&defn_sum/2, [0, 0])
       assert Nx.Stream.send(stream, 1) == :ok
@@ -155,7 +151,6 @@ defmodule EXLA.Defn.APITest do
       assert_equal(Nx.Stream.done(stream), Nx.tensor(3))
     end
 
-    @tag :mlir_token_error
     test "send x2/recv x2" do
       %_{} = stream = EXLA.stream(&defn_sum/2, [0, 0])
       assert Nx.Stream.send(stream, 1) == :ok
@@ -188,7 +183,6 @@ defmodule EXLA.Defn.APITest do
 
     defn stream_empty_outfeed(i, t), do: {{}, i + t}
 
-    @tag :mlir_token_error
     test "send/recv with empty outfeed" do
       %_{} = stream = EXLA.stream(&stream_empty_outfeed/2, [0, 0.0])
       assert Nx.Stream.send(stream, 1) == :ok
@@ -214,7 +208,6 @@ defmodule EXLA.Defn.APITest do
       assert Nx.Stream.done(stream) == {}
     end
 
-    @tag :mlir_token_error
     test "handles failure before writing" do
       {_, ref} = spawn_monitor(fn -> EXLA.stream(&defn_sum/2, [0, 0]) end)
       assert_receive {:DOWN, ^ref, _, _, _}
@@ -225,7 +218,6 @@ defmodule EXLA.Defn.APITest do
       assert_equal(Nx.Stream.done(stream), Nx.tensor(1))
     end
 
-    @tag :mlir_token_error
     test "handles failure after writing" do
       {_, ref} =
         spawn_monitor(fn ->
@@ -241,7 +233,6 @@ defmodule EXLA.Defn.APITest do
       assert_equal(Nx.Stream.done(stream), Nx.tensor(1))
     end
 
-    @tag :mlir_token_error
     test "raises if recv is pending on done" do
       %_{} = stream = EXLA.stream(&defn_sum/2, [0, 0])
       assert Nx.Stream.send(stream, 1) == :ok
@@ -251,7 +242,6 @@ defmodule EXLA.Defn.APITest do
                    fn -> Nx.Stream.done(stream) end
     end
 
-    @tag :mlir_token_error
     test "raises if stream is done when recving" do
       %_{} = stream = EXLA.stream(&defn_sum/2, [0, 0])
       assert_equal(Nx.Stream.done(stream), Nx.tensor(0))
@@ -285,7 +275,6 @@ defmodule EXLA.Defn.APITest do
       {acc, acc + a - c}
     end
 
-    @tag :mlir_token_error
     test "lazy container in" do
       args = [%LazyOnly{a: 0, b: 0, c: 0}, 0]
       %_{} = stream = EXLA.stream(&lazy_container_stream/2, args)
@@ -312,14 +301,12 @@ defmodule EXLA.Defn.APITest do
       hook(a + b, :default, send_to_self(:default))
     end
 
-    @tag :mlir_token_error
     test "executes hook with default" do
       assert hook_default(2, 3)
       assert_receive {:default, tensor}
       assert_equal(tensor, Nx.tensor(5))
     end
 
-    @tag :mlir_token_error
     test "executes hook with callback" do
       assert_equal(
         EXLA.jit(&hook_default/2, hooks: %{default: send_to_self(:tag)}).(2, 3),
@@ -343,7 +330,6 @@ defmodule EXLA.Defn.APITest do
       hook(a + b, :optional)
     end
 
-    @tag :mlir_token_error
     test "executes optional hook" do
       assert_equal(hook_optional(2, 3), Nx.tensor(5))
 
@@ -421,7 +407,6 @@ defmodule EXLA.Defn.APITest do
       hook(container, :container)
     end
 
-    @tag :mlir_token_error
     test "executes hook with container" do
       container = %Container{a: 1, b: 2, c: :reset, d: :elem}
       EXLA.jit(&hook_container/1, hooks: %{container: send_to_self(:tag)}).(container)
@@ -433,7 +418,6 @@ defmodule EXLA.Defn.APITest do
 
     defn hook_stream(entry, acc), do: hook({acc, entry + acc}, :stream)
 
-    @tag :mlir_token_error
     test "executes hook with stream" do
       %_{} = stream = EXLA.stream(&hook_stream/2, [0, 0], hooks: %{stream: send_to_self(:tag)})
       assert Nx.Stream.send(stream, 1) == :ok

--- a/exla/test/exla/defn/expr_test.exs
+++ b/exla/test/exla/defn/expr_test.exs
@@ -1521,7 +1521,6 @@ defmodule EXLA.Defn.ExprTest do
       end
     end
 
-    @tag :mlir_cond_inside_while
     test "while inside if" do
       assert %{a: a, b: b} = while_inside_if(1, %{a: 1, b: 2.0})
       assert_all_close(a, 1)
@@ -3771,7 +3770,6 @@ defmodule EXLA.Defn.ExprTest do
 
     defn svd(t), do: Nx.LinAlg.svd(t)
 
-    @tag :mlir_linalg_nor_supported_yet
     test "svd" do
       input = Nx.iota({3, 3})
       output = Nx.as_type(input, {:f, 32})
@@ -3788,7 +3786,6 @@ defmodule EXLA.Defn.ExprTest do
       )
     end
 
-    @tag :mlir_linalg_nor_supported_yet
     test "svd (tall matrix)" do
       input = Nx.tensor([[2, 0], [0, 1], [0, 0]])
       output = Nx.as_type(input, {:f, 32})
@@ -3805,7 +3802,6 @@ defmodule EXLA.Defn.ExprTest do
       )
     end
 
-    @tag :mlir_linalg_nor_supported_yet
     test "svd (wide matrix)" do
       input = Nx.tensor([[2, 0, 0], [0, 1, 0]])
       output = Nx.as_type(input, {:f, 32})
@@ -4140,7 +4136,6 @@ defmodule EXLA.Defn.ExprTest do
     end
   end
 
-  @tag :mlir_cond_inside_while
   test "computes while inside cond" do
     assert {i} = while_in_cond(0)
     assert_equal(i, Nx.tensor(5))

--- a/exla/test/exla/defn/expr_test.exs
+++ b/exla/test/exla/defn/expr_test.exs
@@ -3878,6 +3878,7 @@ defmodule EXLA.Defn.ExprTest do
     end
   end
 
+
   describe "argsort" do
     defn argsort0(t), do: Nx.argsort(t, axis: 0)
     defn argsort1(t), do: Nx.argsort(t, axis: 1)

--- a/exla/test/exla/defn/expr_test.exs
+++ b/exla/test/exla/defn/expr_test.exs
@@ -1500,7 +1500,6 @@ defmodule EXLA.Defn.ExprTest do
 
     @tag :conditional_inside_map_reduce
     @tag :unsupported_64_bit_op
-    @tag :mlir_token_error
     test "maps a function with conditional" do
       assert_equal(
         map_conditional(Nx.tensor([-2, -1, 0, 1, 2])),

--- a/exla/test/exla/defn/expr_test.exs
+++ b/exla/test/exla/defn/expr_test.exs
@@ -3878,7 +3878,6 @@ defmodule EXLA.Defn.ExprTest do
     end
   end
 
-
   describe "argsort" do
     defn argsort0(t), do: Nx.argsort(t, axis: 0)
     defn argsort1(t), do: Nx.argsort(t, axis: 1)

--- a/exla/test/exla/defn/vectorize_test.exs
+++ b/exla/test/exla/defn/vectorize_test.exs
@@ -160,6 +160,7 @@ defmodule EXLA.Defn.VectorizeTest do
   end
 
   describe "cond" do
+    @describetag :mlir_cond_error
     deftransformp send_value(val, opts \\ []) do
       Nx.Defn.Kernel.hook(val, &send(opts[:pid] || self(), {&1, clause: opts[:clause]}))
     end

--- a/exla/test/exla/mlir/executable_feed_test.exs
+++ b/exla/test/exla/mlir/executable_feed_test.exs
@@ -22,10 +22,10 @@ defmodule EXLA.MLIR.ExecutableFeedTest do
               val_and_token = Value.infeed(token, t.shape)
               val = Value.get_tuple_element(val_and_token, 0)
               new_token = Value.get_tuple_element(val_and_token, 1)
-              outfeed_val = Value.add(val, val)
+              outfeed_val = Value.add(b, val, val)
 
-              _outfeed_token = Value.outfeed(new_token, [outfeed_val])
-              Value.tuple(b, [Value.add(outfeed_val, val)])
+              _outfeed_token = Value.outfeed([outfeed_val], new_token)
+              Value.tuple(b, [Value.add(b, outfeed_val, val)])
             end)
           end)
         end)

--- a/exla/test/exla/serving_test.exs
+++ b/exla/test/exla/serving_test.exs
@@ -67,8 +67,6 @@ defmodule EXLA.ServingTest do
 
   describe "partitioning" do
     @describetag :multi_device
-    @describetag :mlir_token_error
-
     for backend <- [Nx.BinaryBackend, EXLA.Backend] do
       test "spawns tasks concurrently with #{inspect(backend)}", config do
         execute_sync_supervised!(config, batch_size: 2, partitions: true)

--- a/exla/test/exla/serving_test.exs
+++ b/exla/test/exla/serving_test.exs
@@ -67,6 +67,7 @@ defmodule EXLA.ServingTest do
 
   describe "partitioning" do
     @describetag :multi_device
+    @describetag :mlir_multi_device_error
     for backend <- [Nx.BinaryBackend, EXLA.Backend] do
       test "spawns tasks concurrently with #{inspect(backend)}", config do
         execute_sync_supervised!(config, batch_size: 2, partitions: true)

--- a/exla/test/test_helper.exs
+++ b/exla/test/test_helper.exs
@@ -24,7 +24,7 @@ exclude =
   if compiler_mode == :mlir do
     exclude ++
       [
-        # :mlir_token_error,
+        :mlir_token_error,
         :mlir_vectorization
       ]
   else

--- a/exla/test/test_helper.exs
+++ b/exla/test/test_helper.exs
@@ -24,7 +24,7 @@ exclude =
   if compiler_mode == :mlir do
     exclude ++
       [
-        :mlir_token_error,
+        # :mlir_token_error,
         :mlir_vectorization
       ]
   else

--- a/exla/test/test_helper.exs
+++ b/exla/test/test_helper.exs
@@ -22,11 +22,7 @@ exclude =
 
 exclude =
   if compiler_mode == :mlir do
-    exclude ++
-      [
-        :mlir_token_error,
-        :mlir_vectorization
-      ]
+    exclude ++ [:mlir_cond_error]
   else
     exclude
   end

--- a/exla/test/test_helper.exs
+++ b/exla/test/test_helper.exs
@@ -22,7 +22,7 @@ exclude =
 
 exclude =
   if compiler_mode == :mlir do
-    exclude ++ [:mlir_cond_error]
+    exclude ++ [:mlir_cond_error, :mlir_multi_device_error]
   else
     exclude
   end


### PR DESCRIPTION
Adds initial support for infeed and outfeed in MLIR

Some tests are still skipped due to incomplete/incorrect implementations

Also changes binary ops to receive an explicit builder function instead of requiring both operands to belong in the same function.
