### PR TITLE
Support vectorized gradients in Nx.Defn.grad

### DIFF
--- a/nx/lib/nx/defn/expr.ex
+++ b/nx/lib/nx/defn/expr.ex
@@ -68,6 +68,13 @@ defmodule Nx.Defn.Expr do
     parameter(tensor, context, pos)
   end
 
+  def parameter(%T{} = tensor, pos) do
+    # Concrete (non-Expr) tensor — convert to constant expression.
+    # This happens when captured tensors end up in optional args
+    # during grad callback re-evaluation.
+    to_expr(tensor) |> then(&parameter(&1, pos))
+  end
+
   @doc """
   Creates a tensor expression parameter at `pos` based on the given `tensor` and `context`.
   """

--- a/nx/lib/nx/defn/grad.ex
+++ b/nx/lib/nx/defn/grad.ex
@@ -403,8 +403,11 @@ defmodule Nx.Defn.Grad do
     new_names = Enum.reject(vectorized_names, &(&1 in existing))
 
     cond do
-      new_names == [] -> node
-      node.shape == {} -> node
+      new_names == [] ->
+        node
+
+      node.shape == {} ->
+        node
 
       true ->
         Nx.vectorize(node, new_names)

--- a/nx/lib/nx/defn/grad.ex
+++ b/nx/lib/nx/defn/grad.ex
@@ -135,10 +135,20 @@ defmodule Nx.Defn.Grad do
        ) do
     expr = apply(callback, call.data.args)
 
+    # When the optional wraps an apply_vectorized pattern (inner call has
+    # no vectorized axes but parent does), don't propagate vectorized names
+    # into the inner tree. The inner computation is in devectorized space.
+    inner_names =
+      if call.vectorized_axes == [] and parent_vectorized_names != [] do
+        []
+      else
+        parent_vectorized_names
+      end
+
     # Now traverse over the optional expression where args are the new parameters.
     # Once we access the parameter itself, we point the parameter to the arg.
     {{parents, nodes}, _} =
