### PR TITLE
fix: add support for defn compilation in EXLA.to_mlir_module

### DIFF
--- a/exla/lib/exla.ex
+++ b/exla/lib/exla.ex
@@ -383,12 +383,14 @@ defmodule EXLA do
       throw({:mlir_module, executable.ref, used_inputs, outputs})
     end
 
-    opts = [
-      {EXLA, {&EXLA.Defn.LockedCache.run/2, comp_fun}},
-      {:module_compilation, :to_mlir} | options
-    ]
+    opts =
+      Keyword.merge(options, [
+        {EXLA, {&EXLA.Defn.LockedCache.run/2, comp_fun}},
+        module_compilation: :to_mlir,
+        compiler: EXLA
+      ])
 
-    compile(function, args, opts)
+    EXLA.Defn.__compile__(function, args, function, opts)
   catch
     {:mlir_module, ref, used_inputs, output_container} ->
       %{
@@ -397,7 +399,6 @@ defmodule EXLA do
         mlir_module: EXLA.MLIR.Module.as_string(%EXLA.MLIR.Module{ref: ref})
       }
   end
-
 
   @doc """
   Checks if the compilation of function with args is cached.

--- a/exla/lib/exla.ex
+++ b/exla/lib/exla.ex
@@ -389,7 +389,7 @@ defmodule EXLA do
       throw({:mlir_module, executable.ref, used_inputs, outputs})
     end
 
-    {nested?, options} = Keyword.pop(options, :nested_defn_compilation, false)
+    {nested_compilation?, options} = Keyword.pop(options, :nested_defn_compilation, false)
 
     opts =
       Keyword.merge(options, [
@@ -398,7 +398,7 @@ defmodule EXLA do
         compiler: EXLA
       ])
 
-    if nested? do
+    if nested_compilation? do
       EXLA.Defn.__compile__(function, args, function, opts)
     else
       Nx.Defn.compile(function, args, opts)

--- a/exla/lib/exla.ex
+++ b/exla/lib/exla.ex
@@ -362,7 +362,7 @@ defmodule EXLA do
 
   ## Options
 
-    * `:nested_defn_compilation` - a boolean that indicates whether
+    * `:within_defn_compiler` - a boolean that indicates whether
       this function is being called from within a `defn` compiler.
       Defaults to `false`.
 
@@ -384,19 +384,13 @@ defmodule EXLA do
       """
   '''
   def to_mlir_module(function, args, options \\ []) do
-    comp_fun = fn _key, callback ->
-      {:ok, {_xla_time, executable, {_, used_inputs, outputs}, _outfeed}} = callback.()
-      throw({:mlir_module, executable.ref, used_inputs, outputs})
-    end
-
-    {nested_compilation?, options} = Keyword.pop(options, :nested_defn_compilation, false)
+    {nested_compilation?, options} = Keyword.pop(options, :within_defn_compiler, false)
 
     opts =
-      Keyword.merge(options, [
-        {EXLA, {&EXLA.Defn.LockedCache.run/2, comp_fun}},
+      Keyword.merge(options,
         module_compilation: :to_mlir,
         compiler: EXLA
-      ])
+      )
 
     if nested_compilation? do
       EXLA.Defn.__compile__(function, args, function, opts)

--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -406,7 +406,8 @@ defmodule EXLA.Defn do
       outfeed = Outfeed.new(hooks, defined_hooks)
       comp_key = {ref, client.name, outfeed.used_hooks, lazy_transfers, options}
 
-      {comp_time, {evaled, {xla_time, executable, inputs_and_typespecs, outfeed}}} =
+      {comp_time,
+       {evaled, {xla_time, executable, {inputs_and_typespecs, _used_inputs, _outputs}, outfeed}}} =
         :timer.tc(fn ->
           comp_cache_fun.(comp_key, fn ->
             {reverse_inputs_and_typespecs, reverse_infeeds} =
@@ -466,7 +467,9 @@ defmodule EXLA.Defn do
                   )
                 end)
 
-              {:ok, {xla_time, executable, inputs_and_typespecs, %{outfeed | infeeds: []}}}
+              {:ok,
+               {xla_time, executable, {inputs_and_typespecs, used_inputs, outputs},
+                %{outfeed | infeeds: []}}}
             end)
           end)
         end)

--- a/exla/test/exla_test.exs
+++ b/exla/test/exla_test.exs
@@ -24,7 +24,7 @@ defmodule EXLATest do
     end
 
     def __compile__(_key, vars, fun, opts) do
-      result = EXLA.to_mlir_module(fun, vars, Keyword.put(opts, :nested_defn_compilation, true))
+      result = EXLA.to_mlir_module(fun, vars, Keyword.put(opts, :within_defn_compiler, true))
       throw({__MODULE__, result})
     end
   end
@@ -35,7 +35,8 @@ defmodule EXLATest do
     end
 
     def __compile__(_key, vars, fun, opts) do
-      EXLA.to_mlir_module(fun, vars, Keyword.put(opts, :nested_defn_compilation, false))
+      # Keyword.delete to ensure default is false
+      EXLA.to_mlir_module(fun, vars, Keyword.delete(opts, :within_defn_compiler))
     end
   end
 
@@ -65,7 +66,7 @@ defmodule EXLATest do
 
           assert Nx.compatible?(container, Nx.template({}, :s32))
 
-          assert used_inputs == %{0 => nil, 1 => nil}
+          assert MapSet.equal?(used_inputs, MapSet.new([0, 1]))
       end
     end
   end

--- a/exla/test/exla_test.exs
+++ b/exla/test/exla_test.exs
@@ -17,4 +17,56 @@ defmodule EXLATest do
       end
     end
   end
+
+  defmodule ValidCompiler do
+    def __jit__(key, vars, fun, args_list, opts) do
+      __compile__(key, vars, fun, opts).(args_list)
+    end
+
+    def __compile__(_key, vars, fun, opts) do
+      result = EXLA.to_mlir_module(fun, vars, Keyword.put(opts, :nested_defn_compilation, true))
+      throw({__MODULE__, result})
+    end
+  end
+
+  defmodule InvalidCompiler do
+    def __jit__(key, vars, fun, args_list, opts) do
+      __compile__(key, vars, fun, opts).(args_list)
+    end
+
+    def __compile__(_key, vars, fun, opts) do
+      EXLA.to_mlir_module(fun, vars, Keyword.put(opts, :nested_defn_compilation, false))
+    end
+  end
+
+  describe "to_mlir_module/3" do
+    test "fails if the compiler doesn't set the nested compilation flag" do
+      assert_raise BadArityError, fn ->
+        Nx.Defn.jit_apply(&Nx.add/2, [1, 2], compiler: __MODULE__.InvalidCompiler)
+      end
+    end
+
+    test "works if the compiler sets the nested compilation flag" do
+      try do
+        Nx.Defn.jit_apply(&Nx.add/2, [1, 2], compiler: __MODULE__.ValidCompiler)
+      catch
+        {__MODULE__.ValidCompiler, result} ->
+          assert %{mlir_module: module, output_container: container, used_inputs: used_inputs} =
+                   result
+
+          assert module == """
+                 module {
+                   func.func public @main(%arg0: tensor<i32>, %arg1: tensor<i32>) -> tensor<i32> {
+                     %0 = stablehlo.add %arg0, %arg1 : tensor<i32>
+                     return %0 : tensor<i32>
+                   }
+                 }
+                 """
+
+          assert Nx.compatible?(container, Nx.template({}, :s32))
+
+          assert used_inputs == %{0 => nil, 1 => nil}
+      end
+    end
+  end
 end


### PR DESCRIPTION
`EXLA.to_mlir_module` wasn't working when being called from within a Defn compiler.
The new option adds the control needed for this to work.
