### PR TITLE
Fix min / max value for 16 bit signed type

### DIFF
--- a/nx/lib/nx/constants.ex
+++ b/nx/lib/nx/constants.ex
@@ -158,7 +158,7 @@ defmodule Nx.Constants do
       iex> Nx.Constants.max_finite({:s, 16})
       #Nx.Tensor<
         s16
-        32677
+        32767
       >
 
       iex> Nx.Constants.max_finite({:f, 32})
@@ -220,7 +220,7 @@ defmodule Nx.Constants do
       iex> Nx.Constants.min_finite({:s, 16})
       #Nx.Tensor<
         s16
-        -32678
+        -32768
       >
 
       iex> Nx.Constants.min_finite({:f, 32})

--- a/nx/lib/nx/shared.ex
+++ b/nx/lib/nx/shared.ex
@@ -560,7 +560,7 @@ defmodule Nx.Shared do
 
   @doc false
   def raise_vectorization_not_supported(%T{vectorized_axes: [_ | _]}, {function, arity}) do
-    raise ArgumentError, "#{function}/#{arity} is does not support vectorized inputs"
+    raise ArgumentError, "#{function}/#{arity} does not support vectorized inputs"
   end
 
   def raise_vectorization_not_supported(_, _), do: nil

--- a/nx/lib/nx/type.ex
+++ b/nx/lib/nx/type.ex
@@ -63,7 +63,7 @@ defmodule Nx.Type do
   def min_finite_binary(type)
 
   def min_finite_binary({:s, 8}), do: <<-128::8-signed-native>>
-  def min_finite_binary({:s, 16}), do: <<-32678::16-signed-native>>
+  def min_finite_binary({:s, 16}), do: <<-32768::16-signed-native>>
   def min_finite_binary({:s, 32}), do: <<-2_147_483_648::32-signed-native>>
   def min_finite_binary({:s, 64}), do: <<-9_223_372_036_854_775_808::64-signed-native>>
   def min_finite_binary({:u, size}), do: <<0::size(size)-native>>
@@ -85,7 +85,7 @@ defmodule Nx.Type do
   def max_finite_binary(type)
 
   def max_finite_binary({:s, 8}), do: <<127::8-signed-native>>
-  def max_finite_binary({:s, 16}), do: <<32677::16-signed-native>>
+  def max_finite_binary({:s, 16}), do: <<32767::16-signed-native>>
   def max_finite_binary({:s, 32}), do: <<2_147_483_647::32-signed-native>>
   def max_finite_binary({:s, 64}), do: <<9_223_372_036_854_775_807::64-signed-native>>
   def max_finite_binary({:u, 8}), do: <<255::8-native>>

--- a/nx/test/nx/vectorize_test.exs
+++ b/nx/test/nx/vectorize_test.exs
@@ -577,7 +577,7 @@ defmodule Nx.VectorizeTest do
     end
 
     test "simple cond" do
-      # this tests the case where we have a two vectorized predicates
+      # this tests the case where we have two vectorized predicates
       pred1 = Nx.vectorize(~VEC[1 0 0], :pred)
       pred2 = Nx.vectorize(~VEC[0 0 0], :pred)
 


### PR DESCRIPTION
Fixes min / max value for 16 bit signed type, plus a small typo fix.

https://github.com/elixir-nx/nx/blob/2f44f4a9bf950ef4cbeb719785d9d9d881690bb9/exla/test/exla/defn/expr_test.exs#L1108-L1110

Thank you for reviewing.

