### PR TITLE
Add stack as a callback

### DIFF
--- a/exla/lib/exla/backend.ex
+++ b/exla/lib/exla/backend.ex
@@ -244,6 +244,17 @@ defmodule EXLA.Backend do
   end
 
   @impl true
+  def stack(out, tensors, axis) do
+    out = Nx.to_template(out)
+
+    expr_fun = fn tensors ->
+      Nx.Defn.Expr.stack(out, Tuple.to_list(tensors), axis)
+    end
+
+    jit([], expr_fun, tensors, [List.to_tuple(tensors)])
+  end
+
+  @impl true
   def slice(out, tensor, start_indices, lengths, strides) do
     out = Nx.to_template(out)
 

--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -1312,10 +1312,13 @@ defmodule EXLA.Defn do
   end
 
   defp to_operator(:concatenate, [[%Value{} | _rest] = tensors, axis], ans, _state) do
-    tensors =
-      tensors
-      |> Enum.map(&to_type(&1, ans.type))
+    tensors = Enum.map(tensors, &to_type(&1, ans.type))
+    Value.concatenate(tensors, axis, expr_to_typespec(ans))
+  end
 
+  defp to_operator(:stack, [[%Value{} | _rest] = tensors, axis], ans, _state) do
+    reshape_typespec = Typespec.tensor(ans.type, put_elem(ans.shape, axis, 1))
+    tensors = Enum.map(tensors, &(&1 |> to_type(ans.type) |> Value.reshape(reshape_typespec)))
     Value.concatenate(tensors, axis, expr_to_typespec(ans))
   end
 

--- a/nx/lib/nx/backend.ex
+++ b/nx/lib/nx/backend.ex
@@ -77,6 +77,7 @@ defmodule Nx.Backend do
   @callback take_along_axis(out :: tensor, input :: tensor, indices :: tensor, axis) :: tensor
   @callback gather(out :: tensor, input :: tensor, indices :: tensor, keyword) :: tensor
   @callback concatenate(out :: tensor, tensor, axis) :: tensor
+  @callback stack(out :: tensor, tensor, axis) :: tensor
   @callback select(out :: tensor, tensor, tensor, tensor) :: tensor
 
   @callback conv(out :: tensor, tensor, kernel :: tensor, keyword) :: tensor

--- a/nx/lib/nx/binary_backend.ex
+++ b/nx/lib/nx/binary_backend.ex
@@ -2078,6 +2078,19 @@ defmodule Nx.BinaryBackend do
   end
 
   @impl true
+  def stack(out, tensors, axis) do
+    %{shape: output_shape, type: {_, size} = output_type} = out
+
+    tensors
+    |> Enum.map(fn %{shape: shape} = t ->
+      t = as_type(%{t | type: output_type}, t)
+      {to_binary(t), Tuple.insert_at(shape, axis, 1)}
+    end)
+    |> bin_concatenate(size, axis, output_shape)
+    |> then(&from_binary(out, &1))
+  end
+
+  @impl true
   def concatenate(out, tensors, axis) do
     %{shape: output_shape, type: {_, size} = output_type} = out
 

--- a/nx/lib/nx/defn/evaluator.ex
+++ b/nx/lib/nx/defn/evaluator.ex
@@ -20,7 +20,7 @@ defmodule Nx.Defn.Evaluator do
   alias Nx.Defn.{Composite, Expr, Tree}
 
   @creation_ops [:eye, :iota, :from_binary]
-  @list_ops [:concatenate]
+  @list_ops [:concatenate, :stack]
   @indices_ops [:slice, :put_slice]
 
   @impl true

--- a/nx/lib/nx/defn/expr.ex
+++ b/nx/lib/nx/defn/expr.ex
@@ -1214,6 +1214,12 @@ defmodule Nx.Defn.Expr do
   end
 
   @impl true
+  def stack(out, tensors, axis) do
+    {tensors, context} = to_exprs(tensors)
+    expr(out, context, :stack, [tensors, axis])
+  end
+
+  @impl true
   def triangular_solve(out, a, b, opts) do
     {[a, b], context} = to_exprs([a, b])
     expr(out, context, :triangular_solve, [a, b, opts])

--- a/nx/lib/nx/defn/grad.ex
+++ b/nx/lib/nx/defn/grad.ex
@@ -620,6 +620,21 @@ defmodule Nx.Defn.Grad do
     [{x, g}]
   end
 
+  defp grad(:stack, [tensors, axis], ans, g) do
+    zero_axes = List.duplicate(0, Nx.rank(ans))
+    ans_shape_list = Tuple.to_list(ans.shape)
+
+    {pairs, _} =
+      Enum.map_reduce(tensors, 0, fn t, limit ->
+        current_limit = 1 + limit
+        start = List.replace_at(zero_axes, axis, limit)
+        len = List.replace_at(ans_shape_list, axis, 1)
+        {{t, Nx.slice(g, start, len)}, current_limit}
+      end)
+
+    pairs
+  end
+
   defp grad(:concatenate, [tensors, axis], ans, g) do
     zero_axes = List.duplicate(0, Nx.rank(ans))
     ans_shape_list = Tuple.to_list(ans.shape)

--- a/nx/lib/nx/defn/tree.ex
+++ b/nx/lib/nx/defn/tree.ex
@@ -202,7 +202,8 @@ defmodule Nx.Defn.Tree do
     {[%{token | hooks: hooks}], acc}
   end
 
-  def apply_args(%T{data: %Expr{op: :concatenate, args: [list | args]}}, _type, acc, fun) do
+  def apply_args(%T{data: %Expr{op: op, args: [list | args]}}, _type, acc, fun)
+      when op in [:concatenate, :stack] do
     {list, acc} = Enum.map_reduce(list, acc, fun)
     {[list | args], acc}
   end

--- a/torchx/lib/torchx/backend.ex
+++ b/torchx/lib/torchx/backend.ex
@@ -338,6 +338,16 @@ defmodule Torchx.Backend do
   end
 
   @impl true
+  def stack(out, tensors, axis) do
+    reshape = put_elem(out.shape, axis, 1)
+
+    tensors
+    |> Enum.map(&(&1 |> from_nx() |> Torchx.reshape(reshape)))
+    |> Torchx.concatenate(axis)
+    |> to_nx(out)
+  end
+
+  @impl true
   def take(out, t, i, axis) do
     axes = Nx.axes(t)
 


### PR DESCRIPTION
Generally speaking we want to reduce the number of callbacks but stack causes one additional copy of every tensor and it is used very frequently.

One option is to use optional callbacks, but concatenate/stack are the only operations that require a variable number of arguments, which is hard to include as part of the optional/evaluator system, so it its own callback.

Closes #1441.