### PR TITLE
feat: improve precision for nx constants

### DIFF
--- a/nx/lib/nx/constants.ex
+++ b/nx/lib/nx/constants.ex
@@ -3,6 +3,10 @@ defmodule Nx.Constants do
   Common constants used in computations.
 
   This module can be used in `defn`.
+
+  The functions `e/0`, `pi/0` and `i/0` will follow the same rules as
+  literal constants when used inside `defn`. This means that they will
+  use the surrounding precision instead of defaulting to f32.
   """
 
   import Nx.Shared

--- a/nx/lib/nx/defn/compiler.ex
+++ b/nx/lib/nx/defn/compiler.ex
@@ -592,6 +592,18 @@ defmodule Nx.Defn.Compiler do
     {{{:., dot_meta, [Complex, :new]}, meta, args}, state}
   end
 
+  defp normalize({{:., dot_meta, [Nx.Constants, :i]}, meta, []}, state) do
+    {{{:., dot_meta, [Complex, :new]}, meta, [0, 1]}, state}
+  end
+
+  defp normalize({{:., dot_meta, [Nx.Constants, :e]}, meta, []}, state) do
+    {{{:., dot_meta, [:math, :exp]}, meta, [1]}, state}
+  end
+
+  defp normalize({{:., dot_meta, [Nx.Constants, :pi]}, meta, []}, state) do
+    {{{:., dot_meta, [:math, :pi]}, meta, []}, state}
+  end
+
   defp normalize({{:., dot_meta, [mod, name]}, meta, args}, state) when mod in @allowed_modules do
     {args, state} = normalize_list(args, state)
     {{{:., dot_meta, [mod, name]}, meta, args}, state}


### PR DESCRIPTION
If we rewrite the Nx defn AST during normalization to use the number values from :math or Complex for the arity-0 versions of i/e/pi, we can benefit from the previous pull requests on precision upcasting "for free".

This is implicit behavior, so I understand if we don't want this, but I believe it makes for a better UX.
