### PR TITLE
refactor(mlir): reduce tuple usage for returns in favor of variadic+flat tuples

### DIFF
--- a/exla/c_src/exla/exla.cc
+++ b/exla/c_src/exla/exla.cc
@@ -638,7 +638,7 @@ ERL_NIF_TERM deserialize_executable(ErlNifEnv* env, int argc, const ERL_NIF_TERM
   }
 
   EXLA_ASSIGN_OR_RETURN_NIF(exla::ExlaExecutable * executable,
-    (*client)->DeserializeExecutable(serialized), env);
+                            (*client)->DeserializeExecutable(serialized), env);
 
   return exla::nif::ok(env, exla::nif::make<exla::ExlaExecutable*>(env, executable));
 }
@@ -690,7 +690,6 @@ static ErlNifFunc exla_funcs[] = {
     {"mlir_less_equal", 3, mlir_less_equal},
     {"mlir_greater", 3, mlir_greater},
     {"mlir_greater_equal", 3, mlir_greater_equal},
-    {"mlir_build", 2, mlir_build},
     {"dump_mlir_module", 1, dump_mlir_module},
     {"mlir_get_shape", 1, mlir_get_shape},
     {"mlir_convert", 3, mlir_convert},
@@ -922,7 +921,6 @@ static ErlNifFunc exla_funcs[] = {
     {"start_log_sink", 1, start_log_sink},
     // Serialization
     {"serialize_executable", 1, serialize_executable},
-    {"deserialize_executable", 2, deserialize_executable}
-  };
+    {"deserialize_executable", 2, deserialize_executable}};
 
 ERL_NIF_INIT(Elixir.EXLA.NIF, exla_funcs, &load, NULL, NULL, NULL);

--- a/exla/c_src/exla/mlir/builder.cc
+++ b/exla/c_src/exla/mlir/builder.cc
@@ -1368,12 +1368,13 @@ mlir::Value MLIRFunction::OutfeedOp(std::vector<mlir::Value> inputs, mlir::Value
   return builder->create<mlir::stablehlo::OutfeedOp>(builder->getUnknownLoc(), mlir::ValueRange(inputs), token);
 }
 
