### PR TITLE
Enforce :safe in Nx.deserialize and EXLA disk cache deserialization

### DIFF
--- a/exla/lib/exla/defn/disk.ex
+++ b/exla/lib/exla/defn/disk.ex
@@ -12,7 +12,7 @@ defmodule EXLA.Defn.Disk do
     cached =
       case File.read(cache) do
         {:ok, <<"EXLA", @version, blob::binary>>} ->
-          case :erlang.binary_to_term(blob) do
+          case :erlang.binary_to_term(blob, [:safe]) do
             {^keys, executable, value} ->
               debug? && Logger.debug("EXLA disk cache found at #{inspect(cache)}")
               {EXLA.Executable.load(client, executable), value}

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -15563,6 +15563,8 @@ defmodule Nx do
   """
   @doc type: :conversion
   def deserialize(data, opts \\ []) do
+    opts = if :safe in opts, do: opts, else: [:safe | opts]
+
     data
     |> IO.iodata_to_binary()
     |> deserialize_binary(opts)

--- a/nx/test/nx_test.exs
+++ b/nx/test/nx_test.exs
@@ -2744,7 +2744,7 @@ defmodule NxTest do
       ]
 
       assert {1, :little, _} =
-               serialized |> :erlang.iolist_to_binary() |> :erlang.binary_to_term()
+               serialized |> :erlang.iolist_to_binary() |> :erlang.binary_to_term([:safe])
 
       assert Nx.deserialize(serialized) == %Container{
                a: {Nx.tensor(1, type: :s64), Nx.tensor(2, type: :s64)},


### PR DESCRIPTION
been experimenting with sandboxing an agent and telling it it's in a ctf find vulnerabilities, make a report. It found one on nx that seemed worth upstreaming

----

## Summary

`Nx.deserialize/2` passes `opts` directly to `:erlang.binary_to_term/2`, defaulting to `[]`. This means callers who write `Nx.deserialize(data)` — the natural API — get no atom safety. A crafted `.nx` file can exhaust the atom table and crash the VM.

Similarly, `EXLA.Defn.Disk` calls `binary_to_term(blob)` with no flags when loading cached executables.

This PR adds automatic `:safe` enforcement in both paths. The flag only restricts creation of new atoms — all atoms used by legitimate tensors (`:f32`, `:s64`, axis names, etc.) already exist in any running Nx application, so this is a no-op for valid data.

## Changes

- **`nx/lib/nx.ex`**: `deserialize/2` now ensures `:safe` is always in the opts list passed to `binary_to_term/2`
- **`exla/lib/exla/defn/disk.ex`**: Disk cache loading now uses `binary_to_term(blob, [:safe])`
- **`nx/test/nx_test.exs`**: Updated test that calls `binary_to_term` directly to also pass `[:safe]`

I have a runnable PoC demonstrating atom table exhaustion via a crafted payload — happy to share privately if useful for review.

## Test plan

- [x] Existing `Nx.deserialize` round-trip tests pass (`:safe` is a no-op for valid data since all relevant atoms already exist)
- [x] EXLA disk cache tests unaffected
- [ ] Maintainers: optionally verify that `Nx.deserialize(malicious_payload)` now raises `ArgumentError` instead of crashing the VM

🤖 Generated with [Claude Code](https://claude.com/claude-code)