### PR TITLE
Fix hook order inside while loop

### DIFF
--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -312,14 +312,14 @@ defmodule EXLA.Defn do
        ) do
     [initial_arg, _arg, pred, body] = args
 
+    {initial, cache} = recur_composite(initial_arg, state, cache)
+
     initial =
       if token = get_token(cache) do
-        {token, initial_arg}
+        [token | initial]
       else
-        initial_arg
+        initial
       end
-
-    {initial, cache} = recur_composite(initial, state, cache)
 
     {pred_computation, cache} = mlir_while_computation(pred, initial, {:pred, 8}, state, cache)
     {body_computation, cache} = mlir_while_computation(body, initial, :with_token, state, cache)


### PR DESCRIPTION
We use tokens to order hooks, but currently when we enter `while` loop, we don't use the latest token, we always use the starting one. In certain cases this leads to outfeeds in unexpected order and results in an error.