### PR TITLE
Allow runtime_call callbacks to call regular (non-defn) functions

### DIFF
--- a/exla/test/exla/defn/runtime_call_test.exs
+++ b/exla/test/exla/defn/runtime_call_test.exs
@@ -190,8 +190,6 @@ defmodule EXLA.Defn.RuntimeCallTest do
     assert_receive {:container_fun, ^ref}
   end
 
-  # Issue #1684: runtime_call callbacks should be able to call
-  # regular defp functions without requiring deftransform.
   defp plain_add_offset(t, opts) do
     t
     |> Nx.as_type(:f32)

--- a/nx/lib/nx/defn/compiler.ex
+++ b/nx/lib/nx/defn/compiler.ex
@@ -631,8 +631,9 @@ defmodule Nx.Defn.Compiler do
        ) do
     {out, state} = normalize(out, state)
     {tensor_or_container, state} = normalize(tensor_or_container, state)
+    prev_runtime_callback? = state.runtime_callback?
     {fun, state} = normalize(fun, %{state | runtime_callback?: true})
-    state = %{state | runtime_callback?: false}
+    state = %{state | runtime_callback?: prev_runtime_callback?}
     {{{:., dot_meta, [Nx, :runtime_call]}, meta, [out, tensor_or_container, fun]}, state}
   end
 

--- a/nx/test/nx/defn/runtime_call_evaluator_test.exs
+++ b/nx/test/nx/defn/runtime_call_evaluator_test.exs
@@ -47,8 +47,6 @@ defmodule Nx.Defn.RuntimeCallEvaluatorTest do
     assert expected == y
   end
 
-  # Issue #1684: runtime_call callbacks should be able to call
-  # regular defp functions without requiring deftransform.
   defp do_add_offset(t, opts) do
     t
     |> Nx.as_type(:f32)


### PR DESCRIPTION
Closes #1684. The defn compiler now special-cases Nx.runtime_call to normalize the callback with a runtime_callback? flag, which allows local defp and remote module function calls to pass through without requiring deftransform.

# The problem before the fix:
When you write a runtime_call callback inside defn, you can't call regular defp functions or non-Nx module functions (like Enum, Map, etc.). The compiler rejects them with "cannot use function X inside defn because it was not defined with defn". The workaround was to use deftransform, but that shouldn't be necessary. The callback runs at runtime in plain Elixir, not inside the computation graph.

## The fix (commit 1 — compiler.ex, 28 lines changed): Three changes to the defn compiler's normalization pass:

  1. Added a runtime_callback? flag to the compiler state
  2. Added a special-case clause for Nx.runtime_call — same pattern used for hook — that normalizes the output template and tensor args as defn expressions but sets runtime_callback?: true when normalizing the callback function
  3. The local function call handler and remote function call handler check the flag — when true, they keep calls as regular Elixir instead of transforming them to __remote__ (which requires defn versions)

## Tests (commit 2 — 246 lines across 2 files): 10 evaluator tests, 5 EXLA integration tests covering:
  - Calling a defp helper from the callback (the exact pattern from the issue)
  - Calling non-Nx modules like Enum.map
  - Nested defp calls (helper calling another helper)
  - Pipe chains mixing Nx and defp functions
  - Multiple runtime_calls with different defp callbacks in the same defn
  - Elixir control flow (if) inside the defp callback
  - Capturing a deftransform option value in the callback closure