### PR TITLE
Test/window op edge cases

### DIFF
--- a/nx/test/nx/defn/grad_test.exs
+++ b/nx/test/nx/defn/grad_test.exs
@@ -1435,7 +1435,9 @@ defmodule Nx.Defn.GradTest do
     defn grad_sum_sin_window_max_cos_same(t) do
       grad(
         t,
-        &Nx.sum(Nx.sin(Nx.window_max(Nx.cos(&1), {1, 3, 3, 1}, padding: :same, strides: [1, 2, 2, 1])))
+        &Nx.sum(
+          Nx.sin(Nx.window_max(Nx.cos(&1), {1, 3, 3, 1}, padding: :same, strides: [1, 2, 2, 1]))
+        )
       )
     end
 

--- a/nx/test/nx_test.exs
+++ b/nx/test/nx_test.exs
@@ -890,7 +890,9 @@ defmodule NxTest do
 
     test "computes a same padding window max 1D" do
       t = Nx.iota({8}, type: {:f, 32})
-      assert Nx.window_max(t, {3}, padding: :same, strides: [2]) == Nx.tensor([1.0, 3.0, 5.0, 7.0])
+
+      assert Nx.window_max(t, {3}, padding: :same, strides: [2]) ==
+               Nx.tensor([1.0, 3.0, 5.0, 7.0])
     end
 
     test "computes a same padding window max 2D" do
@@ -1100,16 +1102,14 @@ defmodule NxTest do
       # dilated kernel with same padding
       t5 = Nx.iota({4, 4}, type: {:f, 32})
 
-      assert Nx.shape(
-               Nx.window_max(t5, {2, 2}, padding: :same, window_dilations: [2, 2])
-             ) == {4, 4}
+      assert Nx.shape(Nx.window_max(t5, {2, 2}, padding: :same, window_dilations: [2, 2])) ==
+               {4, 4}
 
       # dilated kernel larger than input with same padding
       t6 = Nx.iota({2, 2}, type: {:f, 32})
 
-      assert Nx.shape(
-               Nx.window_max(t6, {2, 2}, padding: :same, window_dilations: [2, 2])
-             ) == {2, 2}
+      assert Nx.shape(Nx.window_max(t6, {2, 2}, padding: :same, window_dilations: [2, 2])) ==
+               {2, 2}
     end
   end
 


### PR DESCRIPTION
I threw claude at it, had tests made for edge cases. found an additional bug. some of these tests depend on the other PR. generated summary below
-------
## Summary

Adds comprehensive test coverage for window operations (max, min, sum, product, scatter, reduce) across edge-case configurations that were previously untested.

**Depends on #1676 on elixir-nx/nx** (includes the select_and_scatter padding fix as a base).

## Tests Added

**Forward-pass tests (`nx_test.exs`):**
- Window max/min/sum with `window_dilations` + `strides` + `:same` padding combined
- Window max with dilations + explicit asymmetric padding
- Window product with `:same` padding (4D, 2D, 1D)
- 1D window max/sum with dilations
- Window scatter max/min with `:same` and explicit padding
- Window reduce with custom function (sum of squares)
- Window reduce (custom sum) matches `window_sum`
- `Shape.pool` edge cases: kernel > input, kernel >> input, stride > kernel, non-divisible dims, dilated kernels

**Gradient tests (`grad_test.exs`):**
- Window sum gradient with dilations + strides + same/explicit padding
- 1D window sum gradient with dilations
- Window max gradient in f64 and bf16 precision
- Pad gradient (symmetric, interior, cos composition)
- Conv gradient with dilated kernel + `:same` padding (4x4 and 2x2 inputs)

## Notable finding

While writing these tests, discovered that `window_max`/`window_min` gradients crash when `window_dilations` is used. The gradient code in `grad.ex:650` drops the `window_dilations` option when calling `window_scatter_max/min`, and those functions don't accept dilations at all. Separate bug to file.

## Test Results

```
479 tests, 0 failures, 1 skipped
```