### PR TITLE
Use `@moduledoc` for `Nx.Defn.Expr`

### DIFF
--- a/nx/lib/nx/defn/expr.ex
+++ b/nx/lib/nx/defn/expr.ex
@@ -1,5 +1,5 @@
 defmodule Nx.Defn.Expr do
-  @doc """
+  @moduledoc """
   The expression used by `Nx.Defn.Compiler`.
 
   `Nx.Defn.Compiler` changes `Nx` default backend from `Nx.BinaryBackend`


### PR DESCRIPTION
Improves documentation rendering.