### PR TITLE
Update LibTorch to version 2.8

### DIFF
--- a/torchx/README.md
+++ b/torchx/README.md
@@ -33,15 +33,15 @@ Mix.install([
 
 We will automatically download a precompiled version of `LibTorch` that
 runs on the CPU. If you want to use another version, you can set `LIBTORCH_VERSION`
-to `2.1.0` or later.
+to `2.5.0` or later.
 
 If you want torch with CUDA support, please use `LIBTORCH_TARGET` to choose
 CUDA versions. The current supported targets are:
 
 - `cpu` default CPU only version
-- `cu118` CUDA 11.8 and CPU version (no macOS support)
 - `cu126` CUDA 12.6 and CPU version (no macOS support)
 - `cu128` CUDA 12.8 and CPU version (no macOS support)
+- `cu129` CUDA 12.9 and CPU version (no macOS support)
 
 Once downloaded, we will compile `Torchx` bindings. You will need `make`/`nmake`,
 `cmake` (3.12+) and a `C++` compiler. If building on Windows, you will need:

--- a/torchx/README.md
+++ b/torchx/README.md
@@ -10,7 +10,7 @@ In order to use `Torchx`, you will need Elixir installed. Then create an Elixir 
 via the `mix` build tool:
 
 ```
-$ mix new my_app
+mix new my_app
 ```
 
 Then you can add `Torchx` as dependency in your `mix.exs`:
@@ -39,9 +39,10 @@ If you want torch with CUDA support, please use `LIBTORCH_TARGET` to choose
 CUDA versions. The current supported targets are:
 
 - `cpu` default CPU only version
+- `cu118` CUDA 11.8 and CPU version (no macOS support, libtorch `< 2.8.0` only)
 - `cu126` CUDA 12.6 and CPU version (no macOS support)
 - `cu128` CUDA 12.8 and CPU version (no macOS support)
-- `cu129` CUDA 12.9 and CPU version (no macOS support)
+- `cu129` CUDA 12.9 and CPU version (no macOS support, libtorch `>= 2.8.0` only)
 
 Once downloaded, we will compile `Torchx` bindings. You will need `make`/`nmake`,
 `cmake` (3.12+) and a `C++` compiler. If building on Windows, you will need:

--- a/torchx/mix.exs
+++ b/torchx/mix.exs
@@ -75,11 +75,11 @@ defmodule Torchx.MixProject do
 
   defp libtorch_config() do
     target = System.get_env("LIBTORCH_TARGET", "cpu")
-    version = System.get_env("LIBTORCH_VERSION", "2.7.0")
+    version = System.get_env("LIBTORCH_VERSION", "2.8.0")
     env_dir = System.get_env("LIBTORCH_DIR")
 
     %{
-      valid_targets: ["cpu", "cu118", "cu126", "cu128"],
+      valid_targets: ["cpu", "cu126", "cu128", "cu129"],
       target: target,
       version: version,
       base: "libtorch",

--- a/torchx/mix.exs
+++ b/torchx/mix.exs
@@ -78,8 +78,26 @@ defmodule Torchx.MixProject do
     version = System.get_env("LIBTORCH_VERSION", "2.8.0")
     env_dir = System.get_env("LIBTORCH_DIR")
 
+    # 2.8.0 is the first version that supports cu129 and drops cu118
+    # cu118 might still be needed for older hardware, so we're keeping it
+    # for now.
+    valid_targets = ["cpu", "cu118", "cu126", "cu128"]
+
+    valid_targets =
+      case Version.parse(version) do
+        {:ok, parsed} ->
+          if Version.match?(parsed, "<= 2.7.0") do
+            valid_targets
+          else
+            (valid_targets -- ["cu118"]) ++ ["cu129"]
+          end
+
+        _ ->
+          valid_targets
+      end
+
     %{
-      valid_targets: ["cpu", "cu126", "cu128", "cu129"],
+      valid_targets: valid_targets,
       target: target,
       version: version,
       base: "libtorch",


### PR DESCRIPTION
Update LibTorch to version 2.8. This also requires updating the supported CUDA versions.

There was a breaking api change in LibTorch 2.5 release, so older versions will not compile.

https://pytorch.org/get-started/locally/