### PR TITLE
Fix hook message ordering race in while loops

### DIFF
--- a/exla/lib/exla/defn/outfeed.ex
+++ b/exla/lib/exla/defn/outfeed.ex
@@ -260,7 +260,10 @@ defmodule EXLA.Defn.Outfeed do
         end
       end
 
-    send(parent, ref)
-    fun.(EXLA.Defn.Buffers.to_nx!(buffers, template))
+    try do
+      fun.(EXLA.Defn.Buffers.to_nx!(buffers, template))
+    after
+      send(parent, ref)
+    end
   end
 end

--- a/exla/test/exla/defn/api_test.exs
+++ b/exla/test/exla/defn/api_test.exs
@@ -243,6 +243,39 @@ defmodule EXLA.Defn.APITest do
       assert tuple == {Nx.tensor(120.0), Nx.tensor(1)}
     end
 
+    defn hook_countdown(x) do
+      while x, Nx.greater(x, 0) do
+        hook(Nx.subtract(x, 1), :countdown)
+      end
+    end
+
+    test "hook messages within while arrive in iteration order" do
+      # Hook messages must arrive in the order their iterations executed.
+      # The hook sleeps proportional to the value, so without serialized
+      # hook execution, earlier iterations (higher values, longer sleep)
+      # finish after later ones, reversing the order.
+      parent = self()
+
+      ordered_hook = fn x ->
+        val = Nx.to_number(x)
+        Process.sleep(val * 50)
+        send(parent, {:countdown, val})
+      end
+
+      EXLA.jit(&hook_countdown/1, hooks: %{countdown: ordered_hook}).(5)
+
+      values =
+        for _ <- 1..5 do
+          receive do
+            {:countdown, val} -> val
+          after
+            5_000 -> flunk("timed out waiting for hook message")
+          end
+        end
+
+      assert values == [4, 3, 2, 1, 0]
+    end
+
     defn hook_cond(a, b) do
       cond do
         a == -1 -> hook(b * 2, :cond)


### PR DESCRIPTION
Execute hook callback before sending completion signal to outfeed loop, ensuring hook side-effects complete before the next iteration's hook process is spawned. Uses try/after to guarantee the parent is unblocked even if the hook raises.

Fixes #1686

## Tradeoff
this serializes hook execution. so the outfeed loop now waits for run.(...) to complete before proceeding. (before it could run concurrently with the next from_outfeed NIF call).
outfeed loop already blocked on `receive do ^ref` before looping and `from_outfeed` (mostly waiting for XLA to produce the next value.

if the concurrency is worth keeping, you could instead do a single long-lived hook executor process (ordering guaranteed via BEAM's single-sender message guarantee), but that seems like a bigger change