### PR TITLE
Warn when closure-captured tensors cause recompilation storms

### DIFF
--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -486,9 +486,37 @@ defmodule EXLA.Defn do
         :telemetry.execute([:exla, :compilation], measurements, %{key: key})
       end
 
+      if evaled, do: check_recompilation(key, args_key)
+
       outfeed = Outfeed.with_user_hooks(outfeed, hooks)
       {executable, {used_inputs, outputs, outfeed, inputs_and_typespecs}}
     end)
+  end
+
+  @recompilation_threshold 10
+
+  defp check_recompilation(key, args_key) do
+    {:module, mod} = :erlang.fun_info(key, :module)
+    {:new_index, idx} = :erlang.fun_info(key, :new_index)
+    counter_key = {:recompilation, {mod, idx}, args_key}
+
+    count =
+      :ets.update_counter(
+        EXLA.Defn.LockedCache,
+        counter_key,
+        {2, 1},
+        {counter_key, 0}
+      )
+
+    if count == @recompilation_threshold do
+      Logger.warning(
+        "EXLA has compiled the same function #{count} times with the same input " <>
+          "shapes. This typically means tensor values are being captured inside a " <>
+          "closure passed to defn, jit, or value_and_grad. Each distinct captured " <>
+          "value forces a full recompilation. Pass changing tensors as explicit " <>
+          "function arguments instead."
+      )
+    end
   end
 
   defp us_to_ms(time), do: Float.round(time / 1000, 1)

--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -486,7 +486,7 @@ defmodule EXLA.Defn do
         :telemetry.execute([:exla, :compilation], measurements, %{key: key})
       end
 
-      if evaled, do: check_recompilation(key, args_key)
+      if evaled && cache, do: check_recompilation(key, args_key)
 
       outfeed = Outfeed.with_user_hooks(outfeed, hooks)
       {executable, {used_inputs, outputs, outfeed, inputs_and_typespecs}}
@@ -498,19 +498,11 @@ defmodule EXLA.Defn do
   defp check_recompilation(key, args_key) do
     {:module, mod} = :erlang.fun_info(key, :module)
     {:new_index, idx} = :erlang.fun_info(key, :new_index)
-    counter_key = {:recompilation, {mod, idx}, args_key}
-
-    count =
-      :ets.update_counter(
-        EXLA.Defn.LockedCache,
-        counter_key,
-        {2, 1},
-        {counter_key, 0}
-      )
+    count = EXLA.Defn.LockedCache.count({mod, idx, args_key})
 
     if count == @recompilation_threshold do
       Logger.warning(
-        "EXLA has compiled the same function #{count} times with the same input " <>
+        "EXLA has compiled #{inspect(key)} #{count} times with the same input " <>
           "shapes. This typically means tensor values are being captured inside a " <>
           "closure passed to defn, jit, or value_and_grad. Each distinct captured " <>
           "value forces a full recompilation. Pass changing tensors as explicit " <>

--- a/exla/lib/exla/defn/locked_cache.ex
+++ b/exla/lib/exla/defn/locked_cache.ex
@@ -22,6 +22,13 @@ defmodule EXLA.Defn.LockedCache do
   end
 
   @doc """
+  Atomically increments and returns a counter for the given key.
+  """
+  def count(key) do
+    :ets.update_counter(@name, {:counter, key}, {2, 1}, {{:counter, key}, 0})
+  end
+
+  @doc """
   Reads cache key or executes the given function if not
   cached yet.
   """

--- a/exla/test/exla/defn/recompilation_warning_test.exs
+++ b/exla/test/exla/defn/recompilation_warning_test.exs
@@ -5,7 +5,7 @@ defmodule EXLA.Defn.RecompilationWarningTest do
 
   setup do
     # Clear any recompilation counters from previous tests
-    :ets.match_delete(EXLA.Defn.LockedCache, {{:recompilation, :_, :_}, :_})
+    :ets.match_delete(EXLA.Defn.LockedCache, {{:counter, {:_, :_, :_}}, :_})
     :ok
   end
 
@@ -19,7 +19,7 @@ defmodule EXLA.Defn.RecompilationWarningTest do
         end
       end)
 
