### PR TITLE
Increase Torch to latest version 2.7

### DIFF
--- a/torchx/c_src/torchx.cpp
+++ b/torchx/c_src/torchx.cpp
@@ -752,7 +752,7 @@ NIF(triangular_solve) {
     upper = !upper;
   }
 
-  torch::Tensor result = torch::linalg::solve_triangular(ts_a, *b, upper, true, false);
+  torch::Tensor result = torch::linalg_solve_triangular(ts_a, *b, upper, true, false);
 
   TENSOR(result);
 }
@@ -963,10 +963,10 @@ NIF(cholesky) {
   }
 
   if (upper) {
-    TENSOR(torch::linalg::cholesky(*t).mH());
+    TENSOR(torch::cholesky(*t).mH());
   }
 
-  TENSOR(torch::linalg::cholesky(*t));
+  TENSOR(torch::cholesky(*t));
 }
 
 NIF(pad) {
@@ -1004,7 +1004,7 @@ NIF(svd) {
 NIF(lu) {
   TENSOR_PARAM(0, t);
 
-  std::tuple<torch::Tensor, torch::Tensor> lu_result = torch::linalg::lu_factor(*t);
+  std::tuple<torch::Tensor, torch::Tensor> lu_result = torch::linalg_lu_factor(*t);
   std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> plu = torch::lu_unpack(std::get<0>(lu_result), std::get<1>(lu_result));
 
   TENSOR_TUPLE_3(plu);

--- a/torchx/mix.exs
+++ b/torchx/mix.exs
@@ -75,7 +75,7 @@ defmodule Torchx.MixProject do
 
   defp libtorch_config() do
     target = System.get_env("LIBTORCH_TARGET", "cpu")
-    version = System.get_env("LIBTORCH_VERSION", "2.4.0")
+    version = System.get_env("LIBTORCH_VERSION", "2.7.0")
     env_dir = System.get_env("LIBTORCH_DIR")
 
     %{


### PR DESCRIPTION
Update Torch version to 2.7, and address namespace changes that occured in 2.6 which caused compilation failures. The linalg namespace appears to have been removed from the C++ api.