### PR TITLE
refactor: remove tuples from EXLA

### DIFF
--- a/exla/c_src/exla/exla.cc
+++ b/exla/c_src/exla/exla.cc
@@ -603,8 +603,6 @@ static ErlNifFunc exla_funcs[] = {
     {"get_mlir_function_arguments", 1, get_mlir_function_arguments},
     {"mlir_add", 3, mlir_add},
     {"mlir_subtract", 3, mlir_subtract},
-    {"mlir_tuple", 2, mlir_tuple},
-    {"mlir_get_tuple_element", 3, mlir_get_tuple_element},
     {"mlir_multiply", 3, mlir_multiply},
     {"mlir_min", 3, mlir_min},
     {"mlir_max", 3, mlir_max},

--- a/exla/c_src/exla/mlir/ops.cc
+++ b/exla/c_src/exla/mlir/ops.cc
@@ -153,50 +153,6 @@ ERL_NIF_TERM get_mlir_function_arguments(ErlNifEnv* env, int argc, const ERL_NIF
   return exla::nif::ok(env, enif_make_list_from_array(env, terms.data(), terms.size()));
 }
 
-ERL_NIF_TERM mlir_tuple(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
-  if (argc != 2) {
-    return exla::nif::error(env, "Bad argument count.");
-  }
-
-  exla::MLIRFunction** function;
-  std::vector<mlir::Value> vals;
-
-  if (!exla::nif::get<exla::MLIRFunction*>(env, argv[0], function)) {
-    return exla::nif::error(env, "Unable to get function.");
-  }
-  if (!exla::nif::get_list<mlir::Value>(env, argv[1], vals)) {
-    return exla::nif::error(env, "Unable to get values.");
-  }
-
-  mlir::Value res = (*function)->TupleOp(vals);
-
-  return exla::nif::ok(env, exla::nif::make<mlir::Value>(env, res));
-}
-
-ERL_NIF_TERM mlir_get_tuple_element(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
-  if (argc != 3) {
-    return exla::nif::error(env, "Bad argument count.");
-  }
-
-  exla::MLIRFunction** function;
-  mlir::Value* tuple;
-  exla::int64 index;
-
-  if (!exla::nif::get<exla::MLIRFunction*>(env, argv[0], function)) {
-    return exla::nif::error(env, "Unable to get function.");
-  }
-  if (!exla::nif::get<mlir::Value>(env, argv[1], tuple)) {
-    return exla::nif::error(env, "Unable to get tuple.");
-  }
-  if (!exla::nif::get(env, argv[2], &index)) {
-    return exla::nif::error(env, "Unable to get index.");
-  }
-
-  mlir::Value res = (*function)->GetTupleElementOp(*tuple, index);
-
-  return exla::nif::ok(env, exla::nif::make<mlir::Value>(env, res));
-}
-
 ERL_NIF_TERM mlir_binary_op(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[], std::function<mlir::Value(exla::MLIRFunction*, mlir::Value*, mlir::Value*)> op) {
   if (argc != 3) {
     return exla::nif::error(env, "Bad argument count.");

--- a/exla/c_src/exla/mlir/ops.h
+++ b/exla/c_src/exla/mlir/ops.h
@@ -9,8 +9,6 @@ DEFINE_NIF(new_mlir_module);
 DEFINE_NIF(new_mlir_context);
 DEFINE_NIF(create_mlir_function);
 DEFINE_NIF(get_mlir_function_arguments);
-DEFINE_NIF(mlir_tuple);
-DEFINE_NIF(mlir_get_tuple_element);
 
 // Binary Ops
 DEFINE_NIF(mlir_add);

--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -763,10 +763,6 @@ defmodule EXLA.Defn do
     Enum.fetch!(op, index)
   end
 
-  defp to_operator(:elem, [op, index], _ans, _state) do
-    Value.get_tuple_element(op, index)
-  end
-
   defp to_operator(
          :dot,
          [
@@ -1642,13 +1638,6 @@ defmodule EXLA.Defn do
     tuple
     |> Tuple.to_list()
     |> Enum.zip(params)
-    |> Enum.flat_map(&computation_arg_param/1)
-  end
-
-  defp computation_arg_param({tuple, %mod{} = param}) when is_tuple(tuple) do
-    tuple
-    |> Tuple.to_list()
-    |> Enum.with_index(fn arg, i -> {arg, mod.get_tuple_element(param, i)} end)
     |> Enum.flat_map(&computation_arg_param/1)
   end
 

--- a/exla/lib/exla/defn/outfeed.ex
+++ b/exla/lib/exla/defn/outfeed.ex
@@ -183,11 +183,11 @@ defmodule EXLA.Defn.Outfeed do
   defp outfeed_flat_tuple(%Outfeed{token: token, compiled_hooks: ch} = outfeed, builder, tuple) do
     flag = next_hook(ch)
     token = Value.outfeed(Value.constant_r0(builder, flag, {:u, 16}), token)
-    %EXLA.Shape{dims: {size}, dtype: {:tuple, shapes}} = Value.get_shape(tuple)
+    shapes = Enum.map(tuple, &Value.get_shape/1)
 
     token =
-      Enum.reduce(1..size//1, token, fn pos, token ->
-        Value.outfeed(Value.get_tuple_element(tuple, pos - 1), token)
+      Enum.reduce(tuple, token, fn elem, token ->
+        Value.outfeed(elem, token)
       end)
 
     {%{outfeed | token: token}, flag, shapes}

--- a/exla/lib/exla/lib.ex
+++ b/exla/lib/exla/lib.ex
@@ -131,7 +131,7 @@ defmodule EXLA.Lib do
           Value.select(eq?, id, arg_max)
       end
 
-    [%{function: function}, _] = Value.variadic_return([max, arg_max])
+    Value.variadic_return(function, [max, arg_max])
     function
   end
 

--- a/exla/lib/exla/mlir/value.ex
+++ b/exla/lib/exla/mlir/value.ex
@@ -624,28 +624,14 @@ defmodule EXLA.MLIR.Value do
   end
 
   defp flatten_shapes(val) do
-    case val do
-      %EXLA.Shape{dtype: {:tuple, element_shapes}} ->
-        Enum.flat_map(element_shapes, fn shape -> flatten_shapes(shape) end)
-
-      _ ->
-        [val.ref]
-    end
+    [val.ref]
   end
 
   defp flatten_tuples(val) when is_list(val) do
     Enum.flat_map(val, &flatten_tuples/1)
   end
 
-  defp flatten_tuples(val) do
-    case get_shape(val) do
-      %{dtype: {:tuple, _}, dims: {0}} ->
-        []
-
-      _ ->
-        [val.ref]
-    end
-  end
+  defp flatten_tuples(val), do: [val.ref]
 
   defp unwrap!(:ok), do: :ok
   defp unwrap!({:ok, value}), do: value

--- a/exla/lib/exla/mlir/value.ex
+++ b/exla/lib/exla/mlir/value.ex
@@ -611,7 +611,7 @@ defmodule EXLA.MLIR.Value do
     {results, %Region{ref: pred_ref}, %Region{ref: body_ref}}
   end
 
-  def variadic_return([%Value{function: function} | _] = values, flatten_tuples? \\ false) do
+  def variadic_return(function, values, flatten_tuples? \\ false) when is_list(values) do
     refs =
       if flatten_tuples? do
         flatten_tuples(values)

--- a/exla/lib/exla/mlir/value.ex
+++ b/exla/lib/exla/mlir/value.ex
@@ -77,18 +77,6 @@ defmodule EXLA.MLIR.Value do
     %Value{op | ref: ref}
   end
 
-  def tuple(%Function{} = func, vals) when is_list(vals) do
-    refs = Enum.map(vals, fn %Value{ref: ref} -> ref end)
-    ref = EXLA.NIF.mlir_tuple(func.ref, refs) |> unwrap!()
-    %Value{ref: ref, function: func}
-  end
-
-  def get_tuple_element(%Value{function: %Function{} = func, ref: ref}, index)
-      when is_integer(index) do
-    ref = EXLA.NIF.mlir_get_tuple_element(func.ref, ref, index) |> unwrap!()
-    %Value{ref: ref, function: func}
-  end
-
   def get_shape(%Value{ref: ref}) do
     shape_ref = EXLA.NIF.mlir_get_shape(ref) |> unwrap!()
     EXLA.Shape.get_shape_info(shape_ref)
@@ -653,11 +641,6 @@ defmodule EXLA.MLIR.Value do
     case get_shape(val) do
       %{dtype: {:tuple, _}, dims: {0}} ->
         []
-
-      %{dtype: {:tuple, _}, dims: {n}} ->
-        # TO-DO(mlir): maybe we can avoid building tuples altogether.
-        # Nx should be returning all tuples as flattened anyway.
-        Enum.flat_map(0..(n - 1), fn i -> val |> get_tuple_element(i) |> flatten_tuples() end)
 
       _ ->
         [val.ref]

--- a/exla/lib/exla/mlir/value.ex
+++ b/exla/lib/exla/mlir/value.ex
@@ -611,13 +611,8 @@ defmodule EXLA.MLIR.Value do
     {results, %Region{ref: pred_ref}, %Region{ref: body_ref}}
   end
 
-  def variadic_return(function, values, flatten_tuples? \\ false) when is_list(values) do
-    refs =
-      if flatten_tuples? do
-        flatten_tuples(values)
-      else
-        Enum.map(values, & &1.ref)
-      end
+  def variadic_return(function, values) when is_list(values) do
+    refs = Enum.map(values, & &1.ref)
 
     refs = EXLA.NIF.mlir_return(function.ref, refs) |> unwrap!()
 

--- a/exla/lib/exla/nif.ex
+++ b/exla/lib/exla/nif.ex
@@ -45,8 +45,6 @@ defmodule EXLA.NIF do
   def mlir_transpose(_function, _operand, _shape), do: :erlang.nif_error(:undef)
   def mlir_slice(_function, _operand, _starts, _limits, _strides), do: :erlang.nif_error(:undef)
   def mlir_dynamic_slice(_function, _operand, _starts, _lengths), do: :erlang.nif_error(:undef)
-  def mlir_tuple(_function, _vals), do: :erlang.nif_error(:undef)
-  def mlir_get_tuple_element(_function, _tuple, _index), do: :erlang.nif_error(:undef)
   def mlir_pad(_function, _tensor, _pad, _low, _high, _mid), do: :erlang.nif_error(:undef)
 
   def mlir_reduce(_function, _reducer, _init_values, _inputs, _dimensions),

--- a/exla/test/exla/backend_test.exs
+++ b/exla/test/exla/backend_test.exs
@@ -21,8 +21,14 @@ defmodule EXLA.BackendTest do
     logsumexp: 2
   ]
 
+  if is_mac_arm?() do
+    @skip_mac_arm [asin: 1, sin: 1, cos: 1]
+  else
+    @skip_mac_arm []
+  end
+
   doctest Nx,
-    except: [:moduledoc] ++ @excluded_doctests
+    except: [:moduledoc] ++ @excluded_doctests ++ @skip_mac_arm
 
   test "Nx.to_binary/1" do
     t = Nx.tensor([1, 2, 3, 4], backend: EXLA.Backend)
@@ -157,7 +163,7 @@ defmodule EXLA.BackendTest do
     # This is not really meant to work in practice,
     # but it does work with the Nx.BinaryBackend so
     # we make it work for EXLA too.
-    defn double(fun), do: double_transform(fun.())
+    defn(double(fun), do: double_transform(fun.()))
 
     deftransformp(double_transform(x), do: Nx.backend_transfer(Nx.Defn.Kernel.*(x, x)))
 

--- a/exla/test/exla/executable_test.exs
+++ b/exla/test/exla/executable_test.exs
@@ -12,7 +12,7 @@ defmodule EXLA.ExecutableTest do
     test "with no inputs and default options" do
       assert [a = %DeviceBuffer{}] =
                run_one([], [], Shape.make_shape({:s, 32}, {}), fn b ->
-                 Value.tuple(b, [Value.constant_r0(b, 1, {:s, 32})])
+                 [Value.constant_r0(b, 1, {:s, 32})]
                end)
 
       assert <<1::32-native>> == DeviceBuffer.read(a)
@@ -24,7 +24,7 @@ defmodule EXLA.ExecutableTest do
 
       assert [a = %DeviceBuffer{}] =
                run_one([t1, t2], [], Shape.make_tuple_shape([t1.shape]), fn b, x, y ->
-                 Value.tuple(b, [Value.add(b, x, y)])
+                 [Value.add(b, x, y)]
                end)
 
       assert <<2::32-native>> == DeviceBuffer.read(a)
@@ -49,12 +49,12 @@ defmodule EXLA.ExecutableTest do
 
       assert [%DeviceBuffer{}] =
                run_one([t1, t2], [], t1.shape, fn b, x, y ->
-                 Value.tuple(b, [Value.add(b, x, y)])
+                 [Value.add(b, x, y)]
                end)
 
       assert [%DeviceBuffer{}] =
                run_one([t1, t2], [], Shape.make_tuple_shape([t1.shape]), fn b, x, y ->
-                 Value.tuple(b, [Value.add(b, x, y)])
+                 [Value.add(b, x, y)]
                end)
 
       assert DeviceBuffer.read(t1) == <<1::32-native>>
@@ -67,7 +67,7 @@ defmodule EXLA.ExecutableTest do
 
       exec =
         compile([t1.shape, t2.shape], [], [t1.shape], fn b, x, y ->
-          Value.tuple(b, [Value.add(b, x, y)])
+          [Value.add(b, x, y)]
         end)
 
       assert [[t3 = %DeviceBuffer{}]] = Executable.run(exec, [[t1, t2]])
@@ -89,7 +89,7 @@ defmodule EXLA.ExecutableTest do
 
       assert [a = %DeviceBuffer{}] =
                run_one([t1, t2], [], {t1.shape}, fn b, x, y ->
-                 Value.tuple(b, [Value.add(b, x, y)])
+                 [Value.add(b, x, y)]
                end)
 
       assert <<3::32-native>> == DeviceBuffer.read(a)
@@ -100,8 +100,8 @@ defmodule EXLA.ExecutableTest do
       t2 = BinaryBuffer.from_binary(<<2::32-native>>, Shape.make_shape({:s, 32}, {}))
 
       assert [a = %DeviceBuffer{}, b = %DeviceBuffer{}] =
-               run_one([t1, t2], [], Shape.make_tuple_shape([t1.shape, t2.shape]), fn b, x, y ->
-                 Value.tuple(b, [x, y])
+               run_one([t1, t2], [], Shape.make_tuple_shape([t1.shape, t2.shape]), fn _b, x, y ->
+                 [x, y]
                end)
 
       assert <<1::32-native>> == DeviceBuffer.read(a)
@@ -119,7 +119,7 @@ defmodule EXLA.ExecutableTest do
                  [device_id: 1],
                  EXLA.Shape.make_tuple_shape([t1.shape, t2.shape, t1.shape]),
                  fn b, x, y ->
-                   Value.tuple(b, [x, y, Value.add(b, x, y)])
+                   [x, y, Value.add(b, x, y)]
                  end
                )
 
@@ -132,7 +132,7 @@ defmodule EXLA.ExecutableTest do
 
       assert_raise RuntimeError, ~r"Expected buffer to be placed on device 0", fn ->
         run_one([a, b], [device_id: 0], t1.shape, fn b, x, y ->
-          Value.tuple(b, [Value.add(b, x, y)])
+          [Value.add(b, x, y)]
         end)
       end
     end
@@ -165,7 +165,7 @@ defmodule EXLA.ExecutableFeedTest do
 
                    outfeed_val = Value.add(b, val, val)
                    _outfeed_token = Value.outfeed(outfeed_val, new_token)
-                   Value.tuple(b, [Value.add(b, outfeed_val, val)])
+                   [Value.add(b, outfeed_val, val)]
                  end)
                end)
 
@@ -204,7 +204,7 @@ defmodule EXLA.ExecutableFeedTest do
                    Value.variadic_return(b, [body_token, input])
                    Function.pop_region(b)
 
-                   Value.tuple(b, [result])
+                   [result]
                  end)
                end)
 

--- a/exla/test/exla/executable_test.exs
+++ b/exla/test/exla/executable_test.exs
@@ -193,7 +193,7 @@ defmodule EXLA.ExecutableFeedTest do
 
                    [_token, val] = Function.push_region(b, condition_region)
                    zero = Value.constant_r0(b, 0, {:s, 32})
-                   Value.variadic_return([Value.not_equal(b, val, zero)])
+                   Value.variadic_return(b, [Value.not_equal(b, val, zero)])
                    Function.pop_region(b)
 
                    [body_token, val] = Function.push_region(b, body_region)
@@ -201,7 +201,7 @@ defmodule EXLA.ExecutableFeedTest do
                    body_token = Value.outfeed(Value.add(b, val, val), body_token)
                    {body_token, [input]} = Value.infeed(body_token, t.shape)
 
-                   Value.variadic_return([body_token, input])
+                   Value.variadic_return(b, [body_token, input])
                    Function.pop_region(b)
 
                    Value.tuple(b, [result])

--- a/exla/test/support/exla_case.ex
+++ b/exla/test/support/exla_case.ex
@@ -43,4 +43,8 @@ defmodule EXLA.Case do
       """)
     end
   end
+
+  def is_mac_arm? do
+    Application.fetch_env!(:exla, :is_mac_arm)
+  end
 end

--- a/exla/test/support/exla_helpers.ex
+++ b/exla/test/support/exla_helpers.ex
@@ -15,7 +15,7 @@ defmodule EXLAHelpers do
 
       fun
       |> apply([builder | params])
-      |> then(&EXLA.MLIR.Value.variadic_return(List.wrap(&1)))
+      |> then(&EXLA.MLIR.Value.variadic_return(builder, List.wrap(&1)))
 
       EXLA.MLIR.Module.compile(
         builder.module,

--- a/exla/test/test_helper.exs
+++ b/exla/test/test_helper.exs
@@ -17,6 +17,14 @@ exclude =
     _ -> [:conditional_inside_map_reduce]
   end
 
+case {:os.type(), List.to_string(:erlang.system_info(:system_architecture))} do
+  {{:unix, :darwin}, "aarch64" <> _} ->
+    Application.put_env(:exla, :is_mac_arm, true)
+
+  _ ->
+    Application.put_env(:exla, :is_mac_arm, false)
+end
+
 if client.platform == :host and client.device_count == 1 and System.schedulers_online() > 1 do
   IO.puts(
     "To run multi-device tests: XLA_FLAGS=--xla_force_host_platform_device_count=#{System.schedulers_online()} mix test"


### PR DESCRIPTION
Removes tuples from EXLA altogether, as the MLIR compiler can work with variadic/lists of inputs and outputs