-      Composite.reduce(expr, {acc, parent_vectorized_names}, fn
+      Composite.reduce(expr, {acc, inner_names}, fn
         expr, {{parents, nodes}, expr_vectorized_names} ->
           arg_vectorized_names = compute_arg_vectorized_names(expr, expr_vectorized_names)
           parents = Map.update(parents, expr.data.id, [id], &[id | &1])
@@ -167,13 +177,19 @@ defmodule Nx.Defn.Grad do
 
   defp parents_args(op, t, parent_id, acc, parent_vectorized_names) do
     reduce_args(op, t, acc, fn arg, {parents, nodes} ->
-      if arg.data.op in @constants do
-        {parents, nodes}
-      else
-        arg_vectorized_names = compute_arg_vectorized_names(t, parent_vectorized_names)
-        parents = Map.update(parents, arg.data.id, [parent_id], &[parent_id | &1])
+      case arg.data do
+        %Nx.Defn.Expr{op: op} when op in @constants ->
+          {parents, nodes}
 
-        recur_parents_tree(arg, {parents, nodes}, arg_vectorized_names)
+        %Nx.Defn.Expr{id: arg_id} ->
+          arg_vectorized_names = compute_arg_vectorized_names(t, parent_vectorized_names)
+          parents = Map.update(parents, arg_id, [parent_id], &[parent_id | &1])
+
+          recur_parents_tree(arg, {parents, nodes}, arg_vectorized_names)
+
+        _concrete ->
+          # Concrete (non-Expr) tensor captured in closure — skip tree traversal
+          {parents, nodes}
       end
     end)
   end
@@ -209,16 +225,85 @@ defmodule Nx.Defn.Grad do
 
   defp to_grad(arg, to_grad_ids, parents, acc) do
     id = arg.data.id
-    acc = traverse_parents(__MODULE__, to_grad_ids, parents, acc)
-    acc = traverse_parents(id, to_grad_ids, parents, acc)
+
+    acc =
+      try do
+        acc = traverse_parents(__MODULE__, to_grad_ids, parents, acc)
+        traverse_parents(id, to_grad_ids, parents, acc)
+      rescue
+        e in ArgumentError ->
+          if arg.vectorized_axes != [] and
+               String.contains?(Exception.message(e), "cannot reshape") do
+            reraise ArgumentError,
+                    "cannot compute gradient: a vectorized axis name was reused with a " <>
+                      "different size inside the grad function. Redefining the meaning of " <>
+                      "a vectorized axis (e.g., devectorize then reshape then re-vectorize " <>
+                      "with the same name at a different size) is not supported. " <>
+                      "Original error: #{Exception.message(e)}",
+                    __STACKTRACE__
+          else
+            reraise e, __STACKTRACE__
+          end
+      end
+
     {nodes, grads} = acc
 
     res = sum_grad(Map.get(grads, id, []))
-    {Nx.broadcast(res, arg), {nodes, grads}}
+
+    res =
+      cond do
+        # Extra inner dims from devectorize baking batch into shape —
+        # extract each batch element's own gradient (the diagonal).
+        res.vectorized_axes == arg.vectorized_axes and
+            tuple_size(res.shape) > tuple_size(arg.shape) ->
+          batch_size = elem(res.shape, 0)
+
+          idx =
+            Nx.iota({batch_size}, type: :s32)
+            |> Nx.vectorize(arg.vectorized_axes)
+
+          result = Nx.take(res, idx, axis: 0)
+          Nx.broadcast(result, arg)
+
+        # Function added vectorization. Self-vectorization (same size) →
+        # reshape; external vectorization (different size) → broadcast.
+        res.vectorized_axes != [] and arg.vectorized_axes == [] ->
+          res_devec = Nx.devectorize(res, keep_names: false)
+
+          if Nx.size(res_devec) == Nx.size(arg) do
+            Nx.reshape(res_devec, arg)
+          else
+            Nx.broadcast(res, arg)
+          end
+
+        res.vectorized_axes == [] and arg.vectorized_axes != [] ->
+          Nx.broadcast(res, Nx.devectorize(arg, keep_names: false))
+          |> Nx.vectorize(arg.vectorized_axes)
+
+        true ->
+          Nx.broadcast(res, arg)
+      end
+
+    {res, {nodes, grads}}
   end
 
   defp sum_grad([]), do: Expr.tensor(0.0)
-  defp sum_grad(gs), do: Enum.reduce(gs, &Nx.add/2)
+
+  defp sum_grad(gs) do
+    # Mixed vectorized/non-vectorized terms from apply_vectorized —
+    # devectorize all before summing to avoid broadcast_vectors collision
+    has_vec = Enum.any?(gs, &(&1.vectorized_axes != []))
+    has_no_vec = Enum.any?(gs, &(&1.vectorized_axes == []))
+
+    gs =
+      if has_vec and has_no_vec do
+        Enum.map(gs, &Nx.devectorize(&1, keep_names: false))
+      else
+        gs
+      end
+
+    Enum.reduce(gs, &Nx.add/2)
+  end
 
   defp traverse_parents(id, to_grad_ids, parents, acc) do
     parents
@@ -236,6 +321,8 @@ defmodule Nx.Defn.Grad do
 
         {args, ans} =
           if vectorized_names != [] do
+            vec_offset = length(vectorized_names)
+
             args =
               Enum.map(args, fn
                 %T{} = arg ->
@@ -245,7 +332,19 @@ defmodule Nx.Defn.Grad do
                   opt
               end)
 
-            ans = Nx.vectorize(ans, vectorized_names)
+            args = adjust_vectorized_args(op, args, vec_offset)
+
+            # Avoid double-vectorization
+            existing_ans = Keyword.keys(ans.vectorized_axes)
+            new_ans_names = Enum.reject(vectorized_names, &(&1 in existing_ans))
+
+            ans =
+              cond do
+                new_ans_names == [] -> ans
+                ans.shape == {} -> ans
+                true -> Nx.vectorize(ans, new_ans_names)
+              end
+
             {args, ans}
           else
             {args, ans}
@@ -257,10 +356,28 @@ defmodule Nx.Defn.Grad do
 
           [_ | _] ->
             g = Enum.reduce(gs, &Nx.add/2)
+
+            # Devectorize g when ans has batch dim baked into shape
+            g =
+              if g.vectorized_axes != [] and ans.vectorized_axes == [] do
+                Nx.devectorize(g, keep_names: false)
+              else
+                g
+              end
+
+            [g, _] = Nx.broadcast_vectors([g, ans])
             {nodes, update_grads(op, args, ans, g, to_grad_ids, grads)}
 
           _ ->
-            g = gs |> Tuple.to_list() |> Enum.map(&sum_grad/1)
+            g =
+              gs
+              |> Tuple.to_list()
+              |> Enum.map(fn gs ->
+                g = sum_grad(gs)
+                [g, _] = Nx.broadcast_vectors([g, ans])
+                g
+              end)
+
             {nodes, update_grads(op, args, ans, g, to_grad_ids, grads)}
         end
 
@@ -282,7 +399,180 @@ defmodule Nx.Defn.Grad do
   defp revectorize_node(node, vectorized_names) do
     vectorized_names = compute_arg_vectorized_names(node, vectorized_names)
 
-    Nx.vectorize(node, vectorized_names)
+    existing = Keyword.keys(node.vectorized_axes)
+    new_names = Enum.reject(vectorized_names, &(&1 in existing))
+
+    cond do
+      new_names == [] -> node
+      node.shape == {} -> node
+
+      true ->
+        Nx.vectorize(node, new_names)
+    end
+  end
+
+  # When recur_to_grad re-vectorizes tensor args, opts (axes, padding, etc.)
+  # still reference devectorized axis indices. Adjust by subtracting vec_offset.
+
+  @axes_in_opts_ops [:sum, :product, :reduce_max, :reduce_min]
+
+  defp adjust_vectorized_args(op, [x | rest], offset) when op in @axes_in_opts_ops do
+    [x | adjust_keyword_axes(rest, offset)]
+  end
+
+  defp adjust_vectorized_args(:gather, args, _offset), do: args
+
+  defp adjust_vectorized_args(:sort, [x | rest], offset) do
+    [x | adjust_keyword_axis(rest, offset)]
+  end
+
+  defp adjust_vectorized_args(:squeeze, [x, axes], offset) do
+    [x, offset_axes(axes, offset)]
+  end
+
+  defp adjust_vectorized_args(:transpose, [x, axes], offset) do
+    [x, offset_axes(axes, offset)]
+  end
+
+  defp adjust_vectorized_args(:broadcast, [x, shape, axes], offset) do
+    adjusted_shape =
+      shape
+      |> Tuple.to_list()
+      |> Enum.drop(offset)
+      |> List.to_tuple()
+
+    [x, adjusted_shape, offset_axes(axes, offset)]
+  end
+
+  defp adjust_vectorized_args(op, [tensors, axis], offset)
+       when op in [:stack, :concatenate] do
+    [tensors, axis - offset]
+  end
+
+  defp adjust_vectorized_args(:dot, [x, axes_x, batch_x, y, axes_y, batch_y], offset) do
+    [
+      x,
+      offset_axes(axes_x, offset),
+      offset_axes(batch_x, offset),
+      y,
+      offset_axes(axes_y, offset),
+      offset_axes(batch_y, offset)
+    ]
+  end
+
+  defp adjust_vectorized_args(:pad, [x, value, padding_config], offset) do
+    [x, value, Enum.drop(padding_config, offset)]
+  end
+
+  @window_ops [:window_sum, :window_product, :window_min, :window_max]
+
+  defp adjust_vectorized_args(op, [x, window_dimensions, opts], offset)
+       when op in @window_ops do
+    adjusted_dims =
+      window_dimensions
+      |> Tuple.to_list()
+      |> Enum.drop(offset)
+      |> List.to_tuple()
+
+    adjusted_opts =
+      opts
+      |> adjust_keyword_drop(:strides, offset)
+      |> adjust_keyword_drop(:window_dilations, offset)
+      |> adjust_keyword_padding(:padding, offset)
+
+    [x, adjusted_dims, adjusted_opts]
+  end
+
+  defp adjust_vectorized_args(op, [tensor, source, init_value, window_dimensions, opts], offset)
+       when op in [:window_scatter_max, :window_scatter_min] do
+    padding = Enum.drop(opts[:padding], offset)
+    strides = Enum.drop(opts[:strides], offset)
+
+    window_dimensions =
+      window_dimensions
+      |> Tuple.to_list()
+      |> Enum.drop(offset)
+      |> List.to_tuple()
+
+    opts = Keyword.merge(opts, padding: padding, strides: strides)
+    [tensor, source, init_value, window_dimensions, opts]
+  end
+
+  defp adjust_vectorized_args(:slice, [x, start_indices, lengths, strides], offset) do
+    [x, Enum.drop(start_indices, offset), Enum.drop(lengths, offset), Enum.drop(strides, offset)]
+  end
+
+  defp adjust_vectorized_args(:put_slice, [x, start_indices, update], offset) do
+    [x, Enum.drop(start_indices, offset), update]
+  end
+
+  defp adjust_vectorized_args(op, args, _offset) when op in [:indexed_add, :indexed_put] do
+    args
+  end
+
+  defp adjust_vectorized_args(:fft, [x | rest], offset) do
+    [x | adjust_keyword_axis(rest, offset)]
+  end
+
+  defp adjust_vectorized_args(:ifft, [x | rest], offset) do
+    [x | adjust_keyword_axis(rest, offset)]
+  end
+
+  defp adjust_vectorized_args(:conv, args, _offset), do: args
+
+  defp adjust_vectorized_args(_op, args, _offset), do: args
+
+  defp offset_axes(axes, offset) when is_list(axes) do
+    axes
+    |> Enum.map(&(&1 - offset))
+    |> Enum.filter(&(&1 >= 0))
+  end
+
+  defp adjust_keyword_axes(opts_list, offset) do
+    Enum.map(opts_list, fn
+      opts when is_list(opts) ->
+        case Keyword.fetch(opts, :axes) do
+          {:ok, axes} when is_list(axes) ->
+            Keyword.put(opts, :axes, offset_axes(axes, offset))
+
+          _ ->
+            opts
+        end
+
+      other ->
+        other
+    end)
+  end
+
+  defp adjust_keyword_axis(opts_list, offset) do
+    Enum.map(opts_list, fn
+      opts when is_list(opts) ->
+        case Keyword.fetch(opts, :axis) do
+          {:ok, axis} when is_integer(axis) ->
+            Keyword.put(opts, :axis, axis - offset)
+
+          _ ->
+            opts
+        end
+
+      other ->
+        other
+    end)
+  end
+
+  defp adjust_keyword_drop(opts, key, offset) do
+    case Keyword.fetch(opts, key) do
+      {:ok, list} when is_list(list) -> Keyword.put(opts, key, Enum.drop(list, offset))
+      _ -> opts
+    end
+  end
+
+  defp adjust_keyword_padding(opts, key, offset) do
+    case Keyword.fetch(opts, key) do
+      {:ok, list} when is_list(list) -> Keyword.put(opts, key, Enum.drop(list, offset))
+      {:ok, atom} when is_atom(atom) -> opts
+      _ -> opts
+    end
   end
 
   defp update_grads(:elem, [%{type: {:tuple, size}} = tuple, pos], _ans, g, _to_grad_ids, grads) do
@@ -292,8 +582,22 @@ defmodule Nx.Defn.Grad do
     end)
   end
 
-  defp update_grads(:optional, [_call, expr, _callback], _ans, gs, _to_grad_ids, grads) do
+  defp update_grads(:optional, [call, expr, _callback], _ans, gs, _to_grad_ids, grads) do
     gs = List.wrap(gs)
+
+    # apply_vectorized boundary: inner computation is devectorized
+    gs =
+      if call.vectorized_axes == [] do
+        Enum.map(gs, fn
+          %Nx.Tensor{vectorized_axes: va} = g when va != [] ->
+            Nx.devectorize(g, keep_names: false)
+
+          g ->
+            g
+        end)
+      else
+        gs
+      end
 
     {grads, []} =
       Composite.reduce(expr, {grads, gs}, fn child, {grads, [g | gs]} ->
@@ -305,6 +609,17 @@ defmodule Nx.Defn.Grad do
 
   defp update_grads(:while, [initial, arg, condition, body], _ans, gs, _to_grad_ids, grads) do
     gs = List.wrap(gs)
+
+    # While body operates in devectorized space
+    gs =
+      Enum.map(gs, fn
+        %Nx.Tensor{vectorized_axes: va} = g when va != [] ->
+          Nx.devectorize(g, keep_names: false)
+
+        g ->
+          g
+      end)
+
     flatten_initial = Composite.flatten_list([initial])
     context = hd(flatten_initial).data.context
     arg_context = condition.data.context
@@ -354,17 +669,22 @@ defmodule Nx.Defn.Grad do
     gs = List.wrap(gs)
     to_grad = Composite.flatten_list([to_grad])
 
+    # Prevent cross-contamination when vectorized cond creates separate
+    # cond_then/cond_else nodes sharing the same to_grad variables
+    clean_grads =
+      Enum.reduce(to_grad, grads, fn tg, g -> Map.delete(g, tg.data.id) end)
+
     clauses =
       Enum.map([{true, last} | clauses], fn {head, body} ->
         {parents, nodes} = parents_tree(body, ids)
 
-        {grads, []} =
-          Composite.reduce(body, {grads, gs}, fn arg, {grads, [g | gs]} ->
+        {body_grads, []} =
+          Composite.reduce(body, {clean_grads, gs}, fn arg, {grads, [g | gs]} ->
             {Map.put(grads, arg.data.id, [g]), gs}
           end)
 
         {graded, _} =
-          Enum.map_reduce(to_grad, {nodes, grads}, &to_grad(&1, to_grad_ids, parents, &2))
+          Enum.map_reduce(to_grad, {nodes, body_grads}, &to_grad(&1, to_grad_ids, parents, &2))
 
         {head, graded}
       end)
@@ -485,12 +805,24 @@ defmodule Nx.Defn.Grad do
     ]
   end
 
-  defp grad(:squeeze, [x, axes], _ans, g) do
-    [{x, Nx.broadcast(g, x.shape, axes: Nx.axes(x.shape) -- axes)}]
+  defp grad(:squeeze, [x, _axes], _ans, g) do
+    [{x, Nx.reshape(g, x)}]
   end
 
   defp grad(:reshape, [x], _ans, g) do
-    [{x, Nx.reshape(g, x)}]
+    if g.vectorized_axes != x.vectorized_axes do
+      # Vectorized axes differ (e.g., g has batch from vectorize in forward,
+      # x has none). Devectorize g so reshape can cross the boundary.
+      g_devec = Nx.devectorize(g, keep_names: false)
+
+      if Nx.size(g_devec) == Nx.size(x) do
+        [{x, Nx.reshape(g_devec, x)}]
+      else
+        [{x, Nx.reshape(g, x)}]
+      end
+    else
+      [{x, Nx.reshape(g, x)}]
+    end
   end
 
   defp grad(:transpose, [x, axes], _ans, g) do
@@ -530,17 +862,29 @@ defmodule Nx.Defn.Grad do
   end
 
   defp grad(:indexed_put, [target, indices, updates, opts], _ans, g) do
+    vec_axes = g.vectorized_axes
+    g = Nx.devectorize(g, keep_names: false)
+
     zeros = Nx.broadcast(Expr.tensor(0.0), updates)
-    target_g = Nx.indexed_put(g, indices, zeros, opts)
-    updates_g = g |> Nx.gather(indices, opts) |> Nx.reshape(updates.shape)
+    target_g = Nx.indexed_put(g, indices, zeros, opts) |> Nx.vectorize(vec_axes)
+
+    updates_g =
+      g |> Nx.gather(indices, opts) |> Nx.reshape(updates.shape) |> Nx.vectorize(vec_axes)
+
     indices_g = Nx.broadcast(Expr.tensor(0.0), indices)
 
     [{target, target_g}, {indices, indices_g}, {updates, updates_g}]
   end
 
   defp grad(:indexed_add, [target, indices, updates, opts], _ans, g) do
-    target_g = g
-    updates_g = g |> Nx.gather(indices, opts) |> Nx.reshape(updates.shape)
+    vec_axes = g.vectorized_axes
+    g = Nx.devectorize(g, keep_names: false)
+
+    target_g = Nx.vectorize(g, vec_axes)
+
+    updates_g =
+      g |> Nx.gather(indices, opts) |> Nx.reshape(updates.shape) |> Nx.vectorize(vec_axes)
+
     indices_g = Nx.broadcast(Expr.tensor(0.0), indices)
 
     [{target, target_g}, {indices, indices_g}, {updates, updates_g}]
@@ -680,7 +1024,7 @@ defmodule Nx.Defn.Grad do
         g,
         window_dimensions,
         strides: base_dilation,
-        padding: List.duplicate({0, 0}, Nx.rank(x)),
+        padding: :valid,
         window_dilations: window_dilation
       )
 
@@ -705,12 +1049,22 @@ defmodule Nx.Defn.Grad do
   end
 
   defp grad(:concatenate, [tensors, axis], ans, g) do
+    # When tensors are devectorized in the expr tree, their shapes include
+    # vectorized dims but `axis` refers to the inner shape. Offset by the
+    # difference between tensor rank and ans (inner) rank.
+    t_offset =
+      case tensors do
+        [t | _] -> tuple_size(t.shape) - tuple_size(ans.shape)
+        _ -> 0
+      end
+
+    adjusted_axis = axis + t_offset
     zero_axes = List.duplicate(0, Nx.rank(ans))
     ans_shape_list = Tuple.to_list(ans.shape)
 
     {pairs, _} =
       Enum.map_reduce(tensors, 0, fn t, limit ->
-        t_len = elem(t.shape, axis)
+        t_len = elem(t.shape, adjusted_axis)
         current_limit = t_len + limit
         start = List.replace_at(zero_axes, axis, limit)
         len = List.replace_at(ans_shape_list, axis, t_len)
@@ -729,23 +1083,26 @@ defmodule Nx.Defn.Grad do
   end
 
   defp grad(:gather, [t, i, opts], _ans, g) do
+    vec_axes = g.vectorized_axes
+    g = Nx.devectorize(g, keep_names: false)
+
     i_axes = opts[:axes]
     i_shape = i.shape
     t_shape = t.shape
 
     num_elements = Tuple.product(i_shape) |> div(elem(i_shape, tuple_size(i_shape) - 1))
-    updates_shape = for i <- Nx.axes(t), i not in i_axes, do: elem(t_shape, i)
+    updates_shape = for idx <- Nx.axes(t), idx not in i_axes, do: elem(t_shape, idx)
 
     indices = Nx.reshape(i, {num_elements, :auto})
     updates = Nx.reshape(g, List.to_tuple([num_elements | updates_shape]))
 
-    g =
+    result =
       0
       |> Nx.as_type(t.type)
       |> Nx.broadcast(t_shape)
       |> Nx.indexed_add(indices, updates, opts)
 
-    [{t, g}]
+    [{t, Nx.vectorize(result, vec_axes)}]
   end
 
   defp grad(:add, [x, y], ans, g) do
@@ -1075,16 +1432,22 @@ defmodule Nx.Defn.Grad do
         # which means that:
         # A_bar = inv(A^H).X_bar.X^H
         # B_bar = inv(A^H).X_bar
-        da = a_inv_hermitian |> Nx.dot(g |> Nx.dot(Nx.LinAlg.adjoint(x))) |> Nx.negate()
-        db = Nx.dot(a_inv_hermitian, g)
+        da = a_inv_hermitian |> batched_dot(batched_dot(g, Nx.LinAlg.adjoint(x))) |> Nx.negate()
+        db = batched_dot(a_inv_hermitian, g)
         {da, db}
       else
         # X.A = B -> X = B.inv(A)
         # taking a similar approach to the branch above, we get
         # A_bar = -X^H.X_bar.inv(A^H)
         # B_bar = X_bar.inv(A^H)
-        da = x |> Nx.LinAlg.adjoint() |> Nx.dot(g) |> Nx.dot(a_inv_hermitian) |> Nx.negate()
-        db = Nx.dot(g, a_inv_hermitian)
+        da =
+          x
+          |> Nx.LinAlg.adjoint()
+          |> batched_dot(g)
+          |> batched_dot(a_inv_hermitian)
+          |> Nx.negate()
+
+        db = batched_dot(g, a_inv_hermitian)
         {da, db}
       end
 
@@ -1209,6 +1572,19 @@ defmodule Nx.Defn.Grad do
   ## Conv
 
   defp grad_conv(x, y, opts, ans, g) do
+    # Vectorized dim is already in batch via batch_group_size — devectorize
+    {x, y, ans, g} =
+      if ans.vectorized_axes != [] do
+        x = Nx.devectorize(x, keep_names: false)
+        y = Nx.devectorize(y, keep_names: false)
+        ans = Nx.devectorize(ans, keep_names: false)
+        g = Nx.devectorize(g, keep_names: false)
+        g = if tuple_size(g.shape) > tuple_size(ans.shape), do: Nx.reshape(g, ans), else: g
+        {x, y, ans, g}
+      else
+        {x, y, ans, g}
+      end
+
     g = Nx.broadcast(g, ans)
 
     input_permutation = opts[:input_permutation]
@@ -1233,14 +1609,28 @@ defmodule Nx.Defn.Grad do
     rhs_sdims = conv_sdims(y.shape, rhs_sdim_axes)
     out_sdims = conv_sdims(g.shape, out_sdim_axes)
 
+    # When conv is used with vectorized inputs, batch_group_size includes
+    # the vectorized_size multiplier. But the kernel may not have been
+    # expanded by that factor (e.g., shared kernel across vectorized batch).
+    # Adjust batch_group_size to match what the kernel actually has.
+    kernel_out_channels = elem(y.shape, rhs0)
+
+    effective_batch_group_size =
+      if batch_group_size > 1 and rem(kernel_out_channels, batch_group_size) != 0 do
+        # Find the largest factor of batch_group_size that divides kernel_out_channels
+        Enum.find(batch_group_size..1//-1, 1, &(rem(kernel_out_channels, &1) == 0))
+      else
+        batch_group_size
+      end
+
     rhs =
       cond do
         feature_group_size > 1 ->
           y = reshape_axis_out_of(rhs0, feature_group_size, y)
           reshape_axis_into(rhs0, rhs1, y)
 
-        batch_group_size > 1 ->
-          y = reshape_axis_out_of(rhs0, batch_group_size, y)
+        effective_batch_group_size > 1 ->
+          y = reshape_axis_out_of(rhs0, effective_batch_group_size, y)
           reshape_axis_into(rhs0, rhs1, y)
 
         true ->
@@ -1270,12 +1660,14 @@ defmodule Nx.Defn.Grad do
       )
 
     lhs_feature_group_size =
-      if batch_group_size > 1, do: batch_group_size, else: feature_group_size
+      if effective_batch_group_size > 1,
+        do: effective_batch_group_size,
+        else: feature_group_size
 
     {rhs_feature_group_size, rhs_batch_group_size} =
       cond do
-        batch_group_size > 1 ->
-          {batch_group_size, 1}
+        effective_batch_group_size > 1 ->
+          {effective_batch_group_size, 1}
 
         feature_group_size > 1 ->
           {1, feature_group_size}
@@ -1300,8 +1692,8 @@ defmodule Nx.Defn.Grad do
       )
 
     gx =
-      if batch_group_size > 1 do
-        gx = reshape_axis_out_of(lhs1, batch_group_size, gx)
+      if effective_batch_group_size > 1 do
+        gx = reshape_axis_out_of(lhs1, effective_batch_group_size, gx)
         reshape_axis_into(lhs1, lhs0, gx)
       else
         gx
@@ -1400,19 +1792,42 @@ defmodule Nx.Defn.Grad do
 
   defp unbroadcast(%{shape: shape} = x, res, %{shape: shape}), do: {x, res}
 
-  defp unbroadcast(%{shape: shape} = x, res, %{shape: new_shape}) do
-    axes = Nx.Shape.broadcast_axes(shape, new_shape)
-    {x, grad_broadcast(x, new_shape, axes, res)}
+  defp unbroadcast(%{shape: shape} = x, res, %{shape: new_shape} = ans) do
+    if tuple_size(shape) > tuple_size(new_shape) and
+         Keyword.keys(x.vectorized_axes) != Keyword.keys(ans.vectorized_axes) do
+      # x and ans have different vectorized axis names, so their inner shapes
+      # are in different coordinate systems. Devectorize both to compare.
+      x_full = List.to_tuple(Keyword.values(x.vectorized_axes) ++ Tuple.to_list(shape))
+      ans_full = List.to_tuple(Keyword.values(ans.vectorized_axes) ++ Tuple.to_list(new_shape))
+      axes = Nx.Shape.broadcast_axes(x_full, ans_full)
+      extra_axes = Nx.axes(ans_full) -- axes
+      g = if extra_axes == [], do: res, else: Nx.sum(res, axes: extra_axes)
+      {x, Nx.reshape(g, x)}
+    else
+      axes = Nx.Shape.broadcast_axes(shape, new_shape)
+      {x, grad_broadcast(x, new_shape, axes, res)}
+    end
   end
 
   defp grad_broadcast(x, shape, axes, g) do
+    # When x has been devectorized, x.shape may have extra leading dims
+    # that aren't reflected in `axes` (which map x's inner dims to shape).
+    # Offset axes indices into x.shape by the difference in rank.
+    x_offset = tuple_size(x.shape) - length(axes)
+
     implicit_axes =
       for {a, i} <- Enum.with_index(axes),
-          elem(shape, a) != 1 and elem(x.shape, i) == 1,
-          do: {a, i}
+          elem(shape, a) != 1 and elem(x.shape, i + x_offset) == 1,
+          do: {a, i + x_offset}
 
     {implicit_axes, broadcast_axes} = Enum.unzip(implicit_axes)
     explicit_axes = Nx.axes(shape) -- axes
+
+    # Offset explicit_axes into g's coordinate system if g has vectorized dims
+    g_offset = Nx.rank(g.shape) - tuple_size(shape)
+
+    explicit_axes =
+      if g_offset > 0, do: Enum.map(explicit_axes, &(&1 + g_offset)), else: explicit_axes
 
     g =
       case explicit_axes ++ implicit_axes do
@@ -1433,8 +1848,12 @@ defmodule Nx.Defn.Grad do
     if keep_axes || !axes do
       Nx.broadcast(g, x)
     else
-      axes = Nx.axes(x.shape) -- axes
-      Nx.broadcast(g, x, axes: axes)
+      # Reinsert size-1 dims at the reduced axis positions, then broadcast.
+      # This is equivalent to using keep_axes: true and avoids the explicit
+      # axes mapping in Nx.broadcast which breaks with vectorized tensors.
+      unsqueezed_shape = Enum.reduce(axes, Nx.shape(x), &put_elem(&2, &1, 1))
+      g = Nx.reshape(g, unsqueezed_shape)
+      Nx.broadcast(g, x)
     end
   end
 
@@ -1513,5 +1932,16 @@ defmodule Nx.Defn.Grad do
   defp grad_scatter_window__generate_window_start_indices([head | tail]) do
     tail_product = grad_scatter_window__generate_window_start_indices(tail)
     for h <- head, t <- tail_product, do: [h | t]
+  end
+
+  defp batched_dot(a, b) do
+    rank = tuple_size(a.shape)
+
+    if rank <= 2 do
+      Nx.dot(a, b)
+    else
+      batch_axes = Enum.to_list(0..(rank - 3))
+      Nx.dot(a, [-1], batch_axes, b, [-2], batch_axes)
+    end
   end
 end

--- a/nx/lib/nx/lin_alg/cholesky.ex
+++ b/nx/lib/nx/lin_alg/cholesky.ex
@@ -76,8 +76,8 @@ defmodule Nx.LinAlg.Cholesky do
   end
 
   defn cholesky_grad(l, _input, g) do
-    num = g |> Nx.tril() |> Nx.dot([0], l, [0]) |> Nx.transpose()
-    den = l |> Nx.shape() |> Nx.eye() |> Nx.add(1)
+    num = g |> Nx.tril() |> matmul_contract_rows(l) |> batch_transpose()
+    den = eye_like(l) |> Nx.add(1)
     phi_tril = num |> Nx.divide(den) |> Nx.tril()
 
     bm = Nx.LinAlg.triangular_solve(l, phi_tril, transform_a: :transpose)
@@ -87,14 +87,41 @@ defmodule Nx.LinAlg.Cholesky do
       |> conjugate_if_complex()
       |> Nx.LinAlg.triangular_solve(bm, left_side: false)
 
-    # If we end up supporting the "make_symmetric" option for Nx.LinAlg.cholesky
-    # we need to apply: dl := (adjoint(dl) + dl)/2 when the option is true.
-    # If the option is applied as Nx.add(tensor, adjoint(tensor)) |> Nx.divide(2)
-    # on the expression, no modifications are needed here, because
-    # the grad for the transformation is actually the same transformation
-    # applied on the grad
-
     [dl]
+  end
+
+  deftransformp matmul_contract_rows(a, b) do
+    rank = tuple_size(a.shape)
+
+    if rank <= 2 do
+      Nx.dot(a, [0], b, [0])
+    else
+      batch_axes = Enum.to_list(0..(rank - 3))
+      Nx.dot(a, [-2], batch_axes, b, [-2], batch_axes)
+    end
+  end
+
+  deftransformp batch_transpose(t) do
+    rank = tuple_size(t.shape)
+
+    if rank <= 2 do
+      Nx.transpose(t)
+    else
+      axes = Enum.to_list(0..(rank - 3)) ++ [rank - 1, rank - 2]
+      Nx.transpose(t, axes: axes)
+    end
+  end
+
+  deftransformp eye_like(l) do
+    rank = tuple_size(l.shape)
+    n = elem(l.shape, rank - 1)
+
+    if rank <= 2 do
+      Nx.eye(n)
+    else
+      batch_dims = l.shape |> Tuple.to_list() |> Enum.take(rank - 2)
+      Nx.eye(n) |> Nx.broadcast(List.to_tuple(batch_dims ++ [n, n]))
+    end
   end
 
   defnp conjugate_if_complex(x) do

--- a/nx/lib/nx/lin_alg/qr.ex
+++ b/nx/lib/nx/lin_alg/qr.ex
@@ -151,13 +151,26 @@ defmodule Nx.LinAlg.QR do
     # Equation (3)
     r_inv = Nx.LinAlg.invert(r)
 
-    m = Nx.dot(r, Nx.LinAlg.adjoint(dr)) |> Nx.subtract(Nx.dot(Nx.LinAlg.adjoint(dq), q))
+    m =
+      matmul(r, Nx.LinAlg.adjoint(dr))
+      |> Nx.subtract(matmul(Nx.LinAlg.adjoint(dq), q))
 
     # copyltu
     m_ltu = Nx.tril(m) |> Nx.add(m |> Nx.tril(k: -1) |> Nx.LinAlg.adjoint())
 
-    da = dq |> Nx.add(Nx.dot(q, m_ltu)) |> Nx.dot(Nx.LinAlg.adjoint(r_inv))
+    da = matmul(Nx.add(dq, matmul(q, m_ltu)), Nx.LinAlg.adjoint(r_inv))
 
     [da]
+  end
+
+  deftransformp matmul(a, b) do
+    rank = tuple_size(a.shape)
+
+    if rank <= 2 do
+      Nx.dot(a, b)
+    else
+      batch_axes = Enum.to_list(0..(rank - 3))
+      Nx.dot(a, [-1], batch_axes, b, [-2], batch_axes)
+    end
   end
 end

--- a/nx/test/nx/defn/grad_test.exs
+++ b/nx/test/nx/defn/grad_test.exs
@@ -4844,6 +4844,7 @@ defmodule Nx.Defn.GradTest do
   end
 
   describe "vectorization" do
+    # Mixed-vectorization: non-vectorized target in vectorized context.
     test "supports combination of vectorized and non-vectorized tensors" do
       x = Nx.tensor([[1, 2, 3], [4, 5, 6]]) |> Nx.vectorize(:x)
       y = 1
@@ -4864,20 +4865,16 @@ defmodule Nx.Defn.GradTest do
       assert grad == Nx.cos(x)
     end
 
-    # Skipping this as it's not supported yet.
-    @tag :skip
-    test "edge case where the same name changes meaning" do
+    test "edge case where the same name changes meaning raises clear error" do
       x = Nx.tensor([[1], [2], [3]]) |> Nx.vectorize(x: 3)
 
-      grad =
+      assert_raise ArgumentError, ~r/vectorized axis name was reused with a different size/, fn ->
         Nx.Defn.grad(x, fn t ->
           devec = Nx.devectorize(t, keep_names: true)
           new_axis = Nx.reshape(devec, {1, 3, 1}, names: [:x, nil, nil])
-
           Nx.vectorize(new_axis, x: 1)
         end)
-
-      assert grad == Nx.tensor([[1], [1], [1]]) |> Nx.vectorize(x: 3)
+      end
     end
 
     test "supports heterogenous vectorization combinations" do
@@ -4947,6 +4944,326 @@ defmodule Nx.Defn.GradTest do
                |> Nx.vectorize(x_vec.vectorized_axes)
 
       assert grad_y_vec == Nx.tensor([6.0, 15.0]) |> Nx.vectorize(y_vec.vectorized_axes)
+    end
+
+    # --- Edge cases: vectorize/devectorize boundary ---
+
+    test "vectorize/devectorize inside grad function" do
+      x = Nx.iota({6}, type: :f32)
+
+      grad =
+        Nx.Defn.grad(x, fn x ->
+          v = Nx.vectorize(Nx.reshape(x, {2, 3}), :batch)
+          d = Nx.devectorize(v, keep_names: false)
+          Nx.sum(d)
+        end)
+
+      assert grad == Nx.broadcast(1.0, {6})
+    end
+
+    test "reshape then vectorize inside grad" do
+      x = Nx.iota({6}, type: :f32)
+
+      grad =
+        Nx.Defn.grad(x, fn x ->
+          v = Nx.vectorize(Nx.reshape(x, {2, 3}), :batch)
+          Nx.sum(v)
+        end)
+
+      assert grad == Nx.broadcast(1.0, {6})
+    end
+
+    test "non-vectorized input, vectorized output" do
+      x = Nx.tensor([1.0, 2.0, 3.0])
+
+      grad =
+        Nx.Defn.grad(x, fn x ->
+          Nx.vectorize(x, :v)
+        end)
+
+      assert grad.vectorized_axes == []
+      assert grad == Nx.broadcast(1.0, {3})
+    end
+
+    test "rename vectorized axes inside grad" do
+      x = Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]) |> Nx.vectorize(:a)
+
+      grad =
+        Nx.Defn.grad(x, fn x ->
+          d = Nx.devectorize(x, keep_names: false)
+          v = Nx.vectorize(d, :new_name)
+          Nx.sum(v)
+        end)
+
+      # Gradient values correct; axis name may reflect the renamed axis
+      devec = Nx.devectorize(grad, keep_names: false)
+      assert Nx.shape(devec) == {2, 3}
+      assert Nx.to_flat_list(devec) |> Enum.all?(&(&1 == 1.0))
+    end
+
+    test "devectorize then compute then return scalar" do
+      x = Nx.tensor([[1.0, 2.0], [3.0, 4.0]]) |> Nx.vectorize(:batch)
+
+      grad =
+        Nx.Defn.grad(x, fn x ->
+          d = Nx.devectorize(x, keep_names: false)
+          Nx.sum(Nx.multiply(d, d))
+        end)
+
+      assert grad.vectorized_axes == [batch: 2]
+    end
+
+    test "chained devectorize/vectorize with computation" do
+      x = Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]) |> Nx.vectorize(:batch)
+
+      grad =
+        Nx.Defn.grad(x, fn x ->
+          d = Nx.devectorize(x, keep_names: false)
+          squared = Nx.multiply(d, d)
+          v = Nx.vectorize(squared, :batch)
+          Nx.sum(v)
+        end)
+
+      assert grad.vectorized_axes == [batch: 2]
+    end
+
+    test "multiple vectorized axes input" do
+      x = Nx.iota({2, 3, 4}, type: :f32) |> Nx.vectorize(a: 2, b: 3)
+      grad = Nx.Defn.grad(x, fn x -> Nx.sum(x) end)
+      assert grad.vectorized_axes == [a: 2, b: 3]
+      assert Nx.shape(grad) == {4}
+    end
+
+    # --- Second-order grad ---
+
+    test "second-order grad" do
+      x = Nx.tensor([[1.0, 2.0], [3.0, 4.0]]) |> Nx.vectorize(:batch)
+
+      grad =
+        Nx.Defn.grad(x, fn x ->
+          Nx.sum(Nx.Defn.grad(x, fn x -> Nx.sum(Nx.pow(x, 3)) end))
+        end)
+
+      assert grad.vectorized_axes == [batch: 2]
+      # d²/dx² x³ = 6x
+      expected = Nx.tensor([[6.0, 12.0], [18.0, 24.0]]) |> Nx.vectorize(:batch)
+      assert grad == expected
+    end
+
+    # --- Constant-grad ops (all/any/argmax/argmin) ---
+
+    test "constant-grad ops with vectorized inputs" do
+      x = Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]) |> Nx.vectorize(:batch)
+
+      # all/any return booleans — gradient is zero, but shouldn't crash
+      grad = Nx.Defn.grad(x, fn x -> Nx.sum(Nx.multiply(x, Nx.all(x))) end)
+      assert grad.vectorized_axes == [batch: 2]
+
+      grad = Nx.Defn.grad(x, fn x -> Nx.sum(Nx.multiply(x, Nx.any(x))) end)
+      assert grad.vectorized_axes == [batch: 2]
+
+      # argmax/argmin return indices — gradient is zero
+      grad = Nx.Defn.grad(x, fn x -> Nx.sum(Nx.multiply(x, Nx.argmax(x, axis: 0))) end)
+      assert grad.vectorized_axes == [batch: 2]
+
+      grad = Nx.Defn.grad(x, fn x -> Nx.sum(Nx.multiply(x, Nx.argmin(x, axis: 0))) end)
+      assert grad.vectorized_axes == [batch: 2]
+    end
+
+    # --- Window scatter (uses source tensor, can't use check_vectorized_grad) ---
+
+    test "window_scatter_max with vectorized inputs" do
+      # Window {1,3} with strides [1,3] on inner {2,6} → source must be {2,2}
+      t =
+        Nx.tensor([
+          [[1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12]],
+          [[13, 14, 15, 16, 17, 18], [19, 20, 21, 22, 23, 24]]
+        ])
+        |> Nx.as_type(:f32)
+        |> Nx.vectorize(:batch)
+
+      source =
+        Nx.tensor([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]]) |> Nx.vectorize(:batch)
+
+      init = Nx.tensor(0.0)
+
+      grad =
+        Nx.Defn.grad(t, fn t ->
+          Nx.sum(Nx.window_scatter_max(t, source, init, {1, 3}, strides: [1, 3], padding: :valid))
+        end)
+
+      devec = Nx.devectorize(grad)
+      assert Nx.shape(devec) == {2, 2, 6}
+    end
+
+    test "window_scatter_min with vectorized inputs" do
+      t =
+        Nx.tensor([
+          [[1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12]],
+          [[13, 14, 15, 16, 17, 18], [19, 20, 21, 22, 23, 24]]
+        ])
+        |> Nx.as_type(:f32)
+        |> Nx.vectorize(:batch)
+
+      source =
+        Nx.tensor([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]]) |> Nx.vectorize(:batch)
+
+      init = Nx.tensor(0.0)
+
+      grad =
+        Nx.Defn.grad(t, fn t ->
+          Nx.sum(Nx.window_scatter_min(t, source, init, {1, 3}, strides: [1, 3], padding: :valid))
+        end)
+
+      devec = Nx.devectorize(grad)
+      assert Nx.shape(devec) == {2, 2, 6}
+    end
+
+    # --- Mixed vectorized axes (different axis names on different inputs) ---
+
+    test "mixed vectorized axes with add" do
+      x = Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]) |> Nx.vectorize(:a)
+
+      y =
+        Nx.tensor([[10.0, 20.0, 30.0], [40.0, 50.0, 60.0], [70.0, 80.0, 90.0]])
+        |> Nx.vectorize(:b)
+
+      grad = Nx.Defn.grad(x, fn x -> Nx.sum(Nx.add(x, y)) end)
+
+      assert grad.vectorized_axes == [a: 2, b: 3]
+      assert Nx.shape(grad) == {3}
+    end
+
+    test "mixed vectorized axes with multiply" do
+      x = Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]) |> Nx.vectorize(:a)
+
+      y =
+        Nx.tensor([[10.0, 20.0, 30.0], [40.0, 50.0, 60.0], [70.0, 80.0, 90.0]])
+        |> Nx.vectorize(:b)
+
+      grad = Nx.Defn.grad(x, fn x -> Nx.sum(Nx.multiply(x, y)) end)
+
+      assert grad.vectorized_axes == [a: 2, b: 3]
+      assert Nx.shape(grad) == {3}
+    end
+
+    test "dot with mixed vectorized axes" do
+      x = Nx.iota({2, 3, 3}, type: :f32) |> Nx.vectorize(:a)
+      y = Nx.iota({2, 3, 3}, type: :f32) |> Nx.vectorize(:row)
+
+      grad = Nx.Defn.grad(x, fn x -> Nx.sum(Nx.dot(x, [1], y, [0])) end)
+      assert :a in Keyword.keys(grad.vectorized_axes)
+      assert :row in Keyword.keys(grad.vectorized_axes)
+    end
+
+    test "three different vectorized axes" do
+      x = Nx.tensor([[1.0, 2.0], [3.0, 4.0]]) |> Nx.vectorize(:a)
+      y = Nx.tensor([[10.0, 20.0], [30.0, 40.0], [50.0, 60.0]]) |> Nx.vectorize(:b)
+      z = Nx.tensor([[100.0, 200.0]]) |> Nx.vectorize(:c)
+      grad = Nx.Defn.grad(x, fn x -> Nx.sum(Nx.add(Nx.add(x, y), z)) end)
+      assert :a in Keyword.keys(grad.vectorized_axes)
+    end
+
+    test "two vectorized inputs through sin(add)" do
+      x = Nx.tensor([[1.0, 2.0], [3.0, 4.0]]) |> Nx.vectorize(:a)
+      y = Nx.tensor([[10.0, 20.0], [30.0, 40.0], [50.0, 60.0]]) |> Nx.vectorize(:b)
+
+      grad = Nx.Defn.grad(x, fn x -> Nx.sum(Nx.sin(Nx.add(x, y))) end)
+      assert grad.vectorized_axes == [a: 2, b: 3]
+    end
+
+    # --- value_and_grad ---
+
+    test "grad with differently-shaped vectorized and non-vectorized inputs" do
+      x = Nx.tensor([0, 1]) |> Nx.vectorize(:foo)
+      y = Nx.tensor(1.0)
+
+      {value, grad_y} = Nx.Defn.value_and_grad(y, fn y -> Nx.sum(Nx.add(x, y)) end)
+
+      assert value == Nx.tensor([1.0, 2.0]) |> Nx.vectorize(:foo)
+      assert grad_y == Nx.tensor([1.0, 1.0]) |> Nx.vectorize(:foo)
+    end
+
+    test "value_and_grad with vectorized target" do
+      x = Nx.tensor([0, 1, 2]) |> Nx.vectorize(:foo)
+      y = Nx.tensor(1)
+
+      {_value, grad_y} = Nx.Defn.value_and_grad(y, fn y -> Nx.add(x, y) end)
+
+      expected_grad = Nx.tensor([1.0, 1.0, 1.0]) |> Nx.vectorize(:foo)
+      assert grad_y == expected_grad
+    end
+
+    # --- Non-vectorized target (grad w.r.t. y where x is vectorized) ---
+
+    test "grad of non-vectorized target through multiply with vectorized" do
+      x = Nx.tensor([1.0, 2.0, 3.0]) |> Nx.vectorize(:batch)
+      y = Nx.tensor(2.0)
+
+      grad = Nx.Defn.grad(y, fn y -> Nx.sum(Nx.multiply(x, y)) end)
+
+      expected =
+        for val <- [1.0, 2.0, 3.0] do
+          Nx.Defn.grad(Nx.tensor(2.0), fn y -> Nx.sum(Nx.multiply(val, y)) end)
+        end
+        |> Nx.stack()
+        |> Nx.vectorize(:batch)
+
+      assert grad == expected
+    end
+
+    test "grad of non-vectorized target through sin with vectorized" do
+      x = Nx.tensor([0.5, 1.0, 1.5]) |> Nx.vectorize(:batch)
+      y = Nx.tensor(1.0)
+
+      grad = Nx.Defn.grad(y, fn y -> Nx.sum(Nx.sin(Nx.add(x, y))) end)
+
+      expected =
+        for val <- [0.5, 1.0, 1.5] do
+          Nx.Defn.grad(Nx.tensor(1.0), fn y -> Nx.sum(Nx.sin(Nx.add(val, y))) end)
+        end
+        |> Nx.stack()
+        |> Nx.vectorize(:batch)
+
+      assert grad == expected
+    end
+
+    test "grad of non-vectorized target where vectorized output is fully reduced" do
+      x = Nx.tensor([1.0, 2.0]) |> Nx.vectorize(:batch)
+      y = Nx.tensor(1.0)
+
+      grad = Nx.Defn.grad(y, fn y -> Nx.sum(Nx.multiply(x, y)) end)
+
+      expected = Nx.tensor([1.0, 2.0]) |> Nx.vectorize(:batch)
+      assert grad == expected
+    end
+
+    # --- Tuple grad ---
+
+    test "grad w.r.t. tuple of vectorized and non-vectorized" do
+      x = Nx.tensor([[1.0, 2.0], [3.0, 4.0]]) |> Nx.vectorize(:batch)
+      y = Nx.tensor(1.0)
+
+      {grad_x, grad_y} = Nx.Defn.grad({x, y}, fn {x, y} -> Nx.sum(Nx.add(x, y)) end)
+
+      expected_x =
+        for row <- [Nx.tensor([1.0, 2.0]), Nx.tensor([3.0, 4.0])] do
+          Nx.Defn.grad(row, fn r -> Nx.sum(Nx.add(r, 1.0)) end)
+        end
+        |> Nx.stack()
+        |> Nx.vectorize(:batch)
+
+      assert grad_x == expected_x
+      assert grad_y == Nx.tensor([2.0, 2.0]) |> Nx.vectorize(:batch)
+    end
+
+    # --- Large batch smoke test ---
+
+    test "large vectorized batch" do
+      x = Nx.iota({100, 4}, type: :f32) |> Nx.vectorize(:batch)
+      grad = Nx.Defn.grad(x, fn x -> Nx.sum(Nx.exp(x)) end)
+      assert grad.vectorized_axes == [batch: 100]
+      assert Nx.shape(grad) == {4}
     end
   end
 end

