### PR TITLE
feat: add shard execution workflow

### DIFF
--- a/nx/config/config.exs
+++ b/nx/config/config.exs
@@ -5,3 +5,7 @@ import Config
 # true inside Nx.
 config :nx, :verify_grad, true
 config :nx, :verify_binary_size, true
+
+# If set to true, shards and sharding stages will be
+# inspected with their debug ids alongside their unique ref ids
+config :nx, :debug_shards, true

--- a/nx/lib/nx/application.ex
+++ b/nx/lib/nx/application.ex
@@ -4,6 +4,7 @@ defmodule Nx.Application do
 
   def start(_type, _args) do
     children = [
+      Nx.Defn.ShardingCompiler.ShardRegistry,
       %{id: Nx.Serving.PG, start: {:pg, :start_link, [Nx.Serving.PG]}},
       {Nx.HiddenServing, Nx.Serving.PG}
     ]

--- a/nx/lib/nx/defn/sharding_compiler.ex
+++ b/nx/lib/nx/defn/sharding_compiler.ex
@@ -20,14 +20,14 @@ defmodule Nx.Defn.ShardingCompiler do
 
     [args] = args
 
-    %T{
-      shape: shape,
-      type: type,
-      data: %ShardPropagation{
-        shards: output_shards,
-        parameter_ids_to_index: parameter_ids_to_index
-      }
-    } =
+    {%T{
+       type: type,
+       data: %ShardPropagation{
+         shards: output_shards,
+         parameter_ids_to_index: parameter_ids_to_index
+       }
+     },
+     shape} =
       propagate_shards(vars, fun, opts[:sharding_config] || [])
 
     data_sections =
@@ -154,7 +154,7 @@ defmodule Nx.Defn.ShardingCompiler do
 
     {container, _cache, _state} = ShardPropagation.traverse(expr, tensor_shardings)
 
-    container
+    {container, expr.shape}
   end
 
   @impl true

--- a/nx/lib/nx/defn/sharding_compiler.ex
+++ b/nx/lib/nx/defn/sharding_compiler.ex
@@ -23,10 +23,9 @@ defmodule Nx.Defn.ShardingCompiler do
     {%T{
        type: type,
        data: %ShardPropagation{
-         shards: output_shards,
-         parameter_ids_to_index: parameter_ids_to_index
+         shards: output_shards
        }
-     },
+     }, parameter_ids_to_index,
      shape} =
       propagate_shards(vars, fun, opts[:sharding_config] || [])
 
@@ -152,9 +151,9 @@ defmodule Nx.Defn.ShardingCompiler do
       |> Enum.with_index(fn x, idx -> {idx, x} end)
       |> Map.new()
 
-    {container, _cache, _state} = ShardPropagation.traverse(expr, tensor_shardings)
+    {container, _cache, state} = ShardPropagation.traverse(expr, tensor_shardings)
 
-    {container, expr.shape}
+    {container, state.parameter_ids_to_index, expr.shape}
   end
 
   @impl true

--- a/nx/lib/nx/defn/sharding_compiler/passes/graph_splitter.ex
+++ b/nx/lib/nx/defn/sharding_compiler/passes/graph_splitter.ex
@@ -267,7 +267,7 @@ defmodule Nx.Defn.ShardingCompiler.Passes.GraphSplitter do
   end
 
   defp rewrite_subtree(
-         %T{data: %Expr{op: :optional, id: id, args: [_call, subexpr, _fun]}},
+         %T{data: %Expr{op: :optional, id: id, args: [call, subexpr, fun]}} = expr,
          state,
          acc
        ) do
@@ -276,9 +276,12 @@ defmodule Nx.Defn.ShardingCompiler.Passes.GraphSplitter do
         {res, put_in(acc.used_args[id], {res, state.shards[id]})}
 
       _ ->
-        # TO-DO: allow for the optional node to go through the pipeline
-        # We're instead always relying on the default implementation here.
-        rewrite_subtree(subexpr, state, acc)
+        {call, acc} = rewrite_subtree(call, state, acc)
+        # `subexpr` is hermetic, in the sense that it is a self-contained scope
+        # from which the arguments always come from `call`, so we can
+        # keep it as is.
+
+        {put_in(expr.data.args, [call, subexpr, fun]), acc}
     end
   end
 

--- a/nx/lib/nx/defn/sharding_compiler/passes/graph_splitter.ex
+++ b/nx/lib/nx/defn/sharding_compiler/passes/graph_splitter.ex
@@ -4,16 +4,23 @@ defmodule Nx.Defn.ShardingCompiler.Passes.GraphSplitter do
   alias Nx.Tensor, as: T
   alias Nx.Defn.Expr
   alias Nx.Defn.ShardingCompiler.Shard
+  alias Nx.Defn.ShardingCompiler.Passes.GraphSplitter.Stage
 
   @gather_ops [:dot]
   @reduction_ops [:sum]
 
-  def traverse(expr, expr_shards \\ %{}) do
+  @ops_to_split Map.merge(
+                  Map.new(@gather_ops, &{&1, :gather}),
+                  Map.new(@reduction_ops, &{&1, :reduce})
+                )
+
+  def traverse(expr, expr_shards \\ %{}, ops_to_split \\ @ops_to_split) do
     # expression_chain is going to be a reverse-accumulation of {category, subexpr}
     # that we can then compile and chain-execute elsewhere. category is either :gather, :reduce or :none
     state = %{
       expression_chain: [],
       nodes_to_replace: %{},
+      ops_to_split: ops_to_split,
       # contains the sharding configuration for each node by id
       shards: expr_shards,
       # args is a map of id -> {stage_id, output_container_position}
@@ -77,13 +84,29 @@ defmodule Nx.Defn.ShardingCompiler.Passes.GraphSplitter do
                 other
             end)
 
-          argument_sources = Map.take(state.args, Map.keys(arg_remapping))
+          arguments = Map.new(arg_remapping, fn {_id, expr} -> {expr.data.id, expr} end)
 
-          [{id, category, expr, argument_sources} | acc]
+          argument_sources =
+            state.args
+            |> Map.take(Map.keys(arg_remapping))
+            |> Map.new(fn {remap_id, v} ->
+              {arg_remapping[remap_id].data.id, v}
+            end)
+
+          [
+            %Stage{
+              id: id,
+              category: category,
+              expr: expr,
+              arguments: arguments,
+              argument_sources: argument_sources
+            }
+            | acc
+          ]
         end
       )
 
-    {expr_chain, Map.delete(state, :expression_chain), cache}
+    {expr_chain, cache, Map.delete(state, :expression_chain)}
   end
 
   defp composite_eval(expr, state, cache) do
