### PR TITLE
feat(mlir): QR as custom call

### DIFF
--- a/exla/Makefile
+++ b/exla/Makefile
@@ -57,8 +57,8 @@ $(EXLA_SO): $(EXLA_CACHE_SO)
 		ln -sf $(EXLA_CACHE_SO_LINK_PATH) $(EXLA_SO) ; \
 	fi
 
-$(EXLA_CACHE_SO): $(XLA_EXTENSION_DIR) $(EXLA_DIR)/exla.cc $(EXLA_DIR)/exla_ops.cc $(EXLA_DIR)/exla_ops.h $(EXLA_DIR)/mlir/ops.cc $(EXLA_DIR)/mlir/ops.h $(EXLA_DIR)/mlir/builder.cc $(EXLA_DIR)/mlir/builder.h $(EXLA_DIR)/exla_client.cc $(EXLA_DIR)/exla_client.h $(EXLA_DIR)/exla_nif_util.cc $(EXLA_DIR)/exla_nif_util.h $(EXLA_DIR)/exla_log_sink.h
-	$(CXX) $(CFLAGS) $(EXLA_DIR)/exla.cc $(EXLA_DIR)/exla_nif_util.cc $(EXLA_DIR)/mlir/ops.cc $(EXLA_DIR)/mlir/builder.cc $(EXLA_DIR)/exla_ops.cc $(EXLA_DIR)/exla_client.cc -o $(EXLA_CACHE_SO) $(LDFLAGS)
+$(EXLA_CACHE_SO): $(XLA_EXTENSION_DIR) $(EXLA_DIR)/exla.cc $(EXLA_DIR)/exla_ops.cc $(EXLA_DIR)/exla_ops.h $(EXLA_DIR)/mlir/ops.cc $(EXLA_DIR)/mlir/ops.h $(EXLA_DIR)/mlir/builder.cc $(EXLA_DIR)/mlir/builder.h $(EXLA_DIR)/mlir/custom_calls.cc $(EXLA_DIR)/mlir/custom_calls.h $(EXLA_DIR)/exla_client.cc $(EXLA_DIR)/exla_client.h $(EXLA_DIR)/exla_nif_util.cc $(EXLA_DIR)/exla_nif_util.h $(EXLA_DIR)/exla_log_sink.h
+	$(CXX) $(CFLAGS) $(EXLA_DIR)/exla.cc $(EXLA_DIR)/exla_nif_util.cc $(EXLA_DIR)/mlir/ops.cc $(EXLA_DIR)/mlir/custom_calls.cc $(EXLA_DIR)/mlir/builder.cc $(EXLA_DIR)/exla_ops.cc $(EXLA_DIR)/exla_client.cc -o $(EXLA_CACHE_SO) $(LDFLAGS)
 
 clean:
 	rm -rf cache

