### PR TITLE
fix: quickstart example in getting_started guide

### DIFF
--- a/nx/guides/getting_started/quickstart.livemd
+++ b/nx/guides/getting_started/quickstart.livemd
@@ -162,7 +162,7 @@ Nx.shape(tensor)
 We can also create a new tensor with the given shape using `Nx.reshape/2`:
 
 ```elixir
-Nx.reshape(tensor, {1, 4}, names: [:batches, :values])
+Nx.reshape(tensor, {1, 6}, names: [:batches, :values])
 ```
 
 This operation generally reuses all of the tensor data and simply


### PR DESCRIPTION
At this point in the guide we have defined tensor as

tensor = Nx.tensor([[1, 2], [3, 4], [5, 6]], names: [:y, :x])

so using Nx.reshape(tensor, {1, 4}, names: [:batches, :values]) outputs an error. Changed it to {1, 4} to prevent this.