### PR TITLE
Support a mapping function in Nx.Defn.Kernel.print_value/2

### DIFF
--- a/nx/test/nx/defn/evaluator_test.exs
+++ b/nx/test/nx/defn/evaluator_test.exs
@@ -324,7 +324,9 @@ defmodule Nx.Defn.EvaluatorTest do
   defn mapped_inspect(a, b), do: print_value(a + b, fn x -> x * 2 end)
 
   test "print_value/2 with mapping function" do
-    assert ExUnit.CaptureIO.capture_io(fn -> mapped_inspect(1, 2) end) ==
+    assert ExUnit.CaptureIO.capture_io(fn ->
+             assert mapped_inspect(1, 2) == Nx.tensor(3)
+           end) ==
              """
              #Nx.Tensor<
                s64
@@ -689,7 +691,7 @@ defmodule Nx.Defn.EvaluatorTest do
       t = Nx.iota({2, 3}, vectorized_axes: [a: 1], type: :s64)
 
       message = """
-      test/nx/defn/evaluator_test.exs:658: the do-block in while must return tensors with the same shape, type, and names as the initial arguments.
+      test/nx/defn/evaluator_test.exs:660: the do-block in while must return tensors with the same shape, type, and names as the initial arguments.
 
       {\e[32m
        <<<<< Body (do-block) <<<<<
@@ -721,7 +723,7 @@ defmodule Nx.Defn.EvaluatorTest do
 
       error =
         """
-        test/nx/defn/evaluator_test.exs:658: condition must be a scalar tensor, got: #Nx.Tensor<
+        test/nx/defn/evaluator_test.exs:660: condition must be a scalar tensor, got: #Nx.Tensor<
           vectorized[x: 1]
           u8[1]
         \s\s

--- a/nx/test/nx/defn/evaluator_test.exs
+++ b/nx/test/nx/defn/evaluator_test.exs
@@ -311,12 +311,24 @@ defmodule Nx.Defn.EvaluatorTest do
 
   defn labelled_inspect(a, b), do: print_value(a + b, label: "add")
 
-  test "print_value/2" do
+  test "print_value/2 with options" do
     assert ExUnit.CaptureIO.capture_io(fn -> labelled_inspect(1, 2) end) ==
              """
              add: #Nx.Tensor<
                s64
                3
+             >
+             """
+  end
+
+  defn mapped_inspect(a, b), do: print_value(a + b, fn x -> x * 2 end)
+
+  test "print_value/2 with mapping function" do
+    assert ExUnit.CaptureIO.capture_io(fn -> mapped_inspect(1, 2) end) ==
+             """
+             #Nx.Tensor<
+               s64
+               6
              >
              """
   end
@@ -677,7 +689,7 @@ defmodule Nx.Defn.EvaluatorTest do
       t = Nx.iota({2, 3}, vectorized_axes: [a: 1], type: :s64)
 
       message = """
-      test/nx/defn/evaluator_test.exs:646: the do-block in while must return tensors with the same shape, type, and names as the initial arguments.
+      test/nx/defn/evaluator_test.exs:658: the do-block in while must return tensors with the same shape, type, and names as the initial arguments.
 
       {\e[32m
        <<<<< Body (do-block) <<<<<
@@ -709,7 +721,7 @@ defmodule Nx.Defn.EvaluatorTest do
 
       error =
         """
-        test/nx/defn/evaluator_test.exs:646: condition must be a scalar tensor, got: #Nx.Tensor<
+        test/nx/defn/evaluator_test.exs:658: condition must be a scalar tensor, got: #Nx.Tensor<
           vectorized[x: 1]
           u8[1]
         \s\s


### PR DESCRIPTION
When debugging large intermediate tensors, I usually look at a small slice or summaries such as `Nx.sum`, however `print_value` requires the returned expression to be used as is. This always leads me to tricks such as:

```elixir
x
|> then(fn x -> x + 0 * Nx.sum(print_value(x[[.., 1..3]])) end)
```

I've just realised we can generalize `print_value` to support additional transformation by using `hook_token`. With the new version, the example above would be:

```elixir
x
|> print_value(& &1[[.., 1..3]])
```