--- a/exla/c_src/exla/exla.cc
+++ b/exla/c_src/exla/exla.cc
@@ -781,7 +781,7 @@ static ErlNifFunc exla_funcs[] = {
     {"mlir_pop_region", 1, mlir_pop_region},
     {"mlir_while", 2, mlir_while},
     {"mlir_return", 2, mlir_return},
-    {"mlir_qr", 2, mlir_qr},
+    {"mlir_qr", 4, mlir_qr},
     // XlaBuilder
     {"new_builder", 1, new_builder},
     {"create_sub_builder", 2, create_sub_builder},

--- a/exla/c_src/exla/exla.cc
+++ b/exla/c_src/exla/exla.cc
@@ -781,6 +781,7 @@ static ErlNifFunc exla_funcs[] = {
     {"mlir_pop_region", 1, mlir_pop_region},
     {"mlir_while", 2, mlir_while},
     {"mlir_return", 2, mlir_return},
+    {"mlir_qr", 2, mlir_qr},
     // XlaBuilder
     {"new_builder", 1, new_builder},
     {"create_sub_builder", 2, create_sub_builder},

--- a/exla/c_src/exla/mlir/builder.cc
+++ b/exla/c_src/exla/mlir/builder.cc
@@ -1417,7 +1417,7 @@ std::pair<mlir::Value, mlir::Value> MLIRFunction::QRCpuCustomCall(mlir::Value op
 
   auto op_shape = op_type.getShape();
 
-  mlir::Value dim_sizes = builder->create<mlir::stablehlo::ConstantOp>(builder->getUnknownLoc(), Int64ToDenseIntElementsAttr(builder, std::vector<int64_t>({2, 2, 2})));
+  mlir::Value dim_sizes = builder->create<mlir::stablehlo::ConstantOp>(builder->getUnknownLoc(), Int64ToDenseIntElementsAttr(builder, std::vector<int64_t>({op_shape.size(), q_shape.size(), r_shape.size()})));
   mlir::Value operand_dims = builder->create<mlir::stablehlo::ConstantOp>(builder->getUnknownLoc(), Int64ToDenseIntElementsAttr(builder, op_shape));
   mlir::Value q_dims = builder->create<mlir::stablehlo::ConstantOp>(builder->getUnknownLoc(), Int64ToDenseIntElementsAttr(builder, q_shape));
   mlir::Value r_dims = builder->create<mlir::stablehlo::ConstantOp>(builder->getUnknownLoc(), Int64ToDenseIntElementsAttr(builder, r_shape));

--- a/exla/c_src/exla/mlir/builder.h
+++ b/exla/c_src/exla/mlir/builder.h
@@ -121,7 +121,7 @@ class MLIRFunction {
   std::vector<mlir::Value> ReturnOp(std::vector<mlir::Value> values);
   int get_mlir_type(ErlNifEnv *env, ERL_NIF_TERM term, mlir::Type *type);
   std::vector<mlir::Value> PushRegion(mlir::Region *region);
-  std::pair<mlir::Value, mlir::Value> QRCpuCustomCall(mlir::Value operand);
+  std::pair<mlir::Value, mlir::Value> QRCpuCustomCall(mlir::Value operand, std::vector<int64_t> q_shape, std::vector<int64_t> r_shape);
   void PopRegion();
   void Build(mlir::Value root);
 

--- a/exla/c_src/exla/mlir/builder.h
+++ b/exla/c_src/exla/mlir/builder.h
@@ -121,6 +121,7 @@ class MLIRFunction {
   std::vector<mlir::Value> ReturnOp(std::vector<mlir::Value> values);
   int get_mlir_type(ErlNifEnv *env, ERL_NIF_TERM term, mlir::Type *type);
   std::vector<mlir::Value> PushRegion(mlir::Region *region);
+  std::pair<mlir::Value, mlir::Value> QRCpuCustomCall(mlir::Value operand);
   void PopRegion();
   void Build(mlir::Value root);
 

--- a/exla/c_src/exla/mlir/custom_calls.cc
+++ b/exla/c_src/exla/mlir/custom_calls.cc
@@ -6,8 +6,44 @@
 #include "builder.h"
 
 template <typename DataType>
-void qr_cpu_custom_call(void *out[], const void *in[]) {
+void single_matrix_qr_cpu_custom_call(DataType *q_out, DataType *r_out, DataType *in, int64_t m, int64_t k, int64_t n, bool complete) {
   typedef Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> RowMajorMatrix;
+
+  Eigen::Map<RowMajorMatrix> input(in, m, n);
+  Eigen::HouseholderQR<RowMajorMatrix> qr = input.householderQr();
+
+  RowMajorMatrix Q, R;
+  size_t num_bytes_q, num_bytes_r;
+
+  if (complete) {
+    Q = qr.householderQ() * RowMajorMatrix::Identity(m, m);
+    R = qr.matrixQR();
+
+    num_bytes_q = m * m * sizeof(DataType);
+
+    for (int64_t i = 0; i < m; ++i) {
+      for (int64_t j = 0; j < n; ++j) {
+        r_out[i * n + j] = (j >= i) ? R(i, j) : static_cast<DataType>(0.0);
+      }
+    }
+  } else {
+    Q = qr.householderQ() * RowMajorMatrix::Identity(m, k);
+    R = qr.matrixQR().topRows(k);
+
+    num_bytes_q = m * k * sizeof(DataType);
+
+    for (int64_t i = 0; i < k; ++i) {
+      for (int64_t j = 0; j < n; ++j) {
+        r_out[i * n + j] = (j >= i) ? R(i, j) : static_cast<DataType>(0.0);
+      }
+    }
+  }
+
+  memcpy(q_out, Q.data(), num_bytes_q);
+}
+
+template <typename DataType>
+void qr_cpu_custom_call(void *out[], const void *in[]) {
   DataType *operand = (DataType *)in[0];
 
   int64_t *dim_sizes = (int64_t *)in[1];
@@ -24,28 +60,32 @@ void qr_cpu_custom_call(void *out[], const void *in[]) {
   int64_t *r_dims_ptr = (int64_t *)in[4];
   std::vector<int64_t> r_dims(r_dims_ptr, r_dims_ptr + num_r_dims);
 
-  // TO-DO: support batched matrices
-  Eigen::Map<RowMajorMatrix> input(operand, operand_dims[operand_dims.size() - 2], operand_dims[operand_dims.size() - 1]);
-  Eigen::HouseholderQR<RowMajorMatrix> qr = input.householderQr();
-  RowMajorMatrix Q = qr.householderQ();
-  RowMajorMatrix R = qr.matrixQR().template triangularView<Eigen::Upper>();
+  int64_t m = q_dims[q_dims.size() - 2];
+  int64_t k = q_dims[q_dims.size() - 1];
+  int64_t n = r_dims[r_dims.size() - 1];
+  bool complete = r_dims[r_dims.size() - 2] == m;
 
-  int64_t total_q_size = 1;
-  for (int64_t i = 0; i < num_q_dims; i++) {
-    total_q_size *= q_dims[i];
-  }
-  int64_t total_r_size = 1;
-  for (int64_t i = 0; i < num_r_dims; i++) {
-    total_r_size *= r_dims[i];
+  auto leading_dimensions = std::vector<int64_t>(operand_dims.begin(), operand_dims.end() - 2);
+
+  int64_t batch_items = 1;
+  for (int64_t i = 0; i < leading_dimensions.size(); i++) {
+    batch_items *= leading_dimensions[i];
   }
 
   DataType *q = (DataType *)out[0];
-  memcpy(q, Q.data(), total_q_size * sizeof(DataType));
-
   DataType *r = (DataType *)out[1];
-  memcpy(r, R.data(), total_r_size * sizeof(DataType));
 
-  return;
+  int64_t r_stride = r_dims[r_dims.size() - 1] * r_dims[r_dims.size() - 2] * sizeof(DataType);
+  int64_t q_stride = q_dims[q_dims.size() - 1] * q_dims[q_dims.size() - 2] * sizeof(DataType);
+  int64_t inner_stride = m * n * sizeof(DataType);
+
+  for (int64_t i = 0; i < batch_items; i++) {
+    single_matrix_qr_cpu_custom_call<DataType>(
+        (DataType *)out[0] + i * q_stride,
+        (DataType *)out[1] + i * r_stride,
+        operand + i * inner_stride * sizeof(DataType),
+        m, k, n, complete);
+  }
 }
 
 void qr_cpu_custom_call_f32(void *out[], const void *in[]) {

--- a/exla/c_src/exla/mlir/custom_calls.cc
+++ b/exla/c_src/exla/mlir/custom_calls.cc
@@ -1,0 +1,57 @@
+#include "custom_calls.h"
+
+#include <Eigen/Dense>
+#include <Eigen/QR>
+
+#include "builder.h"
+
+template <typename DataType>
+void qr_cpu_custom_call(void *out[], const void *in[]) {
+  typedef Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> RowMajorMatrix;
+  DataType *operand = (DataType *)in[0];
+
+  int64_t *dim_sizes = (int64_t *)in[1];
+  int64_t num_operand_dims = dim_sizes[0];
+  int64_t num_q_dims = dim_sizes[1];
+  int64_t num_r_dims = dim_sizes[2];
+
+  int64_t *operand_dims_ptr = (int64_t *)in[2];
+  std::vector<int64_t> operand_dims(operand_dims_ptr, operand_dims_ptr + num_operand_dims);
+
+  int64_t *q_dims_ptr = (int64_t *)in[3];
+  std::vector<int64_t> q_dims(q_dims_ptr, q_dims_ptr + num_q_dims);
+
+  int64_t *r_dims_ptr = (int64_t *)in[4];
+  std::vector<int64_t> r_dims(r_dims_ptr, r_dims_ptr + num_r_dims);
+
+  // TO-DO: support batched matrices
+  Eigen::Map<RowMajorMatrix> input(operand, operand_dims[operand_dims.size() - 2], operand_dims[operand_dims.size() - 1]);
+  Eigen::HouseholderQR<RowMajorMatrix> qr = input.householderQr();
+  RowMajorMatrix Q = qr.householderQ();
+  RowMajorMatrix R = qr.matrixQR().template triangularView<Eigen::Upper>();
+
+  int64_t total_q_size = 1;
+  for (int64_t i = 0; i < num_q_dims; i++) {
+    total_q_size *= q_dims[i];
+  }
+  int64_t total_r_size = 1;
+  for (int64_t i = 0; i < num_r_dims; i++) {
+    total_r_size *= r_dims[i];
+  }
+
+  DataType *q = (DataType *)out[0];
+  memcpy(q, Q.data(), total_q_size * sizeof(DataType));
+
+  DataType *r = (DataType *)out[1];
+  memcpy(r, R.data(), total_r_size * sizeof(DataType));
+
+  return;
+}
+
+void qr_cpu_custom_call_f32(void *out[], const void *in[]) {
+  qr_cpu_custom_call<float>(out, in);
+}
+
+void qr_cpu_custom_call_f64(void *out[], const void *in[]) {
+  qr_cpu_custom_call<double>(out, in);
+}

--- a/exla/c_src/exla/mlir/custom_calls.cc
+++ b/exla/c_src/exla/mlir/custom_calls.cc
@@ -88,6 +88,14 @@ void qr_cpu_custom_call(void *out[], const void *in[]) {
   }
 }
 
+void qr_cpu_custom_call_bf16(void *out[], const void *in[]) {
+  qr_cpu_custom_call<exla::bfloat16>(out, in);
+}
+
+void qr_cpu_custom_call_f16(void *out[], const void *in[]) {
+  qr_cpu_custom_call<exla::float16>(out, in);
+}
+
 void qr_cpu_custom_call_f32(void *out[], const void *in[]) {
   qr_cpu_custom_call<float>(out, in);
 }

--- a/exla/c_src/exla/mlir/custom_calls.h
+++ b/exla/c_src/exla/mlir/custom_calls.h
@@ -1,7 +1,7 @@
 #pragma once
 
-void qr_cpu_custom_call_f32(void *out[], const void *in[]);
-void qr_cpu_custom_call_f64(void *out[], const void *in[]);
-
 template <typename DataType>
 void qr_cpu_custom_call(void *out[], const void *in[]);
+
+void qr_cpu_custom_call_f32(void *out[], const void *in[]);
+void qr_cpu_custom_call_f64(void *out[], const void *in[]);

--- a/exla/c_src/exla/mlir/custom_calls.h
+++ b/exla/c_src/exla/mlir/custom_calls.h
@@ -3,5 +3,7 @@
 template <typename DataType>
 void qr_cpu_custom_call(void *out[], const void *in[]);
 
+void qr_cpu_custom_call_bf16(void *out[], const void *in[]);
+void qr_cpu_custom_call_f16(void *out[], const void *in[]);
 void qr_cpu_custom_call_f32(void *out[], const void *in[]);
 void qr_cpu_custom_call_f64(void *out[], const void *in[]);

--- a/exla/c_src/exla/mlir/custom_calls.h
+++ b/exla/c_src/exla/mlir/custom_calls.h
@@ -1,0 +1,7 @@
+#pragma once
+
+void qr_cpu_custom_call_f32(void *out[], const void *in[]);
+void qr_cpu_custom_call_f64(void *out[], const void *in[]);
+
+template <typename DataType>
+void qr_cpu_custom_call(void *out[], const void *in[]);

--- a/exla/c_src/exla/mlir/ops.cc
+++ b/exla/c_src/exla/mlir/ops.cc
@@ -1608,12 +1608,13 @@ ERL_NIF_TERM mlir_return(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
 }
 
 ERL_NIF_TERM mlir_qr(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
-  if (argc != 2) {
+  if (argc != 4) {
     return exla::nif::error(env, "Bad argument count.");
   }
 
   exla::MLIRFunction** function;
   mlir::Value* value;
+  std::vector<int64_t> q_shape, r_shape;
 
   if (!exla::nif::get<exla::MLIRFunction*>(env, argv[0], function)) {
     return exla::nif::error(env, "Unable to get function.");
@@ -1621,8 +1622,14 @@ ERL_NIF_TERM mlir_qr(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
   if (!exla::nif::get<mlir::Value>(env, argv[1], value)) {
     return exla::nif::error(env, "Unable to get value.");
   }
+  if (!exla::nif::get_list(env, argv[2], q_shape)) {
+    return exla::nif::error(env, "Unable to get Q shape.");
+  }
+  if (!exla::nif::get_list(env, argv[3], r_shape)) {
+    return exla::nif::error(env, "Unable to get R shape.");
+  }
 
-  std::pair<mlir::Value, mlir::Value> result = (*function)->QRCpuCustomCall(*value);
+  std::pair<mlir::Value, mlir::Value> result = (*function)->QRCpuCustomCall(*value, q_shape, r_shape);
 
   ERL_NIF_TERM q = exla::nif::make<mlir::Value>(env, result.first);
   ERL_NIF_TERM r = exla::nif::make<mlir::Value>(env, result.second);

--- a/exla/c_src/exla/mlir/ops.cc
+++ b/exla/c_src/exla/mlir/ops.cc
@@ -1606,3 +1606,26 @@ ERL_NIF_TERM mlir_return(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
   std::vector<mlir::Value> res = (*function)->ReturnOp(operands);
   return exla::nif::ok(env, exla::nif::make_list<mlir::Value>(env, res));
 }
+
+ERL_NIF_TERM mlir_qr(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
+  if (argc != 2) {
+    return exla::nif::error(env, "Bad argument count.");
+  }
+
+  exla::MLIRFunction** function;
+  mlir::Value* value;
+
+  if (!exla::nif::get<exla::MLIRFunction*>(env, argv[0], function)) {
+    return exla::nif::error(env, "Unable to get function.");
+  }
+  if (!exla::nif::get<mlir::Value>(env, argv[1], value)) {
+    return exla::nif::error(env, "Unable to get value.");
+  }
+
+  std::pair<mlir::Value, mlir::Value> result = (*function)->QRCpuCustomCall(*value);
+
+  ERL_NIF_TERM q = exla::nif::make<mlir::Value>(env, result.first);
+  ERL_NIF_TERM r = exla::nif::make<mlir::Value>(env, result.second);
+
+  return exla::nif::ok(env, enif_make_tuple2(env, q, r));
+}

--- a/exla/c_src/exla/mlir/ops.h
+++ b/exla/c_src/exla/mlir/ops.h
@@ -115,3 +115,4 @@ DEFINE_NIF(mlir_outfeed);
 DEFINE_NIF(mlir_call);
 DEFINE_NIF(mlir_while);
 DEFINE_NIF(mlir_return);
+DEFINE_NIF(mlir_qr);

--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -753,12 +753,9 @@ defmodule EXLA.Defn do
            _out,
          %{client: %EXLA.Client{platform: :host}, builder: %Function{} = function} = state,
          cache
-       )
-       when elem(tensor.shape, tuple_size(tensor.shape) - 2) >=
-              elem(tensor.shape, tuple_size(tensor.shape) - 1) do
+       ) do
     # We match only on platform: :host for MLIR, as we want to support
     # QR-on-cpu as a custom call only in this case
-    # TO-DO: Add support for wide-mode inputs as well
     {tensor, cache} = recur_operator(tensor, state, cache)
 
     tensor =

--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -747,13 +747,17 @@ defmodule EXLA.Defn do
          :optional,
          %T{
            data: %Expr{
-             args: [%{data: %{op: :qr, args: [tensor, _opts]}}, {q_expr, r_expr}, _callback]
+             args: [
+               %{data: %{op: :qr, args: [tensor, _opts]}},
+               {%{type: {type_kind, _}} = q_expr, r_expr},
+               _callback
+             ]
            }
-         } =
-           _out,
+         },
          %{client: %EXLA.Client{platform: :host}, builder: %Function{} = function} = state,
          cache
-       ) do
+       )
+       when type_kind != :c do
     # We match only on platform: :host for MLIR, as we want to support
     # QR-on-cpu as a custom call only in this case
     {tensor, cache} = recur_operator(tensor, state, cache)

--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -330,6 +330,7 @@ defmodule EXLA.Defn do
             end)
 
           state = %{
+            client: client,
             precision: Keyword.get(options, :precision, :default),
             builder: body_b,
             params: Map.new(input_params ++ acc_params ++ constant_params),
@@ -392,7 +393,7 @@ defmodule EXLA.Defn do
 
     client = EXLA.Client.fetch!(client_name)
 
-    callback = &to_root_computation(&1, &2, &3, &4, compile_options)
+    callback = &to_root_computation(&1, &2, &3, &4, Keyword.put(compile_options, :client, client))
 
     {executable, used_inputs, outputs, outfeed, :ok, debug?} =
       compile(client, key, vars, fun, compile_options, 0, [], callback)
@@ -435,6 +436,7 @@ defmodule EXLA.Defn do
       end
 
     state = %{
+      client: Keyword.fetch!(options, :client),
       precision: Keyword.get(options, :precision, :default),
       builder: builder,
       params: Map.new(params ++ outfeed.infeeds),
@@ -739,6 +741,32 @@ defmodule EXLA.Defn do
   defp cached_recur_operator(:fun, %T{data: %Expr{args: args}, type: type}, state, cache) do
     [args, expr, {_, name, _}] = args
     {fun_computation(name, args, expr, type, state), cache}
+  end
+
+  defp cached_recur_operator(
+         :optional,
+         %T{
+           data: %Expr{
+             args: [%{data: %{op: :qr, args: [tensor, opts]}}, {q_expr, _r_expr}, _callback]
+           }
+         } =
+           _out,
+         %{client: %EXLA.Client{platform: :host}, builder: %Function{} = function} = state,
+         cache
+       ) do
+    # We match only on platform: :host for MLIR, as we want to support
+    # QR-on-cpu as a custom call only in this case
+    {tensor, cache} = recur_operator(tensor, state, cache)
+
+    tensor =
+      if op_type(tensor) != q_expr.type do
+        to_type(tensor, q_expr.type)
+      else
+        tensor
+      end
+
+    {q, r} = Value.qr(tensor, opts[:mode] == :complete)
+    {Value.tuple(function, [q, r]), cache}
   end
 
   defp cached_recur_operator(

--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -135,7 +135,7 @@ defmodule EXLA.Defn do
   end
 
   defp to_stream_computation(
-         _client,
+         client,
          input_length,
          acc_length,
          %Function{} = builder,
@@ -207,6 +207,7 @@ defmodule EXLA.Defn do
             end)
 
           state = %{
+            client: client,
             builder: builder,
             precision: Keyword.get(options, :precision, :default),
             params: Map.new(input_params ++ acc_params ++ constant_params),
@@ -435,8 +436,14 @@ defmodule EXLA.Defn do
           end)
       end
 
+    client = Keyword.fetch!(options, :client)
+
+    unless client do
+      raise ArgumentError, "missing client"
+    end
+
     state = %{
-      client: Keyword.fetch!(options, :client),
+      client: client,
       precision: Keyword.get(options, :precision, :default),
       builder: builder,
       params: Map.new(params ++ outfeed.infeeds),

--- a/exla/lib/exla/mlir/value.ex
+++ b/exla/lib/exla/mlir/value.ex
@@ -625,8 +625,11 @@ defmodule EXLA.MLIR.Value do
     Enum.map(refs, fn ref -> %Value{function: function, ref: ref} end)
   end
 
-  def qr(%Value{function: function, ref: ref}, opts) do
-    {q_ref, r_ref} = EXLA.NIF.mlir_qr(function.ref, ref) |> unwrap!()
+  def qr(%Value{function: function, ref: ref}, q_shape, r_shape)
+      when is_tuple(q_shape) and is_tuple(r_shape) do
+    {q_ref, r_ref} =
+      EXLA.NIF.mlir_qr(function.ref, ref, Tuple.to_list(q_shape), Tuple.to_list(r_shape))
+      |> unwrap!()
 
     {
       %Value{function: function, ref: q_ref},

--- a/exla/lib/exla/mlir/value.ex
+++ b/exla/lib/exla/mlir/value.ex
@@ -625,6 +625,15 @@ defmodule EXLA.MLIR.Value do
     Enum.map(refs, fn ref -> %Value{function: function, ref: ref} end)
   end
 
+  def qr(%Value{function: function, ref: ref}, opts) do
+    {q_ref, r_ref} = EXLA.NIF.mlir_qr(function.ref, ref) |> unwrap!()
+
+    {
+      %Value{function: function, ref: q_ref},
+      %Value{function: function, ref: r_ref}
+    }
+  end
+
   defp flatten_shapes(val) when is_list(val) do
     Enum.flat_map(val, &flatten_shapes/1)
   end

--- a/exla/lib/exla/nif.ex
+++ b/exla/lib/exla/nif.ex
@@ -183,7 +183,7 @@ defmodule EXLA.NIF do
   def mlir_while(_function, _initial), do: :erlang.nif_error(:undef)
   def mlir_return(_function, _operands), do: :erlang.nif_error(:undef)
 
-  def mlir_qr(_function, _operand), do: :erlang.nif_error(:undef)
+  def mlir_qr(_function, _operand, _q_shape, _r_shape), do: :erlang.nif_error(:undef)
 
   def new_builder(_name),
     do: :erlang.nif_error(:undef)

--- a/exla/lib/exla/nif.ex
+++ b/exla/lib/exla/nif.ex
@@ -183,6 +183,8 @@ defmodule EXLA.NIF do
   def mlir_while(_function, _initial), do: :erlang.nif_error(:undef)
   def mlir_return(_function, _operands), do: :erlang.nif_error(:undef)
 
+  def mlir_qr(_function, _operand), do: :erlang.nif_error(:undef)
+
   def new_builder(_name),
     do: :erlang.nif_error(:undef)
 

--- a/exla/test/exla/defn/expr_test.exs
+++ b/exla/test/exla/defn/expr_test.exs
@@ -3766,6 +3766,13 @@ defmodule EXLA.Defn.ExprTest do
       assert q.shape == {3, 3}
       assert r.shape == {3, 2}
       assert_all_close(Nx.dot(q, r), output, atol: 1.0e-5, rtol: 1.0e-5)
+
+      input = Nx.iota({2, 3})
+      output = Nx.as_type(input, {:f, 32})
+      assert {q, r} = qr_complete(input)
+      assert q.shape == {2, 2}
+      assert r.shape == {2, 3}
+      assert_all_close(Nx.dot(q, r), output, atol: 1.0e-5, rtol: 1.0e-5)
     end
 
     defn svd(t), do: Nx.LinAlg.svd(t)

--- a/exla/test/exla/defn/expr_test.exs
+++ b/exla/test/exla/defn/expr_test.exs
@@ -3753,18 +3753,20 @@ defmodule EXLA.Defn.ExprTest do
     defn qr_complete(t), do: Nx.LinAlg.qr(t, mode: :complete)
 
     test "qr" do
-      input = Nx.iota({3, 2})
+      input = Nx.iota({3, 3})
       output = Nx.as_type(input, {:f, 32})
 
       assert {q, r} = qr(input)
-      assert q.shape == {3, 2}
-      assert r.shape == {2, 2}
+
+      dbg({q, r})
+      assert q.shape == {3, 3}
+      assert r.shape == {3, 3}
       assert_all_close(Nx.dot(q, r), output)
 
-      assert {q, r} = qr_complete(Nx.iota({3, 2}))
-      assert q.shape == {3, 3}
-      assert r.shape == {3, 2}
-      assert_all_close(Nx.dot(q, r), output)
+      # assert {q, r} = qr_complete(Nx.iota({3, 2}))
+      # assert q.shape == {3, 3}
+      # assert r.shape == {3, 2}
+      # assert_all_close(Nx.dot(q, r), output)
     end
 
     defn svd(t), do: Nx.LinAlg.svd(t)

--- a/exla/test/exla/defn/expr_test.exs
+++ b/exla/test/exla/defn/expr_test.exs
@@ -3770,7 +3770,6 @@ defmodule EXLA.Defn.ExprTest do
 
     defn svd(t), do: Nx.LinAlg.svd(t)
 
-    @tag :skip
     test "svd" do
       input = Nx.iota({3, 3})
       output = Nx.as_type(input, {:f, 32})
@@ -3787,7 +3786,6 @@ defmodule EXLA.Defn.ExprTest do
       )
     end
 
-    @tag :skip
     test "svd (tall matrix)" do
       input = Nx.tensor([[2, 0], [0, 1], [0, 0]])
       output = Nx.as_type(input, {:f, 32})
@@ -3804,7 +3802,6 @@ defmodule EXLA.Defn.ExprTest do
       )
     end
 
-    @tag :skip
     test "svd (wide matrix)" do
       input = Nx.tensor([[2, 0, 0], [0, 1, 0]])
       output = Nx.as_type(input, {:f, 32})

--- a/exla/test/exla/defn/expr_test.exs
+++ b/exla/test/exla/defn/expr_test.exs
@@ -3753,24 +3753,24 @@ defmodule EXLA.Defn.ExprTest do
     defn qr_complete(t), do: Nx.LinAlg.qr(t, mode: :complete)
 
     test "qr" do
-      input = Nx.iota({3, 3})
+      input = Nx.iota({3, 2})
       output = Nx.as_type(input, {:f, 32})
 
       assert {q, r} = qr(input)
 
-      dbg({q, r})
-      assert q.shape == {3, 3}
-      assert r.shape == {3, 3}
+      assert q.shape == {3, 2}
+      assert r.shape == {2, 2}
       assert_all_close(Nx.dot(q, r), output)
 
-      # assert {q, r} = qr_complete(Nx.iota({3, 2}))
-      # assert q.shape == {3, 3}
-      # assert r.shape == {3, 2}
-      # assert_all_close(Nx.dot(q, r), output)
+      assert {q, r} = qr_complete(Nx.iota({3, 2}))
+      assert q.shape == {3, 3}
+      assert r.shape == {3, 2}
+      assert_all_close(Nx.dot(q, r), output, atol: 1.0e-5, rtol: 1.0e-5)
     end
 
     defn svd(t), do: Nx.LinAlg.svd(t)
 
+    @tag :skip
     test "svd" do
       input = Nx.iota({3, 3})
       output = Nx.as_type(input, {:f, 32})
@@ -3787,6 +3787,7 @@ defmodule EXLA.Defn.ExprTest do
       )
     end
 
+    @tag :skip
     test "svd (tall matrix)" do
       input = Nx.tensor([[2, 0], [0, 1], [0, 0]])
       output = Nx.as_type(input, {:f, 32})
@@ -3803,6 +3804,7 @@ defmodule EXLA.Defn.ExprTest do
       )
     end
 
+    @tag :skip
     test "svd (wide matrix)" do
       input = Nx.tensor([[2, 0, 0], [0, 1, 0]])
       output = Nx.as_type(input, {:f, 32})

--- a/exla/test/exla/executable_test.exs
+++ b/exla/test/exla/executable_test.exs
@@ -191,8 +191,8 @@ defmodule EXLA.ExecutableFeedTest do
                        {new_token, val}
                      else
                        val_and_token = Op.infeed(token, t.shape)
-                       val = Op.get_tuple_element(val_and_token, 1)
-                       new_token = Op.get_tuple_element(val_and_token, 0)
+                       val = Op.get_tuple_element(val_and_token, 0)
+                       new_token = Op.get_tuple_element(val_and_token, 1)
                        {new_token, val}
                      end
 

--- a/exla/test/exla/mlir/custom_call_test.exs
+++ b/exla/test/exla/mlir/custom_call_test.exs
@@ -1,0 +1,41 @@
+defmodule EXLA.MLIR.CustomCallTest do
+  use EXLA.Case, async: true
+
+  describe "qr" do
+    for type <- [bf: 16, f: 16, f: 32, f: 64] do
+      tol_opts =
+        case type do
+          {:f, 16} ->
+            [atol: 1.0e-10, rtol: 1.0e-2]
+
+          {:bf, 16} ->
+            [atol: 1.0e-1, rtol: 1.0e-1]
+
+          {:f, 64} ->
+            [atol: 1.0e-15, rtol: 1.0e-15]
+
+          {:f, 32} ->
+            [atol: 1.0e-6, rtol: 1.0e-6]
+        end
+
+      test "works for input type #{inspect(type)}" do
+        square = Nx.iota({4, 4}, type: unquote(type))
+        tall = Nx.iota({4, 3}, type: unquote(type))
+        wide = Nx.iota({3, 4}, type: unquote(type))
+
+        fun =
+          EXLA.jit(
+            fn t ->
+              {q, r} = Nx.LinAlg.qr(t, mode: :reduced)
+              Nx.dot(q, r)
+            end,
+            compiler_mode: :mlir
+          )
+
+        assert_all_close(fun.(square), square, unquote(tol_opts))
+        assert_all_close(fun.(tall), tall, unquote(tol_opts))
+        assert_all_close(fun.(wide), wide, unquote(tol_opts))
+      end
+    end
+  end
+end

--- a/exla/test/test_helper.exs
+++ b/exla/test/test_helper.exs
@@ -1,6 +1,10 @@
 target = System.get_env("EXLA_TARGET", "host")
 client = EXLAHelpers.client()
 
+if System.get_env("DEBUG") in ["1", "true"] do
+  IO.gets("Press enter to continue... -- PID: #{System.pid()}")
+end
+
 compiler_mode =
   case System.get_env("EXLA_COMPILER_MODE", "mlir") do
     "xla" -> :xla


### PR DESCRIPTION
In short, during our migration to MLIR, QR got slower due
to being implemented in defn (which can't leverage things like in-place modifications).
This adds a custom call for using Eigen (which is already a dependency of ours) on the CPU.