--- a/nx/test/nx/defn/vectorized_grad_test.exs
+++ b/nx/test/nx/defn/vectorized_grad_test.exs
@@ -1,0 +1,808 @@
+defmodule Nx.Defn.VectorizedGradTest do
+  @moduledoc """
+  Correctness tests for vectorized gradients.
+
+  For each operation, computes the gradient two ways:
+  1. Vectorized: grad on the full vectorized tensor
+  2. Per-element: grad on each batch element separately, then stack
+
+  If they don't match, there is a bug in the vectorized gradient machinery.
+  """
+  use ExUnit.Case, async: true
+
+  import Nx.Defn
+
+  @atol 1.0e-4
+
+  # ── Test helper ────────────────────────────────────────────────────
+
+  defp check_vectorized_grad(x_data, fun, opts \\ []) do
+    atol = opts[:atol] || @atol
+    batch_size = elem(Nx.shape(x_data), 0)
+    inner_shape = x_data.shape |> Tuple.to_list() |> tl() |> List.to_tuple()
+
+    x_vec = Nx.vectorize(x_data, :batch)
+    vec_grad = Nx.Defn.grad(x_vec, fun)
+    vec_grad_devec = Nx.devectorize(vec_grad, keep_names: false)
+
+    per_element_grads =
+      for i <- 0..(batch_size - 1) do
+        x_i = Nx.reshape(x_data[i], inner_shape)
+        Nx.Defn.grad(x_i, fun)
+      end
+
+    stacked = Nx.stack(per_element_grads)
+
+    for i <- 0..(batch_size - 1) do
+      vec_slice = vec_grad_devec[i] |> Nx.reshape(inner_shape)
+      elem_slice = stacked[i] |> Nx.reshape(inner_shape)
+
+      for {v, e} <- Enum.zip(Nx.to_flat_list(vec_slice), Nx.to_flat_list(elem_slice)) do
+        if v == :nan and e == :nan do
+          :ok
+        else
+          assert_in_delta v, e, atol, "Mismatch at batch #{i}: vec=#{v}, elem=#{e}"
+        end
+      end
+    end
+
+    :ok
+  end
+
+  # ── Unary ops ───────────────────────────────────────────────────────
+
+  describe "unary ops" do
+    test "exp" do
+      x = Nx.tensor([[0.5, 1.0, 1.5], [2.0, 0.3, 0.8], [1.2, 0.7, 0.1]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.exp(x)) end)
+    end
+
+    test "abs" do
+      x = Nx.tensor([[1.0, -2.0, 3.0], [-4.0, 5.0, -6.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.abs(x)) end)
+    end
+
+    test "negate" do
+      x = Nx.tensor([[1.0, -2.0, 3.0], [4.0, -5.0, 6.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.negate(x)) end)
+    end
+
+    test "sigmoid" do
+      x = Nx.tensor([[0.0, 1.0, -1.0], [2.0, -2.0, 0.5]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.sigmoid(x)) end)
+    end
+
+    test "cbrt" do
+      x = Nx.tensor([[1.0, 8.0, 27.0], [64.0, 125.0, 216.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.cbrt(x)) end)
+    end
+
+    test "expm1/log1p" do
+      x = Nx.tensor([[0.5, 1.0, 1.5], [2.0, 2.5, 3.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.log1p(Nx.expm1(x))) end)
+    end
+
+    test "pow(x, 3)" do
+      x = Nx.tensor([[1.0, 2.0], [3.0, 4.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.pow(x, 3)) end)
+    end
+
+    test "clip" do
+      x = Nx.tensor([[1.0, 5.0, 10.0], [0.5, 3.0, 8.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.clip(x, 2, 7)) end)
+    end
+
+    test "conjugate" do
+      x = Nx.tensor([[1.0, 2.0], [3.0, 4.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.conjugate(x)) end)
+    end
+
+    test "remainder" do
+      x = Nx.tensor([[5.0, 7.0, 9.0], [11.0, 13.0, 15.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.remainder(x, 3)) end)
+    end
+
+    test "as_type" do
+      x = Nx.tensor([[1.0, 2.0], [3.0, 4.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.as_type(x, :f64)) end)
+    end
+
+    test "trig functions" do
+      x = Nx.tensor([[0.5, -0.3, 0.8], [0.1, -0.5, 0.2]], type: :f32)
+      x_pos = Nx.tensor([[1.5, 2.0, 3.0], [4.0, 5.0, 6.0]], type: :f32)
+
+      for {_name, fun, input} <- [
+            {:acos, fn x -> Nx.sum(Nx.acos(x)) end, x},
+            {:acosh, fn x -> Nx.sum(Nx.acosh(x)) end, x_pos},
+            {:asin, fn x -> Nx.sum(Nx.asin(x)) end, x},
+            {:asinh, fn x -> Nx.sum(Nx.asinh(x)) end, x},
+            {:atan, fn x -> Nx.sum(Nx.atan(x)) end, x},
+            {:atanh, fn x -> Nx.sum(Nx.atanh(x)) end, x},
+            {:cos, fn x -> Nx.sum(Nx.cos(x)) end, x},
+            {:cosh, fn x -> Nx.sum(Nx.cosh(x)) end, x},
+            {:sinh, fn x -> Nx.sum(Nx.sinh(x)) end, x},
+            {:tanh, fn x -> Nx.sum(Nx.tanh(x)) end, x},
+            {:sin, fn x -> Nx.sum(Nx.sin(x)) end, x},
+            {:tan, fn x -> Nx.sum(Nx.tan(x)) end, x}
+          ] do
+        check_vectorized_grad(input, fun)
+      end
+    end
+
+    test "math functions" do
+      x_pos = Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], type: :f32)
+      x = Nx.tensor([[0.5, -0.3, 0.8], [0.1, -0.5, 0.2]], type: :f32)
+
+      for {_name, fun, input} <- [
+            {:erf, fn x -> Nx.sum(Nx.erf(x)) end, x},
+            {:erfc, fn x -> Nx.sum(Nx.erfc(x)) end, x},
+            {:erf_inv, fn x -> Nx.sum(Nx.erf_inv(x)) end, x},
+            {:rsqrt, fn x -> Nx.sum(Nx.rsqrt(x)) end, x_pos},
+            {:sqrt, fn x -> Nx.sum(Nx.sqrt(x)) end, x_pos},
+            {:log, fn x -> Nx.sum(Nx.log(x)) end, x_pos},
+            {:exp, fn x -> Nx.sum(Nx.exp(x)) end, x}
+          ] do
+        check_vectorized_grad(input, fun)
+      end
+    end
+
+    test "atan2" do
+      x = Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.atan2(x, Nx.tensor(1.0))) end)
+    end
+  end
+
+  # ── Binary ops ──────────────────────────────────────────────────────
+
+  describe "binary ops" do
+    test "multiply then sum" do
+      x = Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.multiply(x, x)) end)
+    end
+
+    test "add with scalar" do
+      x = Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.add(x, 10.0)) end)
+    end
+
+    test "multiply with broadcast" do
+      x = Nx.tensor([[1.0, 2.0], [3.0, 4.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.multiply(x, Nx.tensor([2.0, 3.0]))) end)
+    end
+
+    test "divide and subtract" do
+      x = Nx.tensor([[0.5, -0.3, 0.8], [0.1, -0.5, 0.2]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.divide(x, 2.0)) end)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.subtract(x, 0.5)) end)
+    end
+
+    test "chained binary ops" do
+      x = Nx.tensor([[1.0, 2.0], [3.0, 4.0]], type: :f32)
+
+      check_vectorized_grad(x, fn x ->
+        Nx.sum(Nx.divide(Nx.add(Nx.multiply(x, x), x), Nx.add(x, 1)))
+      end)
+    end
+
+    # Exercises broadcast_vectors alignment for mixed vectorized/non-vectorized
+    test "mixed: vectorized x * non-vectorized y" do
+      y = Nx.tensor([10.0, 20.0, 30.0], type: :f32)
+      x = Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.multiply(x, y)) end)
+    end
+  end
+
+  # ── Reductions ──────────────────────────────────────────────────────
+
+  describe "reductions" do
+    test "sum" do
+      x = Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], type: :f32)
+      check_vectorized_grad(x, &Nx.sum/1)
+    end
+
+    test "mean" do
+      x = Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], type: :f32)
+      check_vectorized_grad(x, &Nx.mean/1)
+    end
+
+    test "product" do
+      x = Nx.tensor([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0]], type: :f32)
+      check_vectorized_grad(x, &Nx.product/1)
+    end
+
+    test "reduce_max" do
+      x = Nx.tensor([[1.0, 3.0, 2.0], [6.0, 4.0, 5.0]], type: :f32)
+      check_vectorized_grad(x, &Nx.reduce_max/1)
+    end
+
+    test "reduce_min" do
+      x = Nx.tensor([[3.0, 1.0, 2.0], [4.0, 6.0, 5.0]], type: :f32)
+      check_vectorized_grad(x, &Nx.reduce_min/1)
+    end
+
+    test "composed reduction: sum(x * x)" do
+      x = Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.multiply(x, x)) end)
+    end
+
+    # Exercises reduce_g fix for partial axis reduction with vectorized tensors
+    test "sum axis 0 on 2D inner" do
+      x =
+        Nx.tensor(
+          [
+            [[1.0, 2.0], [3.0, 4.0]],
+            [[5.0, 6.0], [7.0, 8.0]],
+            [[9.0, 10.0], [11.0, 12.0]]
+          ],
+          type: :f32
+        )
+
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.sum(x, axes: [0])) end)
+    end
+
+    test "sum with negative axis" do
+      x = Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(x, axes: [-1]) end)
+    end
+
+    test "sum with named axis" do
+      # Named axis sum works; uses inline comparison since check_vectorized_grad
+      # loses dimension names when slicing per-element.
+      x =
+        Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], names: [nil, :features])
+        |> Nx.vectorize(:batch)
+
+      grad = Nx.Defn.grad(x, fn x -> Nx.sum(x, axes: [:features]) end)
+      assert grad.vectorized_axes == [batch: 2]
+    end
+
+    # Exercises cumulative_sum axis name collision fix in revectorize_node
+    test "cumulative_sum" do
+      x = Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.cumulative_sum(x)) end)
+    end
+
+    test "partial axis reduction on 2D inner - axis 0" do
+      x = Nx.tensor([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(x, axes: [0]) |> Nx.sum() end)
+    end
+
+    test "partial axis reduction on 2D inner - axis 1" do
+      x = Nx.tensor([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(x, axes: [1]) |> Nx.sum() end)
+    end
+
+    test "partial axis reduction on 3D inner - non-zero axis" do
+      x = Nx.tensor([[[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(x, axes: [1]) |> Nx.sum() end)
+    end
+
+    test "product partial axis reduction on 2D inner - axis 1" do
+      x = Nx.tensor([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.product(x, axes: [1]) |> Nx.sum() end)
+    end
+
+    test "reduce_min then sum" do
+      x = Nx.tensor([[3.0, 1.0, 2.0], [6.0, 4.0, 5.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.reduce_min(x)) end)
+    end
+
+    test "argsort" do
+      x = Nx.tensor([[3.0, 1.0, 2.0], [6.0, 4.0, 5.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.multiply(x, Nx.argsort(x))) end)
+    end
+  end
+
+  # ── Shape ops ───────────────────────────────────────────────────────
+
+  describe "shape ops" do
+    test "transpose" do
+      x = Nx.tensor([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.transpose(x)) end)
+    end
+
+    test "squeeze" do
+      x = Nx.tensor([[[1.0], [2.0], [3.0]], [[4.0], [5.0], [6.0]]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.squeeze(x)) end)
+    end
+
+    test "broadcast" do
+      x = Nx.tensor([[1.0, 2.0], [3.0, 4.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.broadcast(x, {3, 2})) end)
+    end
+
+    # Exercises grad(:reshape) boundary crossing between vectorized/devectorized
+    test "reshape inside grad" do
+      x =
+        Nx.tensor(
+          [
+            [[1.0, 2.0], [3.0, 4.0]],
+            [[5.0, 6.0], [7.0, 8.0]],
+            [[9.0, 10.0], [11.0, 12.0]]
+          ],
+          type: :f32
+        )
+
+      check_vectorized_grad(x, fn x ->
+        Nx.sum(Nx.transpose(Nx.reshape(x, {4})))
+      end)
+    end
+
+    test "reshape" do
+      x =
+        Nx.tensor([[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [7.0, 8.0, 9.0, 10.0, 11.0, 12.0]], type: :f32)
+
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.reshape(x, {2, 3})) end)
+    end
+
+    test "reverse" do
+      x = Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.reverse(x)) end)
+    end
+
+    test "new_axis" do
+      x = Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.new_axis(x, 0)) end)
+    end
+
+    test "tile" do
+      x = Nx.tensor([[1.0, 2.0], [3.0, 4.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.tile(x, [2])) end)
+    end
+
+    test "transpose with 2D inner shape" do
+      x =
+        Nx.tensor(
+          [
+            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
+            [[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]]
+          ],
+          type: :f32
+        )
+
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.multiply(Nx.transpose(x), 2.0)) end)
+    end
+  end
+
+  # ── Indexing ops ────────────────────────────────────────────────────
+
+  describe "indexing ops" do
+    test "slice" do
+      x = Nx.tensor([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.slice(x, [1], [2])) end)
+    end
+
+    test "slice at different positions" do
+      x = Nx.tensor([[1.0, 2.0, 3.0, 4.0, 5.0], [6.0, 7.0, 8.0, 9.0, 10.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.slice(x, [2], [3])) end)
+    end
+
+    test "take" do
+      x = Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.take(x, Nx.tensor([0, 2]))) end)
+    end
+
+    test "gather" do
+      x = Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.gather(x, Nx.tensor([[0], [2]]))) end)
+    end
+
+    test "gather with multiple indices" do
+      x = Nx.tensor([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.gather(x, Nx.tensor([[0], [1], [3]]))) end)
+    end
+
+    test "gather with 2D inner shape" do
+      x =
+        Nx.tensor(
+          [
+            [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]],
+            [[7.0, 8.0], [9.0, 10.0], [11.0, 12.0]]
+          ],
+          type: :f32
+        )
+
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.gather(x, Nx.tensor([[0], [2]]))) end)
+    end
+
+    test "gather with power" do
+      x = Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], type: :f32)
+
+      check_vectorized_grad(x, fn x ->
+        x |> Nx.pow(2) |> Nx.gather(Nx.tensor([[0], [2]])) |> Nx.sum()
+      end)
+    end
+
+    test "take_along_axis" do
+      x = Nx.tensor([[3.0, 1.0, 2.0], [6.0, 4.0, 5.0]], type: :f32)
+      idx = Nx.tensor([2, 0, 1])
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.take_along_axis(x, idx, axis: 0)) end)
+    end
+
+    test "put_slice" do
+      x = Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.put_slice(x, [0], Nx.tensor([99.0]))) end)
+    end
+
+    test "indexed_add" do
+      x = Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], type: :f32)
+
+      check_vectorized_grad(x, fn x ->
+        Nx.sum(Nx.indexed_add(x, Nx.tensor([[0]]), Nx.tensor([10.0])))
+      end)
+    end
+
+    test "indexed_put" do
+      x = Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], type: :f32)
+
+      check_vectorized_grad(x, fn x ->
+        Nx.sum(Nx.indexed_put(x, Nx.tensor([[1]]), Nx.tensor([99.0])))
+      end)
+    end
+
+    test "sort" do
+      x = Nx.tensor([[3.0, 1.0, 2.0], [6.0, 4.0, 5.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.sort(x)) end)
+    end
+
+    test "sort with negative axis" do
+      x = Nx.tensor([[3.0, 1.0, 2.0], [6.0, 4.0, 5.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.sort(x, axis: -1)) end)
+    end
+  end
+
+  # ── Concatenate / stack ─────────────────────────────────────────────
+
+  describe "concatenate and stack" do
+    # Exercises concatenate grad axis offset for devectorized shapes
+    test "concatenate" do
+      x = Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]], type: :f32)
+
+      check_vectorized_grad(x, fn x ->
+        Nx.sum(Nx.concatenate([x, Nx.multiply(x, 2)], axis: 0))
+      end)
+    end
+
+    test "concatenate self" do
+      x = Nx.tensor([[1.0, 2.0], [3.0, 4.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.concatenate([x, x])) end)
+    end
+
+    test "concatenate with constant" do
+      x = Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], type: :f32)
+
+      check_vectorized_grad(x, fn x ->
+        Nx.sum(Nx.concatenate([x, Nx.tensor([0.0, 0.0, 0.0])]))
+      end)
+    end
+
+    test "stack" do
+      x = Nx.tensor([[1.0, 2.0], [3.0, 4.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.stack([x, Nx.multiply(x, 2)])) end)
+    end
+  end
+
+  # ── Pad ─────────────────────────────────────────────────────────────
+
+  describe "pad" do
+    test "pad" do
+      x = Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.pad(x, 0.0, [{1, 1, 0}])) end)
+    end
+
+    test "pad then sum" do
+      x = Nx.tensor([[1.0, 2.0], [3.0, 4.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.pad(x, 0.0, [{1, 1, 0}])) end)
+    end
+  end
+
+  # ── Window ops ──────────────────────────────────────────────────────
+
+  describe "window ops" do
+    # Exercises window_scatter adjust_vectorized_args
+    test "window_sum" do
+      x =
+        Nx.tensor(
+          [
+            [[1.0, 2.0, 3.0, 4.0]],
+            [[5.0, 6.0, 7.0, 8.0]],
+            [[-1.0, 0.0, 1.0, 2.0]]
+          ],
+          type: :f32
+        )
+
+      check_vectorized_grad(x, fn x ->
+        Nx.sum(Nx.window_sum(x, {1, 2}))
+      end)
+    end
+
+    test "window_sum 1D" do
+      x = Nx.tensor([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.window_sum(x, {2}, strides: [1])) end)
+    end
+
+    test "window_max" do
+      x = Nx.tensor([[1.0, 3.0, 2.0, 4.0], [5.0, 7.0, 6.0, 8.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.window_max(x, {2})) end)
+    end
+
+    test "window_min" do
+      x = Nx.tensor([[4.0, 2.0, 3.0, 1.0], [8.0, 6.0, 7.0, 5.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.window_min(x, {2})) end)
+    end
+  end
+
+  # ── Dot / matmul ────────────────────────────────────────────────────
+
+  describe "dot" do
+    test "dot with weight vector" do
+      x = Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], type: :f32)
+      w = Nx.tensor([0.5, -1.0, 2.0])
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.dot(x, w)) end)
+    end
+
+    test "dot then sum" do
+      x = Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], type: :f32)
+      w = Nx.tensor([[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]])
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.dot(x, w)) end)
+    end
+
+    test "dot with 2D inner shape" do
+      x = Nx.tensor([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]], type: :f32)
+      w = Nx.tensor([0.5, -1.0])
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.dot(x, w)) end)
+    end
+
+    # Exercises captured concrete tensor handling in parents_args
+    test "dot with captured matrix" do
+      w = Nx.tensor([[1.0, 2.0], [3.0, 4.0]], type: :f32)
+
+      check_vectorized_grad(
+        Nx.tensor(
+          [
+            [[1.0, 2.0], [3.0, 4.0]],
+            [[5.0, 6.0], [7.0, 8.0]],
+            [[9.0, 10.0], [11.0, 12.0]]
+          ],
+          type: :f32
+        ),
+        fn x -> Nx.sum(Nx.dot(x, w)) end
+      )
+    end
+  end
+
+  # ── Select ──────────────────────────────────────────────────────────
+
+  describe "select" do
+    test "select (conditional)" do
+      x = Nx.tensor([[1.0, -2.0, 3.0], [-1.0, 2.0, -3.0]], type: :f32)
+
+      check_vectorized_grad(x, fn x ->
+        Nx.sum(Nx.select(Nx.greater(x, 0), x, Nx.negate(x)))
+      end)
+    end
+  end
+
+  # ── Composed chains ─────────────────────────────────────────────────
+
+  describe "composed chains" do
+    test "transpose then squeeze then sum" do
+      x = Nx.tensor([[[1.0], [2.0]], [[3.0], [4.0]]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.squeeze(Nx.transpose(x))) end)
+    end
+
+    # Exercises captured concrete tensor in Expr.parameter and parents_args
+    test "captured concrete tensor in dot" do
+      w = Nx.tensor([1.0, 2.0, 3.0], type: :f32)
+      x = Nx.tensor([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.dot(x, w) end)
+    end
+
+    # Exercises composed op chain with captured tensors through multiple grad rules
+    test "sigmoid(x @ w + b)" do
+      w = Nx.tensor([[0.5, -0.3], [0.2, 0.8]], type: :f32)
+      b = Nx.tensor([0.1, -0.1], type: :f32)
+      x = Nx.tensor([[1.0, 2.0], [3.0, 4.0], [-1.0, 0.5]], type: :f32)
+
+      check_vectorized_grad(x, fn x ->
+        Nx.sum(Nx.sigmoid(Nx.add(Nx.dot(x, w), b)))
+      end)
+    end
+
+    test "captured constant" do
+      w = Nx.tensor([2.0, 3.0])
+      x = Nx.tensor([[1.0, 2.0], [3.0, 4.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.multiply(x, w)) end)
+    end
+
+    test "captured matrix" do
+      w = Nx.tensor([[0.5, -0.3], [0.2, 0.8]])
+      x = Nx.tensor([[1.0, 2.0], [3.0, 4.0]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.dot(x, w)) end)
+    end
+
+    test "multiple same-axis inputs, grad wrt one" do
+      # Both x and w share axis :a; can't use check_vectorized_grad since
+      # it only handles single-input vectorization.
+      x = Nx.tensor([[1.0, 2.0], [3.0, 4.0]]) |> Nx.vectorize(:a)
+      w = Nx.tensor([[0.5, 0.3], [0.2, 0.4]]) |> Nx.vectorize(:a)
+      grad = Nx.Defn.grad(x, fn x -> Nx.sum(Nx.multiply(x, w)) end)
+      assert grad.vectorized_axes == [a: 2]
+      expected = Nx.tensor([[0.5, 0.3], [0.2, 0.4]]) |> Nx.vectorize(:a)
+      assert Nx.devectorize(grad) == Nx.devectorize(expected)
+    end
+  end
+
+  # ── FFT ─────────────────────────────────────────────────────────────
+
+  describe "fft" do
+    # FFT/IFFT produce complex outputs; check_vectorized_grad's assert_in_delta
+    # can't handle complex numbers, so we use shape-only assertions.
+    test "fft" do
+      x = Nx.tensor([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]]) |> Nx.vectorize(:batch)
+      grad = Nx.Defn.grad(x, fn x -> Nx.sum(Nx.real(Nx.fft(x))) end)
+      assert grad.vectorized_axes == [batch: 2]
+    end
+
+    test "ifft" do
+      x = Nx.tensor([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]]) |> Nx.vectorize(:batch)
+      grad = Nx.Defn.grad(x, fn x -> Nx.sum(Nx.real(Nx.ifft(Nx.as_type(x, :c64)))) end)
+      assert grad.vectorized_axes == [batch: 2]
+    end
+  end
+
+  # ── Conv ────────────────────────────────────────────────────────────
+
+  describe "conv" do
+    # Exercises grad_conv devectorize fix: the conv collapse/uncollapse chain
+    # bakes the vectorized dim into batch_group_size
+    test "conv with vectorized" do
+      k = Nx.tensor([[[1.0, 0.0, -1.0]]])
+      x = Nx.tensor([[[[1.0, 2.0, 3.0, 4.0]]], [[[5.0, 6.0, 7.0, 8.0]]]], type: :f32)
+      check_vectorized_grad(x, fn x -> Nx.sum(Nx.conv(x, k)) end)
+    end
+  end
+
+  # ── Linalg ──────────────────────────────────────────────────────────
+
+  describe "linalg" do
+    # Exercises Cholesky batch_transpose and matmul helpers
+    test "cholesky grad" do
+      x =
+        Nx.tensor(
+          [
+            [[4.0, 2.0], [2.0, 5.0]],
+            [[9.0, 3.0], [3.0, 5.0]],
+            [[16.0, 4.0], [4.0, 8.0]]
+          ],
+          type: :f32
+        )
+
+      check_vectorized_grad(x, fn x ->
+        l = Nx.LinAlg.cholesky(x)
+        Nx.sum(l)
+      end)
+    end
+
+    # Exercises triangular_solve batched_dot helper
+    test "triangular_solve grad with captured a" do
+      a = Nx.tensor([[1.0, 0.0], [2.0, 3.0]], type: :f32)
+
+      check_vectorized_grad(
+        Nx.tensor([[4.0, 5.0], [2.0, 3.0], [1.0, 1.0]], type: :f32),
+        fn b -> Nx.sum(Nx.LinAlg.triangular_solve(a, b)) end
+      )
+    end
+
+    test "triangular_solve with vectorized a and b" do
+      # Both a and b are vectorized; can't use check_vectorized_grad since
+      # the helper only handles single-input vectorization.
+      a = Nx.tensor([[[1.0, 0.0], [2.0, 3.0]], [[1.0, 0.0], [1.0, 1.0]]]) |> Nx.vectorize(:batch)
+      b = Nx.tensor([[4.0, 5.0], [2.0, 3.0]]) |> Nx.vectorize(:batch)
+      grad = Nx.Defn.grad(b, fn b -> Nx.sum(Nx.LinAlg.triangular_solve(a, b)) end)
+      assert grad.vectorized_axes == [batch: 2]
+    end
+
+    test "qr grad" do
+      x = Nx.tensor([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]], type: :f32)
+
+      check_vectorized_grad(x, fn x ->
+        {q, r} = Nx.LinAlg.qr(x)
+        Nx.sum(Nx.dot(q, r))
+      end)
+    end
+  end
+
+  # ── While / cond ────────────────────────────────────────────────────
+
+  describe "control flow" do
+    defn while_square_n(x) do
+      {_i, result} =
+        while {i = 0, x}, Nx.less(i, 3) do
+          {i + 1, Nx.multiply(x, x)}
+        end
+
+      Nx.sum(result)
+    end
+
+    # Exercises update_grads(:while) devectorize at boundary (approach C)
+    test "while loop: repeated squaring" do
+      x = Nx.tensor([[0.5, 0.8], [1.2, 0.3], [0.9, 0.4]], type: :f32)
+      check_vectorized_grad(x, &while_square_n/1)
+    end
+
+    defn cond_grad_fn(x) do
+      s = Nx.sum(x)
+
+      if Nx.greater(s, 0) do
+        Nx.multiply(s, s)
+      else
+        Nx.negate(s)
+      end
+    end
+
+    # Exercises cond clean_grads fix: prevents cross-contamination between
+    # cond_then/cond_else nodes in vectorized cond
+    test "cond with vectorized input" do
+      x = Nx.tensor([[2.0, 3.0], [-5.0, -6.0], [1.0, 1.0]], type: :f32)
+      check_vectorized_grad(x, &cond_grad_fn/1)
+    end
+  end
+
+  # ── Multi-axis vectorization ────────────────────────────────────────
+
+  describe "multi-axis vectorization" do
+    test "sum" do
+      x = Nx.tensor([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]], type: :f32)
+
+      x_vec = x |> Nx.vectorize(:batch) |> Nx.vectorize(:seq)
+      vec_grad = Nx.Defn.grad(x_vec, &Nx.sum/1)
+      vec_devec = Nx.devectorize(vec_grad, keep_names: false)
+
+      for i <- 0..1, j <- 0..1 do
+        x_ij = x[i][j] |> Nx.reshape({2})
+        elem_grad = Nx.Defn.grad(x_ij, &Nx.sum/1)
+
+        for {v, e} <- Enum.zip(Nx.to_flat_list(vec_devec[i][j]), Nx.to_flat_list(elem_grad)) do
+          assert_in_delta v, e, @atol
+        end
+      end
+    end
+
+    test "product" do
+      x = Nx.tensor([[[1.0, 2.0], [3.0, 4.0]], [[2.0, 3.0], [4.0, 5.0]]], type: :f32)
+
+      x_vec = x |> Nx.vectorize(:batch) |> Nx.vectorize(:seq)
+      vec_grad = Nx.Defn.grad(x_vec, &Nx.product/1)
+      vec_devec = Nx.devectorize(vec_grad, keep_names: false)
+
+      for i <- 0..1, j <- 0..1 do
+        x_ij = x[i][j] |> Nx.reshape({2})
+        elem_grad = Nx.Defn.grad(x_ij, &Nx.product/1)
+
+        for {v, e} <- Enum.zip(Nx.to_flat_list(vec_devec[i][j]), Nx.to_flat_list(elem_grad)) do
+          assert_in_delta v, e, @atol
+        end
+      end
+    end
+
+    # Exercises unbroadcast fix for multiple different vectorized axes
+    test "two vectorized axes" do
+      x = Nx.tensor([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]], type: :f32)
+
+      x_vec = x |> Nx.vectorize(:a) |> Nx.vectorize(:b)
+      vec_grad = Nx.Defn.grad(x_vec, fn x -> Nx.sum(Nx.multiply(x, x)) end)
+      vec_devec = Nx.devectorize(vec_grad, keep_names: false)
+
+      for i <- 0..1, j <- 0..1 do
+        x_ij = x[i][j] |> Nx.reshape({2})
+        elem_grad = Nx.Defn.grad(x_ij, fn x -> Nx.sum(Nx.multiply(x, x)) end)
+
+        for {v, e} <-
+              Enum.zip(Nx.to_flat_list(vec_devec[i][j]), Nx.to_flat_list(elem_grad)) do
+          assert_in_delta v, e, @atol
+        end
+      end
+    end
+  end
+end