@@ -91,25 +114,19 @@ defmodule Nx.Defn.ShardingCompiler.Passes.GraphSplitter do
   end
 
   defp eval(%T{data: %Expr{id: id, op: op}} = ans, {cache, state}) do
-    case {cache, state.nodes_to_replace} do
-      {_, %{^id => res}} ->
+    case {cache, state.nodes_to_replace, state.ops_to_split} do
+      {_, %{^id => res}, _} ->
         # Replace the node with the corresponding parameter
         {res, {Map.put(cache, id, res), state}}
 
-      {%{^id => res}, _} ->
+      {%{^id => res}, _, _} ->
         {res, {cache, state}}
 
-      {_, _} ->
-        cond do
-          op in @gather_ops ->
-            rewrite_args(ans, :gather, {cache, state})
+      {_, _, %{^op => category}} ->
+        rewrite_args(ans, category, {cache, state})
 
-          op in @reduction_ops ->
-            rewrite_args(ans, :reduce, {cache, state})
-
-          true ->
-            eval_apply(op, ans, {cache, state})
-        end
+      _ ->
+        eval_apply(op, ans, {cache, state})
     end
   end
 
@@ -203,8 +220,8 @@ defmodule Nx.Defn.ShardingCompiler.Passes.GraphSplitter do
     {new_expr, {cache, state}}
   end
 
-  defp eval_apply(:parameter, %T{data: %Expr{id: id}} = expr, {cache, state}) do
-    state = put_in(state.args[id], nil)
+  defp eval_apply(:parameter, %T{data: %Expr{id: id, args: [idx]}} = expr, {cache, state}) do
+    state = put_in(state.args[id], {nil, idx})
     {expr, {Map.put(cache, id, expr), state}}
   end
 
@@ -220,11 +237,14 @@ defmodule Nx.Defn.ShardingCompiler.Passes.GraphSplitter do
     {ans, {Map.put(cache, id, ans), state}}
   end
 
-  defp composite_rewrite_subtree(args, state, acc \\ %{used_args: %{}})
+  defp composite_rewrite_subtree(container, state, acc \\ %{used_args: %{}})
 
-  defp composite_rewrite_subtree(args, state, acc) when is_list(args) do
-    Enum.map_reduce(args, acc, fn
+  defp composite_rewrite_subtree(container, state, acc) when is_list(container) do
+    Enum.map_reduce(container, acc, fn
       %T{} = arg, acc ->
+        composite_rewrite_subtree(arg, state, acc)
+
+      arg, acc when is_list(arg) ->
         composite_rewrite_subtree(arg, state, acc)
 
       arg, acc ->
@@ -232,7 +252,11 @@ defmodule Nx.Defn.ShardingCompiler.Passes.GraphSplitter do
     end)
   end
 
-  defp composite_rewrite_subtree(%T{data: %Expr{id: id, op: :parameter}} = expr, state, acc) do
+  defp composite_rewrite_subtree(container, state, acc) do
+    Composite.traverse(container, acc, &rewrite_subtree(&1, state, &2))
+  end
+
+  defp rewrite_subtree(%T{data: %Expr{id: id, op: :parameter}} = expr, state, acc) do
     case state.nodes_to_replace do
       %{^id => res} ->
         {res, put_in(acc.used_args[id], {res, state.shards[id]})}
@@ -242,19 +266,30 @@ defmodule Nx.Defn.ShardingCompiler.Passes.GraphSplitter do
     end
   end
 
-  defp composite_rewrite_subtree(arg, state, acc) do
-    Composite.traverse(arg, acc, &rewrite_subtree(&1, state, &2))
+  defp rewrite_subtree(
+         %T{data: %Expr{op: :optional, id: id, args: [_call, subexpr, _fun]}},
+         state,
+         acc
+       ) do
+    case state.nodes_to_replace do
+      %{^id => res} ->
+        {res, put_in(acc.used_args[id], {res, state.shards[id]})}
+
+      _ ->
+        # TO-DO: allow for the optional node to go through the pipeline
+        # We're instead always relying on the default implementation here.
+        rewrite_subtree(subexpr, state, acc)
+    end
   end
 
   defp rewrite_subtree(%T{data: %Expr{id: id, args: args}} = expr, state, acc) do
     case state.nodes_to_replace do
       %{^id => res} ->
         # nodes_to_replace always contains a param
-        {res, put_in(acc.used_args[id], res)}
+        {res, put_in(acc.used_args[id], {res, state.shards[id]})}
 
       _ ->
         {args, acc} = composite_rewrite_subtree(args, state, acc)
-
         {put_in(expr.data.args, args), acc}
     end
   end

--- a/nx/lib/nx/defn/sharding_compiler/passes/graph_splitter.ex
+++ b/nx/lib/nx/defn/sharding_compiler/passes/graph_splitter.ex
@@ -73,7 +73,10 @@ defmodule Nx.Defn.ShardingCompiler.Passes.GraphSplitter do
           # Traverse the expression to remap all shapes according to the sharding given
           expr = set_shard_metadata(expr, state.shards)
 
-          arguments = Map.new(arg_remapping, fn {_id, expr} -> {expr.data.id, expr} end)
+          arguments =
+            Map.new(arg_remapping, fn {_id, arg_expr} ->
+              {arg_expr.data.id, set_shard_metadata(arg_expr, state.shards)}
+            end)
 
           argument_sources =
             state.args

--- a/nx/lib/nx/defn/sharding_compiler/passes/graph_splitter/stage.ex
+++ b/nx/lib/nx/defn/sharding_compiler/passes/graph_splitter/stage.ex
@@ -1,0 +1,3 @@
+defmodule Nx.Defn.ShardingCompiler.Passes.GraphSplitter.Stage do
+  defstruct [:id, :category, :expr, :arguments, :argument_sources]
+end

--- a/nx/lib/nx/defn/sharding_compiler/passes/shard_propagation.ex
+++ b/nx/lib/nx/defn/sharding_compiler/passes/shard_propagation.ex
@@ -5,7 +5,7 @@ defmodule Nx.Defn.ShardingCompiler.Passes.ShardPropagation do
 
   alias Nx.Defn.ShardingCompiler.Shard
 
-  defstruct [:id, :shards, :input_tensor_shardings, :parameter_ids_to_index, :expr]
+  defstruct [:id, :shards, :expr]
 
   def traverse(expr, tensor_shardings) do
     {container, {cache, state}} =
@@ -18,9 +18,6 @@ defmodule Nx.Defn.ShardingCompiler.Passes.ShardPropagation do
         },
         %{}
       )