-mlir::Value MLIRFunction::CallOp(std::vector<mlir::Value> inputs, MLIRFunction *computation) {
+std::vector<mlir::Value> MLIRFunction::CallOp(std::vector<mlir::Value> inputs, MLIRFunction *computation) {
   auto builder = module_->builder();
   builder->setInsertionPointToEnd(&func_->getBody().back());
   auto call_op = builder->create<mlir::func::CallOp>(builder->getUnknownLoc(), *computation->function(), mlir::ValueRange(inputs));
 
-  return call_op.getResult(0);
+  mlir::Operation::result_range results = call_op.getResults();
+  return std::vector<mlir::Value>(results.begin(), results.end());
 }
 
 std::vector<mlir::Value> MLIRFunction::WhileOp(MLIRFunction *pred, MLIRFunction *body_function, std::vector<mlir::Value> initial) {

--- a/exla/c_src/exla/mlir/builder.h
+++ b/exla/c_src/exla/mlir/builder.h
@@ -113,7 +113,7 @@ class MLIRFunction {
   ERL_NIF_TERM ConstantOp(mlir::Type type, ErlNifEnv *env, ERL_NIF_TERM value_ptr, std::optional<std::vector<int64_t>> dims = std::nullopt);
   mlir::Value InfeedOp(mlir::Value token, xla::Shape *shape);
   mlir::Value OutfeedOp(std::vector<mlir::Value> inputs, mlir::Value token);
-  mlir::Value CallOp(std::vector<mlir::Value> inputs, MLIRFunction *computation);
+  std::vector<mlir::Value> CallOp(std::vector<mlir::Value> inputs, MLIRFunction *computation);
   std::vector<mlir::Value> WhileOp(MLIRFunction *pred, MLIRFunction *body, std::vector<mlir::Value> initial);
   std::vector<mlir::Value> ReturnOp(std::vector<mlir::Value> values);
   int get_mlir_type(ErlNifEnv *env, ERL_NIF_TERM term, mlir::Type *type);

--- a/exla/c_src/exla/mlir/ops.cc
+++ b/exla/c_src/exla/mlir/ops.cc
@@ -673,26 +673,6 @@ ERL_NIF_TERM mlir_select(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
   return exla::nif::ok(env, exla::nif::make<mlir::Value>(env, res));
 }
 
-ERL_NIF_TERM mlir_build(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
-  if (argc != 2) {
-    return exla::nif::error(env, "Bad argument count.");
-  }
-
-  exla::MLIRFunction** function;
-  mlir::Value* root;
-
-  if (!exla::nif::get<exla::MLIRFunction*>(env, argv[0], function)) {
-    return exla::nif::error(env, "Unable to get function.");
-  }
-  if (!exla::nif::get<mlir::Value>(env, argv[1], root)) {
-    return exla::nif::error(env, "Unable to get root.");
-  }
-
-  (*function)->Build(*root);
-
-  return exla::nif::ok(env);
-}
-
 ERL_NIF_TERM mlir_convert(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
   if (argc != 3) {
     return exla::nif::error(env, "Bad argument count.");

--- a/exla/c_src/exla/mlir/ops.cc
+++ b/exla/c_src/exla/mlir/ops.cc
@@ -1529,9 +1529,9 @@ ERL_NIF_TERM mlir_call(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
     return exla::nif::error(env, "Unable to get computation.");
   }
 
-  mlir::Value result = (*function)->CallOp(arguments, *computation);
+  std::vector<mlir::Value> result = (*function)->CallOp(arguments, *computation);
 
-  return exla::nif::ok(env, exla::nif::make<mlir::Value>(env, result));
+  return exla::nif::ok(env, exla::nif::make_list<mlir::Value>(env, result));
 }
 
 ERL_NIF_TERM mlir_while(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {

--- a/exla/c_src/exla/mlir/ops.h
+++ b/exla/c_src/exla/mlir/ops.h
@@ -85,7 +85,6 @@ DEFINE_NIF(mlir_constant_r0);
 DEFINE_NIF(mlir_constant_from_binary);
 DEFINE_NIF(mlir_dot_general);
 DEFINE_NIF(mlir_select);
-DEFINE_NIF(mlir_build);
 DEFINE_NIF(mlir_convert);
 DEFINE_NIF(mlir_top_k);
 DEFINE_NIF(mlir_sort);

--- a/exla/lib/exla/builder.ex
+++ b/exla/lib/exla/builder.ex
@@ -109,7 +109,7 @@ defmodule EXLA.Builder do
     shape
   end
 
-  defp new(name) when is_binary(name) do
+  def new(name) when is_binary(name) do
     {:ok, ref} = EXLA.NIF.new_builder(name)
     %__MODULE__{ref: ref, parent: nil, name: name}
   end

--- a/exla/lib/exla/builder.ex
+++ b/exla/lib/exla/builder.ex
@@ -89,10 +89,8 @@ defmodule EXLA.Builder do
     %Computation{ref: ref, output_shape: shape}
   end
 
-  def build(%EXLA.MLIR.Value{function: function, ref: root_ref}) do
-    %EXLA.MLIR.Function{ref: function_ref} = function
-
-    :ok = EXLA.NIF.mlir_build(function_ref, root_ref)
+  def build(%EXLA.MLIR.Value{function: function} = value) do
+    EXLA.MLIR.Value.variadic_return([value])
     function
   end
 end

--- a/exla/lib/exla/builder.ex
+++ b/exla/lib/exla/builder.ex
@@ -10,6 +10,22 @@ defmodule EXLA.Builder do
   @enforce_keys [:ref]
   defstruct [:ref, :parent, :name]
 
+  def new_mlir(module_and_name, arg_shapes, return_shape) do
+    {module, name, is_public} =
+      case module_and_name do
+        {%M{} = module, name} -> {module, name, false}
+        _name -> {M.new(), "main", true}
+      end
+
+    M.create_function(
+      module,
+      name,
+      arg_shapes,
+      return_shape,
+      is_public
+    )
+  end
+
   def new(name, inputs, outputs, type, sub? \\ false, variadic_return? \\ false)
 
   def new(name, _inputs, _outputs, :xla, _sub?, _variadic_return?) do

--- a/exla/lib/exla/computation.ex
+++ b/exla/lib/exla/computation.ex
@@ -73,7 +73,7 @@ defmodule EXLA.Computation do
   end
 
   def compile(
-        %EXLA.MLIR.Function{module: module, return_shape: [return_shape]},
+        %EXLA.MLIR.Function{module: module, return_shape: return_shape},
         client,
         arg_shapes,
         opts

--- a/exla/lib/exla/computation.ex
+++ b/exla/lib/exla/computation.ex
@@ -78,8 +78,6 @@ defmodule EXLA.Computation do
         arg_shapes,
         opts
       ) do
-    assert_output_shape!(%{output_shape: return_shape})
-
     EXLA.MLIR.Module.compile(
       module,
       client,

--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -2906,10 +2906,8 @@ defmodule EXLA.Defn do
     to_type(value, {:pred, 8})
   end
 
-  defp new_mlir_function(module_and_name, arg_shapes, return_shape, output_tuple?) do
-    in_shape = arg_shapes
-    out_shape = return_shape
-
+  defp new_mlir_function(module_and_name, in_shape, out_shape, output_tuple?)
+       when is_list(in_shape) and is_list(out_shape) do
     out_shape =
       if output_tuple? do
         [EXLA.Shape.make_tuple_shape(out_shape)]

--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -167,7 +167,6 @@ defmodule EXLA.Defn do
     acc_shape = List.to_tuple(acc_shapes_l)
 
     constant_shapes_l = Enum.map(used_shapes, &elem(&1, 1))
-    constant_shape = List.to_tuple(constant_shapes_l)
 
     flag_shape = EXLA.Shape.make_shape({:pred, 8}, {})
     token_shape = EXLA.Shape.make_token_shape()

--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -2114,14 +2114,11 @@ defmodule EXLA.Defn do
          prepare_args
        ) do
     arg_shapes =
-      Enum.with_index(args, fn arg, i ->
-        {"p#{i}", computation_arg_shape(arg)}
-      end)
+      Enum.map(args, &computation_arg_shape/1)
 
     %{module: module, name: name} = subbuilder(builder, Atom.to_string(op))
 
-    function =
-      EXLA.Builder.new({module, name}, arg_shapes, struct(Nx.Tensor, out), :mlir, true)
+    function = new_mlir_function({module, name}, arg_shapes, out, false)
 
     args = EXLA.MLIR.Function.get_arguments(function)
 

--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -2144,12 +2144,9 @@ defmodule EXLA.Defn do
          type,
          %{builder: %EXLA.MLIR.Function{module: module}} = state
        ) do
-    arg_shapes =
-      Enum.with_index(args, fn arg, i ->
-        {"p#{i}", computation_arg_shape(arg)}
-      end)
+    arg_shapes = Enum.map(args, &computation_arg_shape/1)
 
-    function = EXLA.Builder.new({module, Atom.to_string(name)}, arg_shapes, expr, :mlir, false)
+    function = new_mlir_function({module, Atom.to_string(name)}, arg_shapes, expr, false)
     mlir_args = EXLA.MLIR.Function.get_arguments(function)
 
     arg_params = Enum.zip(args, mlir_args)

--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -1557,7 +1557,8 @@ defmodule EXLA.Defn do
     source = to_type(source, type)
     init_value = to_type(init_value, type)
 
-    args = [%{type: type, shape: {}}, %{type: type, shape: {}}]
+    arg_shape = EXLA.Shape.make_shape(type, {})
+    args = [arg_shape, arg_shape]
     select_fn = op_computation(:greater, args, :unused, state)
     scatter_fn = op_computation(:add, args, :unused, state)
 
@@ -1610,7 +1611,8 @@ defmodule EXLA.Defn do
     source = to_type(source, type)
     init_value = to_type(init_value, type)
 
-    args = [%{type: type, shape: {}}, %{type: type, shape: {}}]
+    arg_shape = EXLA.Shape.make_shape(type, {})
+    args = [arg_shape, arg_shape]
 
     select_fn = op_computation(:less, args, :unused, state)
     scatter_fn = op_computation(:add, args, :unused, state)
@@ -1637,7 +1639,8 @@ defmodule EXLA.Defn do
          %{type: type} = out,
          state
        ) do
-    args = [%{type: type, shape: {}}, %{type: type, shape: {}}]
+    arg_shape = EXLA.Shape.make_shape(type, {})
+    args = [arg_shape, arg_shape]
     scatter_fn = op_computation(:add, args, :unused, state)
 
     scatter(scatter_fn, tensors, out)
@@ -2124,8 +2127,7 @@ defmodule EXLA.Defn do
     subbuilder = subbuilder(state.builder, Atom.to_string(op))
 
     args =
-      Enum.with_index(args, fn arg, i ->
-        fun_shape = computation_arg_shape(arg)
+      Enum.with_index(args, fn fun_shape, i ->
         EXLA.Op.parameter(subbuilder, i, fun_shape, "p#{i}")
       end)
 
@@ -2463,7 +2465,8 @@ defmodule EXLA.Defn do
         initial when is_number(initial) -> EXLA.Op.constant_r0(state.builder, initial, type)
       end
 
-    args = [%{type: type, shape: {}}, %{type: type, shape: {}}]
+    arg_shape = EXLA.Shape.make_shape(type, {})
+    args = [arg_shape, arg_shape]
     # We reverse the argument order because :nan + :infinity
     # returns :nan but :infinity + :nan returns :infinity.
     # So we want to keep the current value as first argument

--- a/exla/lib/exla/executable.ex
+++ b/exla/lib/exla/executable.ex
@@ -84,7 +84,12 @@ defmodule EXLA.Executable do
   end
 
   defp decompose_output({data, device_id}, shape, client) do
-    %Shape{dtype: {:tuple, shapes}} = shape
+    shapes =
+      case shape do
+        %Shape{dtype: {:tuple, shapes}} -> shapes
+        shapes when is_list(shapes) -> shapes
+        %Shape{} -> [shape]
+      end
 
     Enum.zip_with(data, shapes, fn
       buf, subshape when is_reference(buf) ->

--- a/exla/lib/exla/lib.ex
+++ b/exla/lib/exla/lib.ex
@@ -140,19 +140,15 @@ defmodule EXLA.Lib do
     %{module: module, name: name} = subbuilder(builder, "min-max")
 
     function =
-      EXLA.Builder.new(
+      EXLA.Builder.new_mlir(
         {module, name},
         [
-          {"p0", EXLA.Shape.make_shape(type, {})},
-          {"p1", EXLA.Shape.make_shape(index_type, {})},
-          {"p2", EXLA.Shape.make_shape(type, {})},
-          {"p3", EXLA.Shape.make_shape(index_type, {})}
+          EXLA.Shape.make_shape(type, {}),
+          EXLA.Shape.make_shape(index_type, {}),
+          EXLA.Shape.make_shape(type, {}),
+          EXLA.Shape.make_shape(index_type, {})
         ],
-        {struct(Nx.Tensor, type: type, shape: {}),
-         struct(Nx.Tensor, type: index_type, shape: {})},
-        :mlir,
-        false,
-        true
+        [EXLA.Shape.make_shape(type, {}), EXLA.Shape.make_shape(index_type, {})]
       )
 
     [lhs_value, lhs_index, rhs_value, rhs_index] = EXLA.MLIR.Function.get_arguments(function)

--- a/exla/lib/exla/mlir/value.ex
+++ b/exla/lib/exla/mlir/value.ex
@@ -603,8 +603,8 @@ defmodule EXLA.MLIR.Value do
 
   def call(%Function{ref: fun_ref} = function, args, %Function{ref: computation_ref}) do
     arg_refs = Enum.map(args, & &1.ref)
-    ref = EXLA.NIF.mlir_call(fun_ref, arg_refs, computation_ref) |> unwrap!()
-    %Value{ref: ref, function: function}
+    refs = EXLA.NIF.mlir_call(fun_ref, arg_refs, computation_ref) |> unwrap!()
+    Enum.map(refs, &%Value{ref: &1, function: function})
   end
 
   def while(

--- a/exla/test/exla/builder_test.exs
+++ b/exla/test/exla/builder_test.exs
@@ -4,14 +4,14 @@ defmodule EXLA.BuilderTest do
   alias EXLA.{Builder, Computation, Op}
 
   test "new/1 succeeds in creating a new builder" do
-    assert b = %Builder{} = Builder.new("builder", nil, nil, :xla)
+    assert b = %Builder{} = Builder.new("builder")
     assert b.name == "builder"
     assert is_reference(b.ref)
     assert is_nil(b.parent)
   end
 
   test "new/2 succeeds in creating a new subbuilder" do
-    parent = Builder.new("builder", nil, nil, :xla)
+    parent = Builder.new("builder")
     assert b = Builder.new(parent, "subbuilder")
     assert b.name == "subbuilder"
     assert is_reference(b.ref)
@@ -19,7 +19,7 @@ defmodule EXLA.BuilderTest do
   end
 
   test "build/1 returns a computation" do
-    builder = Builder.new("test", nil, nil, :xla)
+    builder = Builder.new("test")
     op = Op.constant_r0(builder, 1, {:s, 32})
     assert %Computation{} = Builder.build(op)
   end

--- a/exla/test/exla/op_test.exs
+++ b/exla/test/exla/op_test.exs
@@ -4,13 +4,13 @@ defmodule EXLA.OpTest do
   alias EXLA.{Builder, Shape, Op}
 
   test "parameter/4 successfully creates op" do
-    builder = Builder.new("test", nil, nil, :xla)
+    builder = Builder.new("test")
     shape = Shape.make_shape({:s, 32}, {1, 1})
     assert %Op{} = Op.parameter(builder, 0, shape, "x")
   end
 
   test "constant_r0/3 successfully creates constant op" do
-    builder = Builder.new("test", nil, nil, :xla)
+    builder = Builder.new("test")
     assert a = %Op{} = Op.constant_r0(builder, 1.0, {:f, 64})
     assert b = %Op{} = Op.constant_r0(builder, 1.0, {:f, 32})
     assert c = %Op{} = Op.constant_r0(builder, -10000, {:s, 32})
@@ -35,7 +35,7 @@ defmodule EXLA.OpTest do
   end
 
   test "constant_from_binary/3" do
-    builder = Builder.new("test", nil, nil, :xla)
+    builder = Builder.new("test")
 
     shape = Shape.make_shape({:s, 64}, {0})
     assert a = %Op{} = Op.constant_from_binary(builder, <<>>, shape)
@@ -70,7 +70,7 @@ defmodule EXLA.OpTest do
   end
 
   test "tuple/2" do
-    builder = Builder.new("test", nil, nil, :xla)
+    builder = Builder.new("test")
 
     shape_a = Shape.make_shape({:s, 64}, {0})
     a = Op.constant_from_binary(builder, <<>>, shape_a)
@@ -177,7 +177,7 @@ defmodule EXLA.OpTest do
   end
 
   test "get_tuple_element/2" do
-    builder = Builder.new("test", nil, nil, :xla)
+    builder = Builder.new("test")
 
     shape_a = Shape.make_shape({:s, 64}, {0})
     a = Op.constant_from_binary(builder, <<>>, shape_a)
@@ -210,7 +210,7 @@ defmodule EXLA.OpTest do
   end
 
   test "add/3 successfully creates add op without broadcast dimensions" do
-    builder = Builder.new("test", nil, nil, :xla)
+    builder = Builder.new("test")
     shape = Shape.make_shape({:s, 32}, {1, 1})
     a = Op.parameter(builder, 0, shape, "a")
     b = Op.parameter(builder, 1, shape, "b")
@@ -218,7 +218,7 @@ defmodule EXLA.OpTest do
   end
 
   test "dot/3 successfully creates dot op" do
-    builder = Builder.new("test", nil, nil, :xla)
+    builder = Builder.new("test")
     shape = Shape.make_shape({:s, 32}, {1, 1})
     a = Op.parameter(builder, 0, shape, "a")
     b = Op.parameter(builder, 1, shape, "b")
@@ -226,14 +226,14 @@ defmodule EXLA.OpTest do
   end
 
   test "exp/1 successfully creates exp op" do
-    builder = Builder.new("test", nil, nil, :xla)
+    builder = Builder.new("test")
     shape = Shape.make_shape({:s, 32}, {1, 1})
     a = Op.parameter(builder, 0, shape, "a")
     assert %Op{} = Op.exp(a)
   end
 
   test "reduce/4 successfully creates reduce op" do
-    builder = Builder.new("test", nil, nil, :xla)
+    builder = Builder.new("test")
     sub_builder = Builder.new(builder, "sub_test")
 
     shape = Shape.make_shape({:f, 64}, {1_000})
@@ -251,14 +251,14 @@ defmodule EXLA.OpTest do
   end
 
   test "get_shape/1 returns shape of op" do
-    builder = Builder.new("test", nil, nil, :xla)
+    builder = Builder.new("test")
     shape = Shape.make_shape({:f, 64}, {5, 5, 5, 5, 5})
     x = Op.parameter(builder, 0, shape, "x")
     assert %Shape{dims: {5, 5, 5, 5, 5}, dtype: {:f, 64}} = Op.get_shape(x)
   end
 
   test "convert_element_type/1 changes type of operand" do
-    builder = Builder.new("test", nil, nil, :xla)
+    builder = Builder.new("test")
 
     shape = Shape.make_shape({:f, 64}, {1, 1})
 
@@ -284,7 +284,7 @@ defmodule EXLA.OpTest do
   end
 
   test "rng_normal/3" do
-    builder = Builder.new("test", nil, nil, :xla)
+    builder = Builder.new("test")
 
     shape_a = Shape.make_shape({:f, 64}, {3, 3, 3})
     mu_a = Op.constant_r0(builder, 0, {:f, 64})
@@ -301,7 +301,7 @@ defmodule EXLA.OpTest do
   end
 
   test "rng_uniform/3" do
-    builder = Builder.new("test", nil, nil, :xla)
+    builder = Builder.new("test")
 
     shape_a = Shape.make_shape({:f, 64}, {3, 3, 3})
     low_a = Op.constant_r0(builder, 0, {:f, 64})

--- a/exla/test/support/exla_helpers.ex
+++ b/exla/test/support/exla_helpers.ex
@@ -10,7 +10,12 @@ defmodule EXLAHelpers do
   It expects a list of shapes which will be given as parameters.
   """
   def compile(shapes, opts \\ [], output \\ nil, fun) do
-    builder = EXLA.Builder.new("test", shapes, output, opts[:compiler_mode] || :xla)
+    builder =
+      if opts[:compiler_mode] != :mlir do
+        EXLA.Builder.new("test")
+      else
+        new_mlir_function("test", List.wrap(shapes), List.wrap(output), false)
+      end
 
     params =
       if opts[:compiler_mode] == :mlir do
@@ -40,5 +45,49 @@ defmodule EXLAHelpers do
     exec = compile(Enum.map(args, & &1.shape), opts, output, fun)
     [result] = EXLA.Executable.run(exec, [args], opts)
     result
+  end
+
+  defp new_mlir_function(module_and_name, arg_shapes, return_shape, output_tuple?) do
+    in_shape = exla_shape(arg_shapes)
+    out_shape = exla_shape(return_shape)
+
+    out_shape =
+      if output_tuple? do
+        [EXLA.Shape.make_tuple_shape(out_shape)]
+      else
+        out_shape
+      end
+
+    EXLA.Builder.new_mlir(module_and_name, in_shape, out_shape)
+  end
+
+  defp exla_shape(tensors) when is_list(tensors) do
+    Enum.flat_map(tensors, &exla_shape/1)
+  end
+
+  defp exla_shape(tensors) when is_tuple(tensors) do
+    tensors
+    |> Tuple.to_list()
+    |> Enum.flat_map(&exla_shape/1)
+  end
+
+  defp exla_shape(%Nx.Tensor{type: {:tuple, _size}, data: %{args: args}}) do
+    Enum.flat_map(args, &exla_shape/1)
+  end
+
+  defp exla_shape(%{type: :token}) do
+    [EXLA.Shape.make_token_shape()]
+  end
+
+  defp exla_shape(%{shape: shape, type: type}) do
+    [EXLA.Shape.make_shape(type, shape)]
+  end
+
+  defp exla_shape(%EXLA.Shape{} = shape) do
+    [shape]
+  end
+
+  defp exla_shape(%EXLA.MLIR.Value{} = value) do
+    [EXLA.MLIR.Value.get_shape(value)]
   end
 end


### PR DESCRIPTION
- refactor: new compilation for cond
- refactor: while on new workflow
- refactor: token computation
- refactor: sort computation
- refactor: op computation
- refactor: fun_computation
- refactor: stream computation
- refactor: root builder
- refactor: separate builder new fully
- refactor: remove mlir_build NIF
