### PR TITLE
fix(torchx): libtorch download for >=2.8 should not include cxx11 abi

### DIFF
--- a/torchx/mix.exs
+++ b/torchx/mix.exs
@@ -153,8 +153,7 @@ defmodule Torchx.MixProject do
 
       url =
         case :os.type() do
-          {:unix, _} ->
-          # {:unix, :linux} ->
+          {:unix, :linux} ->
             if libtorch_config.has_cxx11_abi do
               "https://download.pytorch.org/libtorch/#{libtorch_config.target}/libtorch-cxx11-abi-shared-with-deps-#{libtorch_config.version}%2B#{libtorch_config.target}.zip"
             else


### PR DESCRIPTION
Got a 403 error and when I went to validate the available files,
I noticed that there was no "cxx11-abi" file.

This also brings back some missing env vars that vanished on the latest update to torchx's mix.exs