-
-    container = put_in(container.data.input_tensor_shardings, tensor_shardings)
-    container = put_in(container.data.parameter_ids_to_index, state.parameter_ids_to_index)
 
     {container, cache, state}
   end

--- a/nx/lib/nx/defn/sharding_compiler/passes/shard_propagation.ex
+++ b/nx/lib/nx/defn/sharding_compiler/passes/shard_propagation.ex
@@ -53,7 +53,7 @@ defmodule Nx.Defn.ShardingCompiler.Passes.ShardPropagation do
       t
       |> Nx.axes()
       |> Map.new(fn axis ->
-        {axis, [0..(elem(t.shape, axis) - 1)]}
+        {axis, elem(t.shape, axis)}
       end)
 
     expr = shard_from_config(t, config)
@@ -62,7 +62,7 @@ defmodule Nx.Defn.ShardingCompiler.Passes.ShardPropagation do
   end
 
   defp eval(%T{data: %Expr{op: :constant, args: [_constant]}} = ans, {cache, state}) do
-    expr = shard_from_config(ans, %{0 => [0..0]})
+    expr = shard_from_config(ans, %{})
     state = put_in(state.expr_shards[expr.data.id], expr.data)
     {expr, {cache, state}}
   end
@@ -361,6 +361,7 @@ defmodule Nx.Defn.ShardingCompiler.Passes.ShardPropagation do
   defp resolve_sharding_broadcast(axis, left_shards, false, right_shards, false) do
     # We have a shard on both sides. We need to determine the intersection of the two.
     # This is fine only if all shards are equal
+
     {reverse_out_shards, all_shards_match} =
       Enum.zip_reduce(left_shards, right_shards, {[], true}, fn left,
                                                                 right,

--- a/nx/lib/nx/defn/sharding_compiler/shard_execution.ex
+++ b/nx/lib/nx/defn/sharding_compiler/shard_execution.ex
@@ -7,15 +7,17 @@ defmodule Nx.Defn.ShardingCompiler.ShardExecution do
     :output_entry_index,
     :output_data_section_id,
     :output_starts,
-    :output_lengths
+    :output_lengths,
+    :fetched_inputs
   ]
 
   use GenServer
 
   alias Nx.Defn.ShardingCompiler.Passes.GraphSplitter.Stage
+  alias Nx.Defn.ShardingCompiler.ShardRegistry
 
   def init(
-        stage,
+        %Stage{} = stage,
         input_data_sections,
         output_entry_index,
         output_data_section_id,
@@ -24,6 +26,8 @@ defmodule Nx.Defn.ShardingCompiler.ShardExecution do
       ) do
     Process.send_after(self(), 0, :initialize)
 
+    fetched_inputs = Map.new(input_data_sections, fn {_idx, {arg_id, _}} -> {arg_id, nil} end)
+
     {:ok,
      %__MODULE__{
        stage: stage,
@@ -31,7 +35,8 @@ defmodule Nx.Defn.ShardingCompiler.ShardExecution do
        output_entry_index: output_entry_index,
        output_data_section_id: output_data_section_id,
        output_starts: output_starts,
-       output_lengths: output_lengths
+       output_lengths: output_lengths,
+       fetched_inputs: fetched_inputs
      }}
   end
 
@@ -40,11 +45,41 @@ defmodule Nx.Defn.ShardingCompiler.ShardExecution do
   end
 
   def handle_info(:initialize, state) do
+    ShardRegistry.register_producer(
+      {state.stage.id, state.output_entry_index, state.output_data_section_id}
+    )
+
     {:noreply, state}
   end
 
   def handle_info(:fetch_inputs, state) do
-    inputs = Enum.map(state.data_sections, fn {_, shard} -> shard.input_id end)
-    {:noreply, state, inputs}
+    state =
+      for {arg_idx, {arg_id, data_section_id}} <- state.input_data_sections,
+          is_nil(state.fetched_inputs[arg_id]),
+          reduce: state do
+        state ->
+          {stage_id, stage_idx} = state.stage.argument_sources[arg_id]
+
+          key = {stage_id, stage_idx, data_section_id}
+
+          case ShardRegistry.get(key) do
+            {:ok, data} ->
+              put_in(state.fetched_inputs[arg_id], {arg_idx, data})
+
+            {:error, :pending} ->
+              state
+          end
+      end
+
+    if Enum.any?(state.fetched_inputs, fn {_arg_id, data} -> is_nil(data) end) do
+      Process.send_after(self(), 20, :fetch_inputs)
+      {:noreply, state}
+    else
+      compute(state)
+    end
+  end
+
+  defp compute(state) do
+    {:noreply, state}
   end
 end

--- a/nx/lib/nx/defn/sharding_compiler/shard_execution.ex
+++ b/nx/lib/nx/defn/sharding_compiler/shard_execution.ex
@@ -1,5 +1,14 @@
 defmodule Nx.Defn.ShardingCompiler.ShardExecution do
-  defstruct [:compiled_fun, :stage_id, :input_data_sections, :output_data_sections]
+  # processes a single shard of an output entry, given the corresponding input data sections (1 per input)
+  defstruct [
+    :compiled_fun,
+    :stage,
+    :input_data_sections,
+    :output_entry_index,
+    :output_data_section_id,
+    :output_starts,
+    :output_lengths
+  ]
 
   use GenServer
 