-    assert log =~ "EXLA has compiled the same function"
+    assert log =~ "EXLA has compiled"
     assert log =~ "same input shapes"
     assert log =~ "Pass changing tensors as explicit function arguments"
   end
@@ -33,7 +33,7 @@ defmodule EXLA.Defn.RecompilationWarningTest do
         end
       end)
 
-    refute log =~ "EXLA has compiled the same function"
+    refute log =~ "EXLA has compiled"
   end
 
   test "does not warn for different input shapes" do
@@ -45,6 +45,6 @@ defmodule EXLA.Defn.RecompilationWarningTest do
         end
       end)
 
-    refute log =~ "EXLA has compiled the same function"
+    refute log =~ "EXLA has compiled"
   end
 end

--- a/exla/test/exla/defn/recompilation_warning_test.exs
+++ b/exla/test/exla/defn/recompilation_warning_test.exs
@@ -1,0 +1,50 @@
+defmodule EXLA.Defn.RecompilationWarningTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  setup do
+    # Clear any recompilation counters from previous tests
+    :ets.match_delete(EXLA.Defn.LockedCache, {{:recompilation, :_, :_}, :_})
+    :ok
+  end
+
+  test "warns for closure capturing different tensor values with same shape" do
+    log =
+      capture_log(fn ->
+        for i <- 1..11 do
+          t = Nx.tensor([i, i, i])
+          fun = fn -> Nx.multiply(t, t) end
+          Nx.Defn.jit_apply(fun, [], compiler: EXLA)
+        end
+      end)
+
+    assert log =~ "EXLA has compiled the same function"
+    assert log =~ "same input shapes"
+    assert log =~ "Pass changing tensors as explicit function arguments"
+  end
+
+  test "does not warn for stable functions" do
+    log =
+      capture_log(fn ->
+        for _i <- 1..15 do
+          t = Nx.tensor([1, 2, 3])
+          Nx.Defn.jit_apply(&Nx.multiply/2, [t, t], compiler: EXLA)
+        end
+      end)
+
+    refute log =~ "EXLA has compiled the same function"
+  end
+
+  test "does not warn for different input shapes" do
+    log =
+      capture_log(fn ->
+        for i <- 1..15 do
+          t = Nx.iota({i})
+          Nx.Defn.jit_apply(&Nx.multiply(&1, &1), [t], compiler: EXLA)
+        end
+      end)
+
+    refute log =~ "EXLA has compiled the same function"
+  end
+end


### PR DESCRIPTION
## Summary

When a non-scalar tensor with 10 or more elements is used as a constant inside a defn expression, this change emits a `Logger.warning` during graph construction. The warning explains that constants are embedded into the computation graph and will force recompilation if their values change between calls.

This lives entirely in Nx core (`Nx.Defn.Expr` and `Nx.Defn.Compiler`). No changes to EXLA.

The original version of this PR used an ETS-based recompilation counter in EXLA. Based on review feedback, I moved the check upstream to where constants actually enter the graph. This catches all sources of tensor constants (closure captures, deftransform, anything that flows through `to_expr`), not just the closure capture case.

## How it works

In `Nx.Defn.Expr.to_expr/1`, when a `BinaryBackend` tensor with non-scalar shape and 10+ elements is converted to a `:tensor` expression node, the warning fires. A process dictionary flag limits it to once per trace. The flag is saved and restored in `Nx.Defn.Compiler.runtime_fun/3` so that nested jit calls do not interfere with the outer trace's state.

The 10-element threshold avoids warning on small intentional constants like masks or indices. The warning message notes that intentionally constant tensors can be safely ignored.

## Test plan

- [x] Warning fires when a large tensor is used as a constant in a closure
- [x] No warning for scalar constants
- [x] No warning for small tensor constants (below threshold)
- [x] No warning when tensors are passed as function arguments
- [x] Only one warning per trace, even with multiple large constants
- [x] Full `mix test` passes in both `nx` and `exla`

Closes #1714