### PR TITLE
Hide symbols from the NIF shared library

### DIFF
--- a/exla/Makefile
+++ b/exla/Makefile
@@ -36,7 +36,7 @@ else
 	CFLAGS += -O3
 endif
 
-LDFLAGS = -L$(XLA_EXTENSION_LIB) -lxla_extension -shared
+LDFLAGS = -L$(XLA_EXTENSION_LIB) -lxla_extension -shared -fvisibility=hidden
 
 ifeq ($(CROSSCOMPILE),)
 	# Interrogate the system for local compilation


### PR DESCRIPTION
This compiles the NIF shared library with `-fvisibility=hidden`, hiding all symbols other than the NIF init required by ERTS. I believe this is a good default for NIFs in general, it avoids symbol clashes (e.g. when multiple NIFs use the same external library, possibly with different versions), and it can also improve performance and linking time.

For more details see https://github.com/elixir-nx/fine/issues/2#issuecomment-2703366091.