### PR TITLE
fix: least_squares implementation

### DIFF
--- a/exla/test/exla/nx_linalg_doctest_test.exs
+++ b/exla/test/exla/nx_linalg_doctest_test.exs
@@ -10,7 +10,7 @@ defmodule EXLA.MLIR.NxLinAlgDoctestTest do
     invert: 1,
     matrix_power: 2
   ]
-  @rounding_error_doctests [triangular_solve: 3, eigh: 2, cholesky: 1, least_squares: 2]
+  @rounding_error_doctests [triangular_solve: 3, eigh: 2, cholesky: 1, least_squares: 3]
 
   @excluded_doctests @function_clause_error_doctests ++
                        @rounding_error_doctests ++


### PR DESCRIPTION
The Nx.LinAlg.least_squares implementation assumed that for square matrices, it should fall back to Nx.LinAlg.solve.

However, the least squares solution is to minimize norm(Ax - b, 2), which isn't necessarily equal to solving Ax = b.
For example, if A = [[1, 2], [2, 4]] and b = [[3], [5]], Nx.LinAlg.solve will not be able to find a solution as the system doesn't have a valid solution. By going the pinv route, the minimal solution will be found.