@@ -16,7 +25,7 @@ defmodule Nx.Defn.ShardingCompiler.ShardExecution do
     Process.send_after(self(), 0, :initialize)
 
     {:ok,
-     %{
+     %__MODULE__{
        stage: stage,
        input_data_sections: input_data_sections,
        output_entry_index: output_entry_index,

--- a/nx/lib/nx/defn/sharding_compiler/shard_execution.ex
+++ b/nx/lib/nx/defn/sharding_compiler/shard_execution.ex
@@ -1,0 +1,41 @@
+defmodule Nx.Defn.ShardingCompiler.ShardExecution do
+  defstruct [:compiled_fun, :stage_id, :input_data_sections, :output_data_sections]
+
+  use GenServer
+
+  alias Nx.Defn.ShardingCompiler.Passes.GraphSplitter.Stage
+
+  def init(
+        stage,
+        input_data_sections,
+        output_entry_index,
+        output_data_section_id,
+        output_starts,
+        output_lengths
+      ) do
+    Process.send_after(self(), 0, :initialize)
+
+    {:ok,
+     %{
+       stage: stage,
+       input_data_sections: input_data_sections,
+       output_entry_index: output_entry_index,
+       output_data_section_id: output_data_section_id,
+       output_starts: output_starts,
+       output_lengths: output_lengths
+     }}
+  end
+
+  def start_link(args) do
+    GenServer.start_link(__MODULE__, args)
+  end
+
+  def handle_info(:initialize, state) do
+    {:noreply, state}
+  end
+
+  def handle_info(:fetch_inputs, state) do
+    inputs = Enum.map(state.data_sections, fn {_, shard} -> shard.input_id end)
+    {:noreply, state, inputs}
+  end
+end

--- a/nx/lib/nx/defn/sharding_compiler/shard_execution.ex
+++ b/nx/lib/nx/defn/sharding_compiler/shard_execution.ex
@@ -57,7 +57,7 @@ defmodule Nx.Defn.ShardingCompiler.ShardExecution do
         state ->
           {stage_id, stage_idx} = state.stage.argument_sources[arg_id]
 
-          case ShardRegistry.get(stage_id, stage_idx, data_section_id) do
+          case get(stage_id, stage_idx, data_section_id) do
             {:ok, data} ->
               put_in(state.fetched_inputs[arg_id], {arg_idx, data})
 

--- a/nx/lib/nx/defn/sharding_compiler/shard_execution.ex
+++ b/nx/lib/nx/defn/sharding_compiler/shard_execution.ex
@@ -32,8 +32,6 @@ defmodule Nx.Defn.ShardingCompiler.ShardExecution do
 
     fetched_inputs = Map.new(input_data_sections, fn {_idx, {arg_id, _}} -> {arg_id, nil} end)
 
-    dbg(stage)
-
     arg_templates =
       Enum.map(input_data_sections, fn {idx, {arg_id, shard_ids}} ->
         arg = stage.arguments[arg_id]
@@ -65,8 +63,6 @@ defmodule Nx.Defn.ShardingCompiler.ShardExecution do
 
         Expr.parameter(arg, :root, idx)
       end)
-
-    dbg(stage.expr)
 
     compiled_fun =
       Nx.Defn.Evaluator.__compile__(

--- a/nx/lib/nx/defn/sharding_compiler/shard_execution/argument_provider.ex
+++ b/nx/lib/nx/defn/sharding_compiler/shard_execution/argument_provider.ex
@@ -1,0 +1,21 @@
+defmodule Nx.Defn.ShardingCompiler.ShardExecution.ArgumentProvider do
+  use GenServer
+
+  alias Nx.Defn.ShardingCompiler.ShardRegistry
+
+  def init(data) do
+    {:ok, data}
+  end
+
+  def start_link([data, idx, section_id]) do
+    GenServer.start_link(__MODULE__, data, name: via_tuple(idx, section_id))
+  end
+
+  defp via_tuple(idx, section_id) do
+    {:via, Registry, {ShardRegistry, {nil, idx, section_id}}}
+  end
+
+  def handle_call(:get, _from, data) do
+    {:reply, {:ok, data}, data}
+  end
+end

--- a/nx/lib/nx/defn/sharding_compiler/shard_execution/output_collector.ex
+++ b/nx/lib/nx/defn/sharding_compiler/shard_execution/output_collector.ex
@@ -1,0 +1,153 @@
+defmodule Nx.Defn.ShardingCompiler.ShardExecution.OutputCollector do
+  use GenServer
+
+  alias Nx.Defn.ShardingCompiler.ShardRegistry
+  alias Nx.Defn.ShardingCompiler.ShardExecution
+  alias Nx.Defn.ShardingCompiler.Passes.ShardPropagation
+
+  alias Nx.Tensor, as: T
+
+  def init([expr, previous_stage_id, listener_pid]) do
+    {expr_tuple, unwrap_result} =
+      if is_tuple(expr) do
+        {expr, false}
+      else
+        {{expr}, true}
+      end
+
+    data_sections_by_index =
+      expr_tuple
+      |> Tuple.to_list()
+      |> Enum.with_index(fn expr, idx ->
+        sections =
+          for {starts, data_section_id} <- starts_and_data_section_ids(expr) do
+            {data_section_id, starts, nil}
+          end
+
+        {idx, sections}
+      end)
+
+    Process.send_after(self(), :collect_data, 0)
+
+    {:ok,
+     %{
+       listener_pid: listener_pid,
+       expr_tuple: expr_tuple,
+       previous_stage_id: previous_stage_id,
+       unwrap_result: unwrap_result,
+       data_sections_by_index: data_sections_by_index,
+       output: nil
+     }}
+  end
+
+  def start_link(sharded_expr, previous_stage_id, listener_pid) do
+    GenServer.start_link(
+      __MODULE__,
+      [sharded_expr, previous_stage_id, listener_pid],
+      sharded_exprname: via_tuple(sharded_expr)
+    )
+  end
+
+  defp via_tuple(expr) do
+    expr_id =
+      if is_tuple(expr) do
+        expr
+        |> Tuple.to_list()
+        |> Enum.map(& &1.data.id)
+      else
+        expr.data.id
+      end
+
+    {:via, Registry, {ShardRegistry, {:output, expr_id}}}
+  end
+
+  def handle_call(:get, _from, state) do
+    case state.output do
+      nil -> {:reply, {:error, :pending}, state}
+      data -> {:reply, {:ok, data}, state}
+    end
+  end
+
+  def handle_info(:collect_data, state) do
+    data_sections_by_index =
+      Map.new(state.data_sections_by_index, fn {idx, data_sections} ->
+        data_sections =
+          for {data_section_id, starts, nil} <- data_sections do
+            case ShardExecution.get(state.previous_stage_id, idx, data_section_id) do
+              {:ok, {data, _starts, _lenghts}} ->
+                {data_section_id, starts, data}
+
+              {:error, :pending} ->
+                {data_section_id, starts, nil}
+            end
+          end
+
+        {idx, data_sections}
+      end)
+
+    finished =
+      Enum.all?(data_sections_by_index, fn {_idx, data_sections} ->
+        Enum.all?(data_sections, fn {_, _, data} -> not is_nil(data) end)
+      end)
+
+    output =
+      if finished do
+        out_list = produce_output(state.expr_tuple, data_sections_by_index)
+
+        if state.unwrap_result do
+          [out] = out_list
+          out
+        else
+          List.to_tuple(out_list)
+        end
+      end
+
+    if output do
+      Process.send_after(self(), :notify_listener, 0)
+    else
+      Process.send_after(self(), :collect_data, 0)
+    end
+
+    {:noreply, %{state | output: output, data_sections_by_index: data_sections_by_index}}
+  end
+
+  def handle_info(:notify_listener, state) do
+    send(state.listener_pid, {__MODULE__, :done, self(), state.output})
+    {:noreply, state}
+  end
+
+  defp starts_and_data_section_ids(%T{data: %ShardPropagation{shards: shards}}) do
+    shards
+    |> Enum.sort_by(fn {axis, _} -> axis end)
+    |> Enum.map(fn {axis, shard} -> {shard, axis} end)
+    |> cartesian_product()
+    |> Enum.map(fn sections ->
+      starts =
+        Enum.map(sections, fn {shard, _axis} -> shard.start end)
+
+      data_section_id = Enum.map(sections, fn {shard, _axis} -> shard.id end)
+
+      {starts, data_section_id}
+    end)
+  end
+
+  defp cartesian_product([{data, meta} | rest]) do
+    for x <- data, y <- cartesian_product(rest), do: [{x, meta} | y]
+  end
+
+  defp cartesian_product([]), do: [[]]
+
+  defp produce_output(expr_tuple, data_sections_by_index) do
+    Enum.map(data_sections_by_index, fn {idx, data_sections} ->
+      hole_template = elem(expr_tuple, idx)
+      hole = Nx.broadcast(Nx.tensor(0, type: hole_template.type), hole_template.shape)
+
+      data =
+        Enum.reduce(data_sections, hole, fn {_, starts, data}, acc ->
+          Nx.put_slice(acc, starts, data)
+        end)
+
+      data
+    end)
+  end
+end

--- a/nx/lib/nx/defn/sharding_compiler/shard_execution/supervisor.ex
+++ b/nx/lib/nx/defn/sharding_compiler/shard_execution/supervisor.ex
@@ -1,0 +1,113 @@
+defmodule Nx.Defn.ShardingCompiler.ShardExecution.Supervisor do
+  use Supervisor
+
+  alias Nx.Defn.ShardingCompiler.Passes.GraphSplitter.Stage
+  alias Nx.Defn.ShardingCompiler.Shard
+
+  alias Nx.Defn.Expr
+  alias Nx.Tensor, as: T
+
+  def start_link(%Stage{} = stage) do
+    Supervisor.start_link(__MODULE__, stage)
+  end
+
+  @impl true
+  def init(stage) do
+    children =
+      for {output_entry_index, output_data_sections} <- output_data_sections(stage),
+          {output_data_section_id, input_data_sections, output_starts, output_lengths} <-
+            input_data_sections(stage.arguments, output_data_sections) do
+        %{
+          id: {stage.id, input_data_sections},
+          start:
+            {Nx.Defn.ShardingCompiler.ShardExecution, :start_link,
+             [
+               [
+                 stage,
+                 input_data_sections,
+                 output_entry_index,
+                 output_data_section_id,
+                 output_starts,
+                 output_lengths
+               ]
+             ]},
+          restart: :permanent,
+          type: :worker
+        }
+      end
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+
+  defp output_data_sections(%Stage{expr: expr}) do
+    if is_tuple(expr) do
+      expr
+      |> Tuple.to_list()
+      |> Enum.with_index(fn expr, idx -> {idx, output_data_sections_for_expr(expr)} end)
+    else
+      [{0, output_data_sections_for_expr(expr)}]
+    end
+  end
+
+  defp output_data_sections_for_expr(%T{data: %Expr{op: :metadata, args: [_, %{shards: shards}]}}) do
+    shards
+    |> Enum.sort_by(fn {axis, _} -> axis end)
+    |> Enum.map(fn {axis, shard} -> {shard, axis} end)
+    |> cartesian_product()
+    |> Enum.map(fn sections ->
+      {starts, lengths} =
+        sections
+        |> Enum.map(fn {shard, _axis} -> {shard.start, shard.length} end)
+        |> Enum.unzip()
+
+      data_section_id = Enum.map(sections, fn {shard, _axis} -> shard.id end)
+
+      roots =
+        Enum.map(sections, fn {shard, axis} -> {axis, get_root_parents(shard)} end)
+
+      {data_section_id, {roots, starts, lengths}}
+    end)
+  end
+
+  defp input_data_sections(arguments, output_data_sections) do
+    for {data_section_id, {output_roots_by_dim, starts, lengths}} <- output_data_sections do
+      arg_sections =
+        for {arg_id, arg} <- arguments do
+          %T{data: %Expr{op: :metadata, args: [param, %{shards: shards}]}} = arg
+          %T{data: %Expr{op: :parameter, args: [arg_idx]}} = param
+
+          shards_by_root =
+            for {_axis, shards_for_axis} <- shards,
+                shard <- shards_for_axis,
+                root <- get_root_parents(shard),
+                into: %{} do
+              {root.id, shard}
+            end
+
+          data_section_for_input =
+            Enum.map(output_roots_by_dim, fn {_axis, roots} ->
+              Enum.find(roots, &shards_by_root[&1.id])
+            end)
+
+          {arg_idx, {arg_id, data_section_for_input}}
+        end
+
+      {data_section_id, arg_sections, starts, lengths}
+    end
+  end
+
+  defp cartesian_product([{data, meta} | rest]) do
+    for x <- data, y <- cartesian_product(rest), do: [{x, meta} | y]
+  end
+
+  defp cartesian_product([]), do: [[]]
+
+  defp get_root_parents(shard, acc \\ [])
+
+  defp get_root_parents(%Shard{parents: []} = shard, acc), do: List.flatten([shard | acc])
+
+  defp get_root_parents(%Shard{parents: parents}, acc) do
+    Enum.reduce(parents, acc, &get_root_parents/2)
+    |> List.flatten()
+  end
+end

--- a/nx/lib/nx/defn/sharding_compiler/shard_execution/supervisor.ex
+++ b/nx/lib/nx/defn/sharding_compiler/shard_execution/supervisor.ex
@@ -84,12 +84,13 @@ defmodule Nx.Defn.ShardingCompiler.ShardExecution.Supervisor do
               {root.id, shard}
             end
 
-          data_section_for_input =
+          data_section_id_for_input =
             Enum.map(output_roots_by_dim, fn {_axis, roots} ->
-              Enum.find(roots, &shards_by_root[&1.id])
+              %Shard{} = shard = Enum.find(roots, &shards_by_root[&1.id])
+              shard.id
             end)
 
-          {arg_idx, {arg_id, data_section_for_input}}
+          {arg_idx, {arg_id, data_section_id_for_input}}
         end
 
       {data_section_id, arg_sections, starts, lengths}

--- a/nx/lib/nx/defn/sharding_compiler/shard_execution/supervisor.ex
+++ b/nx/lib/nx/defn/sharding_compiler/shard_execution/supervisor.ex
@@ -85,10 +85,13 @@ defmodule Nx.Defn.ShardingCompiler.ShardExecution.Supervisor do
             end
 
           data_section_id_for_input =
-            Enum.map(output_roots_by_dim, fn {_axis, roots} ->
+            output_roots_by_dim
+            |> Enum.map(fn {_axis, roots} ->
               %Shard{} = shard = Enum.find(roots, &shards_by_root[&1.id])
-              shard.id
+              {shard.axis, shard.id}
             end)
+            |> Enum.sort()
+            |> Enum.map(fn {_axis, id} -> id end)
 
           {arg_idx, {arg_id, data_section_id_for_input}}
         end

--- a/nx/lib/nx/defn/sharding_compiler/shard_registry.ex
+++ b/nx/lib/nx/defn/sharding_compiler/shard_registry.ex
@@ -1,14 +1,19 @@
 defmodule Nx.Defn.ShardingCompiler.ShardRegistry do
+  use GenServer
   @table_name __MODULE__
 
-  def init do
+  def init(_) do
     :ets.new(@table_name, [:named_table, :set, :public])
-    :ok
+    pid_to_key_table = :ets.new(:pid_to_key, [:bag, :protected])
+    {:ok, %{pid_to_key_table: pid_to_key_table}}
   end
 
-  def register_producer({stage_id, index, data_section_id}) do
-    :ets.insert(@table_name, {{stage_id, index, data_section_id}, :pending})
-    :ok
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def register_producer(key) do
+    GenServer.call(__MODULE__, {:register, key})
   end
 
   def get({stage_id, index, data_section_id}) do
@@ -22,5 +27,22 @@ defmodule Nx.Defn.ShardingCompiler.ShardRegistry do
       _ ->
         {:error, :not_found}
     end
+  end
+
+  def handle_call({:register_producer, key}, pid, state) do
+    :ets.insert(@table_name, {key, :pending})
+    :ets.insert(state.pid_to_key_table, {pid, key})
+    Process.monitor(pid)
+    {:reply, :ok, state}
+  end
+
+  def handle_info({:DOWN, _ref, :process, producer_pid, _reason}, state) do
+    for {^producer_pid, key} <- :ets.lookup(state.pid_to_key_table, producer_pid) do
+      :ets.delete(@table_name, key)
+    end
+
+    true = :ets.delete(state.pid_to_key_table, producer_pid)
+
+    {:noreply, state}
   end
 end

--- a/nx/lib/nx/defn/sharding_compiler/shard_registry.ex
+++ b/nx/lib/nx/defn/sharding_compiler/shard_registry.ex
@@ -1,0 +1,26 @@
+defmodule Nx.Defn.ShardingCompiler.ShardRegistry do
+  @table_name __MODULE__
+
+  def init do
+    :ets.new(@table_name, [:named_table, :set, :public])
+    :ok
+  end
+
+  def register_producer({stage_id, index, data_section_id}) do
+    :ets.insert(@table_name, {{stage_id, index, data_section_id}, :pending})
+    :ok
+  end
+
+  def get({stage_id, index, data_section_id}) do
+    case :ets.lookup(@table_name, {stage_id, index, data_section_id}) do
+      [{{^stage_id, ^index, ^data_section_id}, {:ready, tensor}}] ->
+        {:ok, tensor}
+
+      [{{^stage_id, ^index, ^data_section_id}, :pending}] ->
+        {:error, :pending}
+
+      _ ->
+        {:error, :not_found}
+    end
+  end
+end

--- a/nx/lib/nx/defn/sharding_compiler/shard_registry.ex
+++ b/nx/lib/nx/defn/sharding_compiler/shard_registry.ex
@@ -1,4 +1,11 @@
 defmodule Nx.Defn.ShardingCompiler.ShardRegistry do
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [opts]}
+    }
+  end
+
   def start_link(_) do
     Registry.start_link(name: __MODULE__, keys: :unique)
   end

--- a/nx/lib/nx/defn/sharding_compiler/shard_registry.ex
+++ b/nx/lib/nx/defn/sharding_compiler/shard_registry.ex
@@ -1,48 +1,19 @@
 defmodule Nx.Defn.ShardingCompiler.ShardRegistry do
-  use GenServer
-  @table_name __MODULE__
-
-  def init(_) do
-    :ets.new(@table_name, [:named_table, :set, :public])
-    pid_to_key_table = :ets.new(:pid_to_key, [:bag, :protected])
-    {:ok, %{pid_to_key_table: pid_to_key_table}}
-  end
-
   def start_link(_) do
-    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+    Registry.start_link(name: __MODULE__, keys: :unique)
   end
 
-  def register_producer(key) do
-    GenServer.call(__MODULE__, {:register, key})
-  end
+  def lookup(key) do
+    results = :erpc.multicall([Node.self() | Node.list()], Registry, :lookup, [__MODULE__, key])
 
-  def get({stage_id, index, data_section_id}) do
-    case :ets.lookup(@table_name, {stage_id, index, data_section_id}) do
-      [{{^stage_id, ^index, ^data_section_id}, {:ready, tensor}}] ->
-        {:ok, tensor}
-
-      [{{^stage_id, ^index, ^data_section_id}, :pending}] ->
-        {:error, :pending}
-
-      _ ->
-        {:error, :not_found}
+    results
+    |> Enum.find_value(fn
+      {:ok, [{pid, _}]} -> pid
+      _ -> nil
+    end)
+    |> case do
+      nil -> {:error, :pending}
+      pid -> {:ok, pid}
     end
-  end
-
-  def handle_call({:register_producer, key}, pid, state) do
-    :ets.insert(@table_name, {key, :pending})
-    :ets.insert(state.pid_to_key_table, {pid, key})
-    Process.monitor(pid)
-    {:reply, :ok, state}
-  end
-
-  def handle_info({:DOWN, _ref, :process, producer_pid, _reason}, state) do
-    for {^producer_pid, key} <- :ets.lookup(state.pid_to_key_table, producer_pid) do
-      :ets.delete(@table_name, key)
-    end
-
-    true = :ets.delete(state.pid_to_key_table, producer_pid)
-
-    {:noreply, state}
   end
 end

--- a/nx/test/nx/defn/sharding_compiler/passes/graph_splitter_test.exs
+++ b/nx/test/nx/defn/sharding_compiler/passes/graph_splitter_test.exs
@@ -442,5 +442,65 @@ defmodule Nx.Defn.ShardingCompiler.Passes.GraphSplitterTest do
 
       assert out_shards == sharded_expr.data.shards
     end
+
+    test "supports optional callbacks" do
+      arg0 =
+        Nx.u8([
+          [1, 0, 1],
+          [1, 1, 1]
+        ])
+
+      expr =
+        Nx.Defn.debug_expr(fn a, b ->
+          x = Nx.add(b, 1)
+          y = Nx.sum(x, axes: [1])
+          z = Nx.logical_not(y)
+          Nx.subtract(z, a)
+        end).(1, arg0)
+
+      assert {[%Stage{} = stage_0, %Stage{} = stage_1], _cache, _state} =
+               GraphSplitter.traverse(expr)
+
+      [{arg1_id, %T{shape: {2, 3}, type: {:u, 8}, data: %Expr{args: [0]}}}] =
+        Enum.to_list(stage_0.arguments)
+
+      assert stage_0.argument_sources == %{arg1_id => {nil, 1}}
+
+      stage_1_args =
+        Enum.sort_by(stage_1.arguments, fn {_id, %T{data: %Expr{op: :parameter, args: [idx]}}} ->
+          idx
+        end)
+
+      assert [
+               {arg_0_id, %T{shape: {}, type: {:s, 32}}},
+               {arg_1_id, %T{shape: {2, 3}, type: {:u, 8}}}
+             ] =
+               stage_1_args
+
+      assert stage_1.argument_sources == %{arg_0_id => {nil, 0}, arg_1_id => {stage_0.id, 0}}
+
+      assert %T{data: %Expr{op: :subtract, args: [c, d]}} = stage_1.expr
+      assert %T{data: %Expr{op: :optional, args: [call, subexpr, _fun]}} = c
+
+      assert %T{data: %Expr{id: ^arg_0_id, op: :parameter, args: [0]}} = d
+
+      assert %T{data: %Expr{op: :logical_not, args: [b]}} = call
+      assert %T{data: %Expr{op: :sum, args: [a, [axes: [1], keep_axes: false]]}} = b
+      assert %T{data: %Expr{id: ^arg_1_id, op: :parameter, args: [1]}} = a
+
+      assert %T{
+               data: %Expr{
+                 op: :equal,
+                 args: [
+                   %T{data: %Expr{id: subexpr_arg_0_id, op: :parameter, args: [0]}},
+                   %T{data: %Expr{op: :constant, args: [0]}}
+                 ]
+               }
+             } = subexpr
+
+      # ensure subexpr is hermetic
+      assert subexpr_arg_0_id != arg_0_id
+      assert subexpr_arg_0_id != arg_1_id
+    end
   end
 end

--- a/nx/test/nx/defn/sharding_compiler/passes/graph_splitter_test.exs
+++ b/nx/test/nx/defn/sharding_compiler/passes/graph_splitter_test.exs
@@ -379,7 +379,7 @@ defmodule Nx.Defn.ShardingCompiler.Passes.GraphSplitterTest do
              end)
     end
 
-    test "splits on dot if arguments are not sharded on the reduction axis" do
+    test "splits on dot if arguments are sharded on the reduction axis" do
       arg0 =
         Nx.tensor([
           [1, 2, 3],
@@ -416,7 +416,8 @@ defmodule Nx.Defn.ShardingCompiler.Passes.GraphSplitterTest do
           1 => Shard.from_config(arg1, %{})
         })
 
-      assert {[%Stage{expr: stage_0_expr}, %Stage{expr: stage_1_expr}], _cache, _state} =
+      assert {[%Stage{expr: stage_0_expr, arguments: args}, %Stage{expr: stage_1_expr}], _cache,
+              _state} =
                GraphSplitter.traverse(expr, expr_shards)
 
       assert {%T{data: %Expr{op: :metadata, args: [_left, %{shards: left_shards}]}},

--- a/nx/test/nx/defn/sharding_compiler/shard_execution_test.exs
+++ b/nx/test/nx/defn/sharding_compiler/shard_execution_test.exs
@@ -1,0 +1,49 @@
+defmodule Nx.Defn.ShardingCompiler.ShardExecutionTest do
+  use ExUnit.Case, async: true
+
+  alias Nx.Defn.ShardingCompiler.Passes.GraphSplitter
+  alias Nx.Defn.ShardingCompiler.Passes.GraphSplitter.Stage
+  alias Nx.Defn.ShardingCompiler.Passes.ShardPropagation
+  alias Nx.Defn.ShardingCompiler.ShardExecution
+  alias Nx.Defn.ShardingCompiler.Shard
+
+  alias Nx.Tensor, as: T
+  alias Nx.Defn.Expr
+
+  test "Creates all the necessary children for each stage" do
+    arg0 =
+      Nx.tensor([
+        [1, 2, 3],
+        [4, 5, 6]
+      ])
+
+    arg1 =
+      Nx.tensor([
+        [1, 2],
+        [3, 4],
+        [5, 6]
+      ])
+
+    expr =
+      Nx.Defn.debug_expr(fn arg0, arg1 ->
+        x = Nx.add(arg0, 1)
+        y = Nx.subtract(arg1, 2)
+        z = Nx.dot(x, y)
+        w = Nx.multiply(z, 3)
+        Nx.divide(w, 4)
+      end).(arg0, arg1)
+
+    {sharded_expr, _cache, %{expr_shards: expr_shards}} =
+      ShardPropagation.traverse(expr, %{
+        0 => Shard.from_config(arg0, %{0 => [0..0, 1..1], 1 => [0..2]}),
+        1 => Shard.from_config(arg1, %{})
+      })
+
+    assert {[stage0, stage1], _cache, _state} =
+             GraphSplitter.traverse(expr, expr_shards)
+
+    assert {:ok, pid} = ShardExecution.Supervisor.start_link(stage0)
+
+    flunk("incomplete test")
+  end
+end

--- a/nx/test/nx/defn/sharding_compiler/shard_execution_test.exs
+++ b/nx/test/nx/defn/sharding_compiler/shard_execution_test.exs
@@ -28,22 +28,113 @@ defmodule Nx.Defn.ShardingCompiler.ShardExecutionTest do
       Nx.Defn.debug_expr(fn arg0, arg1 ->
         x = Nx.add(arg0, 1)
         y = Nx.subtract(arg1, 2)
-        z = Nx.dot(x, y)
-        w = Nx.multiply(z, 3)
-        Nx.divide(w, 4)
+
+        Nx.multiply(x, Nx.transpose(y))
       end).(arg0, arg1)
 
-    {sharded_expr, _cache, %{expr_shards: expr_shards}} =
+    {%T{
+       data: %ShardPropagation{expr: sharded_expr, parameter_ids_to_index: parameter_ids_to_index}
+     } = ans, _cache,
+     %{expr_shards: expr_shards}} =
       ShardPropagation.traverse(expr, %{
-        0 => Shard.from_config(arg0, %{0 => [0..0, 1..1], 1 => [0..2]}),
-        1 => Shard.from_config(arg1, %{})
+        0 => Shard.from_config(arg0, %{0 => 1, 1 => 3}, debug_id: "arg 0"),
+        1 => Shard.from_config(arg1, %{0 => 3}, debug_id: "arg 1")
       })
 
-    assert {[stage0, stage1], _cache, _state} =
-             GraphSplitter.traverse(expr, expr_shards)
+    dbg(sharded_expr)
+
+    assert {[stage0], _cache, _state} =
+             GraphSplitter.traverse(%T{ans | data: sharded_expr}, expr_shards)
+
+    args_by_idx = %{0 => arg0, 1 => arg1}
+
+    Enum.each(stage0.arguments, fn {id, expr} ->
+      start_shard_providers(expr, args_by_idx)
+    end)
 
     assert {:ok, pid} = ShardExecution.Supervisor.start_link(stage0)
 
-    flunk("incomplete test")
+    children = Supervisor.which_children(pid)
+
+    states =
+      Enum.map(children, fn {key, pid, :worker, [ShardExecution]} ->
+        {key, :sys.get_state(pid)}
+      end)
+      |> Enum.sort_by(fn {_, state} -> {state.output_entry_index, state.output_starts} end)
+
+    assert [executor0, executor1] = states
+
+    assert {key0, executor0_state} = executor0
+    assert {key1, executor1_state} = executor1
+
+    idx_to_id =
+      Map.new(stage0.arguments, fn
+        {id, %T{data: %Expr{op: :parameter, args: [idx]}}} ->
+          {idx, {id, nil}}
+
+        {id, %T{data: %Expr{op: :metadata, args: [expr, %{shards: shards}]}}} ->
+          %T{data: %Expr{op: :parameter, args: [idx]}} = expr
+          {idx, {id, shards}}
+      end)
+
+    assert %ShardExecution{
+             input_data_sections: [{0, input_section0}, {1, input_section1}],
+             output_starts: [0, 0],
+             output_lengths: [1, 3]
+           } = executor0_state
+
+    {id0, %{0 => [shard0, shard1], 1 => [shard2]}} = idx_to_id[0]
+    {id1, %{0 => [shard3], 1 => [shard4, shard5]}} = idx_to_id[1]
+
+    assert {id0, [shard0.id, shard2.id]} == input_section0
+    assert {id1, [shard3.id, shard4.id]} == input_section1
+
+    assert %ShardExecution{
+             input_data_sections: [{0, input_section0}, {1, input_section1}],
+             output_starts: [1, 0],
+             output_lengths: [1, 3]
+           } = executor1_state
+
+    assert {id0, [shard1.id, shard2.id]} == input_section0
+    assert {id1, [shard3.id, shard5.id]} == input_section1
+
+    flunk("need to assert on results")
   end
+
+  defp start_shard_providers(sharded_expr, arg_data) do
+    case sharded_expr do
+      %T{data: %Expr{op: :parameter, args: [idx]}} ->
+        ShardExecution.ArgumentProvider.start_link([
+          sharded_expr,
+          idx,
+          arg_data[idx]
+        ])
+
+      %T{data: %Expr{op: :metadata, args: [%T{data: %Expr{args: [idx]}}, %{shards: shards}]}} ->
+        shards
+        |> Enum.sort_by(fn {axis, _} -> axis end)
+        |> Enum.map(fn {axis, shard} -> {shard, axis} end)
+        |> cartesian_product()
+        |> Enum.each(fn sections ->
+          {starts, lengths} =
+            sections
+            |> Enum.map(fn {shard, _axis} -> {shard.start, shard.length} end)
+            |> Enum.unzip()
+
+          data_section_id = Enum.map(sections, fn {shard, _axis} -> shard.id end)
+
+          ShardExecution.ArgumentProvider.start_link([
+            Nx.slice(arg_data[idx], starts, lengths),
+            idx,
+            data_section_id
+          ])
+        end)
+    end
+  end
+
+  defp cartesian_product([{data, meta} | rest]) do
+    for x <- data, y <- cartesian_product(rest), do: [{x, meta} | y]
+  end
+
+  defp cartesian_product([]), do: [[]]
 end

--- a/nx/test/nx/defn/sharding_compiler_test.exs
+++ b/nx/test/nx/defn/sharding_compiler_test.exs
@@ -15,8 +15,8 @@ defmodule Nx.Defn.ShardingCompilerTest do
 
     inputs = [in0, in1]
 
-    arg0_sharding = %{0 => [0..1], 1 => [0..1]}
-    arg1_sharding = %{4 => [0..0, 1..1]}
+    arg0_sharding = %{0 => 2, 1 => 2}
+    arg1_sharding = %{4 => 1}
 
     sharding = [arg0_sharding, arg1_sharding]
 
@@ -39,8 +39,8 @@ defmodule Nx.Defn.ShardingCompilerTest do
 
     inputs = [t, t]
 
-    arg0_sharding = %{0 => [0..0, 1..1, 2..2]}
-    arg1_sharding = %{1 => [0..0, 1..1, 2..2]}
+    arg0_sharding = %{0 => 1}
+    arg1_sharding = %{1 => 1}
 
     sharding = [arg0_sharding, arg1_sharding]
 
@@ -64,7 +64,7 @@ defmodule Nx.Defn.ShardingCompilerTest do
 
     inputs = [t]
 
-    arg0_sharding = %{0 => [0..0, 1..1, 2..2], 1 => [0..2]}
+    arg0_sharding = %{0 => 1, 1 => 3}
 
     sharding = [arg0_sharding]
 
@@ -88,8 +88,8 @@ defmodule Nx.Defn.ShardingCompilerTest do
 
     inputs = [t0, t1]
 
-    arg0_sharding = %{0 => [0..0, 1..1, 2..2]}
-    arg1_sharding = %{1 => [0..0, 1..1, 2..2]}
+    arg0_sharding = %{0 => 1}
+    arg1_sharding = %{1 => 1}
 
     sharding = [arg0_sharding, arg1_sharding]
 


### PR DESCRIPTION
Adds the initial version of the process communication structure for sharded execution.

Does not handle container outputs for the sharded function yet,
and also does not yet bring everything together into the compiler jit function.