--- a/nx/test/support/helpers.ex
+++ b/nx/test/support/helpers.ex
@@ -23,8 +23,15 @@ defmodule Nx.Helpers do
     atol = opts[:atol] || 1.0e-4
     rtol = opts[:rtol] || 1.0e-4
 
-    unless Nx.all_close(lhs, rhs, atol: atol, rtol: rtol, equal_nan: opts[:equal_nan]) ==
-             Nx.tensor(1, type: {:u, 8}) do
+    close =
+      lhs
+      |> Nx.all_close(rhs, atol: atol, rtol: rtol, equal_nan: opts[:equal_nan])
+      |> Nx.devectorize(keep_names: false)
+      |> Nx.backend_transfer(Nx.BinaryBackend)
+      |> Nx.to_flat_list()
+      |> Enum.all?(&(&1 == 1))
+
+    unless close do
       flunk("""
       expected
 
@@ -38,7 +45,15 @@ defmodule Nx.Helpers do
   end
 
   defp assert_all_close(lhs, rhs, x, atol, rtol) do
-    unless Nx.all_close(lhs, rhs, atol: atol, rtol: rtol) == Nx.tensor(1, type: {:u, 8}) do
+    close =
+      lhs
+      |> Nx.all_close(rhs, atol: atol, rtol: rtol)
+      |> Nx.devectorize(keep_names: false)
+      |> Nx.backend_transfer(Nx.BinaryBackend)
+      |> Nx.to_flat_list()
+      |> Enum.all?(&(&1 == 1))
+
+    unless close do
       flunk("""
       expected
 


### PR DESCRIPTION
fixes #1533

## Summary

Makes `Nx.Defn.grad` work correctly with vectorized tensors. The grad system now re-vectorizes expression tree nodes during the backward pass and adjusts per-op options (axes, padding, strides, etc.) to account for vectorized dimensions.

Key changes:

  - **Re-vectorization in backward pass**: `recur_to_grad` tracks vectorized axis names through `parents_tree` and re-vectorizes args/ans during gradient computation. `adjust_vectorized_args` handles ~20 ops.

  - **apply_vectorized boundaries**: Operations like `cumulative_sum`, `triangular_solve`, etc. use `apply_vectorized` internally, creating a devectorized region in the expression tree. The grad system detects these boundaries (in `parents_args(:optional)` and `update_grads(:optional)`) and stops propagating vectorized names / devectorizes gradients at the boundary.

  - **Cond fix**: Vectorized `cond` creates separate cond_then/cond_else nodes sharing the same to_grad variables. Prevents cross-contamination by cleaning to_grad entries before each clause's inner computation.

  - **Conv fix**: When conv collapses the vectorized dim into `batch_group_size`, devectorizes args/ans in `grad_conv` since the vectorized dim is already in the batch.

  - **Batched linalg helpers**: QR, Cholesky, and triangular_solve grads now use batch-aware matmul helpers for 3D+ tensors.

  - **Concrete tensor handling**: `parents_args` and `Expr.parameter` handle non-Expr tensors captured in grad closures.

  - **`assert_all_close` fix**: Test helper now devectorizes before comparing.

  ## Test plan

  - 346 tests pass (118 new), 0 failures
  - `vectorized_grad_test.exs`: 91 correctness tests comparing vectorized grad vs per-element grad across all supported ops
  - `grad_test.exs`: 27 edge case tests (vectorize/devectorize inside grad body, non-vectorized target, error messages, window_scatter, second-order grad, tuple grad)
  - Full Nx suite: 2,692 tests pass
