### PR TITLE
Add more padding variations: cycle, replicate and mirror

### DIFF
--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -4241,15 +4241,13 @@ defmodule Nx do
   defp left_cycle_index_period(1), do: Nx.tensor([0])
 
   defp left_cycle_index_period(n) do
-    n |> Nx.subtract(Nx.iota({n})) |> Nx.subtract(1) |> Nx.remainder(n)
+    Nx.subtract(n - 1, Nx.iota({n})) |> Nx.remainder(n)
   end
 
   # n == 0 is handled at the call side
   defp right_cycle_index_period(1), do: Nx.tensor([0])
 
-  defp right_cycle_index_period(n) do
-    Nx.iota({n})
-  end
+  defp right_cycle_index_period(n), do: Nx.iota({n})
 
   # n == 0 is handled at the call side
   defp left_mirror_index_period(1), do: Nx.tensor([0])
@@ -4278,7 +4276,7 @@ defmodule Nx do
   defp left_reflect_index_period(n) do
     # Generates the indices for pre-reflecting on the axis
     base = Nx.iota({n - 1})
-    left = base |> Nx.add(1)
+    left = Nx.add(base, 1)
     right = Nx.subtract(n - 2, base)
     Nx.concatenate([left, right])
   end
@@ -4290,23 +4288,19 @@ defmodule Nx do
     # Generates the indices for post-reflecting on the axis
     base = Nx.iota({n - 1})
     left = Nx.subtract(n - 2, base)
-    right = base |> Nx.add(1)
+    right = Nx.add(base, 1)
     Nx.concatenate([left, right])
   end
 
   # n == 0 is handled at the call side
   defp left_replicate_index_period(1), do: Nx.tensor([0])
 
-  defp left_replicate_index_period(n) do
-    Nx.broadcast(0, {n})
-  end
+  defp left_replicate_index_period(n), do: Nx.broadcast(0, {n})
 
   # n == 0 is handled at the call side
   defp right_replicate_index_period(1), do: Nx.tensor([0])
 
-  defp right_replicate_index_period(n) do
-    Nx.broadcast(n - 1, {n})
-  end
+  defp right_replicate_index_period(n), do: Nx.broadcast(n - 1, {n})
 
   defp padding_with_index(tensor, opts) do
     opts = keyword!(opts, [:padding_config, :left_index_period, :right_index_period])

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -16988,7 +16988,7 @@ defmodule Nx do
       which specify the length (0 or greater) of the reflection before and
       after the tensor along a each axis.
 
-  See also: `pad/3`
+  See also: `pad/3`, `cycle/2`, `replicate/2`, `mirror/2`
 
   ## Examples
 
@@ -17013,8 +17013,205 @@ defmodule Nx do
   def reflect(tensor, opts \\ []) do
     opts = keyword!(opts, [:padding_config])
 
+    padding_with_index(tensor,
+      padding_config: opts[:padding_config],
+      left_index_period: &left_reflect_index_period/1,
+      right_index_period: &right_reflect_index_period/1
+    )
+  end
+
+  defp left_reflect_index_period(1), do: Nx.tensor([0])
+
+  defp left_reflect_index_period(n) do
+    # Generates the indices for pre-reflecting on the axis
+    left = Nx.iota({n - 1}) |> Nx.add(1)
+    right = Nx.subtract(n - 2, Nx.iota({n - 1}))
+    Nx.concatenate([left, right])
+  end
+
+  defp right_reflect_index_period(1), do: Nx.tensor([0])
+
+  defp right_reflect_index_period(n) do
+    # Generates the indices for post-reflecting on the axis
+    left = Nx.subtract(n - 2, Nx.iota({n - 1}))
+    right = Nx.iota({n - 1}) |> Nx.add(1)
+    Nx.concatenate([left, right])
+  end
+
+  @doc """
+  Pads a tensor of rank 1 or greater along the given axes through periodic mirroring of its values.
+
+  ## Options
+
+    * `:padding_config` - A list of tuples in the format `{pre, post}`,
+      which specify the length (0 or greater) of the reflection before and
+      after the tensor along a each axis.
+
+  See also: `pad/3`, `cycle/2`, `replicate/2`, `reflect/2`
+
+  ## Examples
+
+      iex> Nx.mirror(Nx.tensor([0, 1, 2]), padding_config: [{3, 3}])
+      #Nx.Tensor<
+        s32[9]
+        [2, 1, 0, 0, 1, 2, 2, 1, 0]
+      >
+
+      iex> Nx.mirror(Nx.tensor([[0, 1, 2], [3, 4, 5]], names: [:x, :y]), padding_config: [{1, 1}, {2, 2}])
+      #Nx.Tensor<
+        s32[x: 4][y: 7]
+        [
+          [1, 0, 0, 1, 2, 2, 1],
+          [1, 0, 0, 1, 2, 2, 1],
+          [4, 3, 3, 4, 5, 5, 4],
+          [4, 3, 3, 4, 5, 5, 4]
+        ]
+      >
+  """
+  @doc type: :shape
+  def mirror(tensor, opts \\ []) do
+    opts = keyword!(opts, [:padding_config])
+
+    padding_with_index(tensor,
+      padding_config: opts[:padding_config],
+      left_index_period: &left_mirror_index_period/1,
+      right_index_period: &right_mirror_index_period/1
+    )
+  end
+
+  defp left_mirror_index_period(1), do: Nx.tensor([0])
+
+  defp left_mirror_index_period(n) do
+    # Generates the indices for pre-mirroring on the axis
+    left = Nx.iota({n})
+    right = Nx.subtract(n - 1, Nx.iota({n}))
+    Nx.concatenate([left, right])
+  end
+
+  defp right_mirror_index_period(1), do: Nx.tensor([0])
+
+  defp right_mirror_index_period(n) do
+    # Generates the indices for post-mirroring on the axis
+    left = Nx.subtract(n - 1, Nx.iota({n}))
+    right = Nx.iota({n})
+    Nx.concatenate([left, right])
+  end
+
+  @doc """
+  Pads a tensor of rank 1 or greater along the given axes through cyclic repetition of its values.
+
+  ## Options
+
+    * `:padding_config` - A list of tuples in the format `{pre, post}`,
+      which specify the length (0 or greater) of the reflection before and
+      after the tensor along a each axis.
+
+  See also: `pad/3`, `reflect/2`, `mirror/2`, `replicate/2`
+
+  ## Examples
+
+      iex> Nx.cycle(Nx.tensor([0, 1, 2]), padding_config: [{3, 1}])
+      #Nx.Tensor<
+        s32[7]
+        [0, 1, 2, 0, 1, 2, 0]
+      >
+
+      iex> Nx.cycle(Nx.tensor([[0, 1, 2], [3, 4, 5]], names: [:x, :y]), padding_config: [{2, 0}, {2, 1}])
+      #Nx.Tensor<
+        s32[x: 4][y: 6]
+        [
+          [1, 2, 0, 1, 2, 0],
+          [4, 5, 3, 4, 5, 3],
+          [1, 2, 0, 1, 2, 0],
+          [4, 5, 3, 4, 5, 3]
+        ]
+      >
+  """
+  @doc type: :shape
+  def cycle(tensor, opts \\ []) do
+    opts = keyword!(opts, [:padding_config])
+
+    padding_with_index(tensor,
+      padding_config: opts[:padding_config],
+      left_index_period: &left_cycle_index_period/1,
+      right_index_period: &right_cycle_index_period/1
+    )
+  end
+
+  defp left_cycle_index_period(1), do: Nx.tensor([0])
+
+  defp left_cycle_index_period(n) do
+    n |> Nx.subtract(Nx.iota({n})) |> Nx.subtract(1) |> Nx.remainder(n)
+  end
+
+  defp right_cycle_index_period(1), do: Nx.tensor([0])
+
+  defp right_cycle_index_period(n) do
+    Nx.iota({n})
+  end
+
+  @doc """
+  Pads a tensor of rank 1 or greater along the given axes through with its outer most values.
+
+  ## Options
+
+    * `:padding_config` - A list of tuples in the format `{pre, post}`,
+      which specify the length (0 or greater) of the reflection before and
+      after the tensor along a each axis.
+
+  See also: `pad/3`, `reflect/2`, `cycle/2`, `mirror/2`
+
+  ## Examples
+
+      iex> Nx.replicate(Nx.tensor([0, 1, 2]), padding_config: [{3, 1}])
+      #Nx.Tensor<
+        s32[7]
+        [0, 0, 0, 0, 1, 2, 2]
+      >
+
+      iex> Nx.replicate(Nx.tensor([[0, 1, 2], [3, 4, 5]], names: [:x, :y]), padding_config: [{2, 2}, {2, 2}])
+      #Nx.Tensor<
+        s32[x: 6][y: 7]
+        [
+          [0, 0, 0, 1, 2, 2, 2],
+          [0, 0, 0, 1, 2, 2, 2],
+          [0, 0, 0, 1, 2, 2, 2],
+          [3, 3, 3, 4, 5, 5, 5],
+          [3, 3, 3, 4, 5, 5, 5],
+          [3, 3, 3, 4, 5, 5, 5]
+        ]
+      >
+  """
+  @doc type: :shape
+  def replicate(tensor, opts \\ []) do
+    opts = keyword!(opts, [:padding_config])
+
+    padding_with_index(tensor,
+      padding_config: opts[:padding_config],
+      left_index_period: &left_replicate_index_period/1,
+      right_index_period: &right_replicate_index_period/1
+    )
+  end
+
+  defp left_replicate_index_period(1), do: Nx.tensor([0])
+
+  defp left_replicate_index_period(n) do
+    0 |> Nx.broadcast({n})
+  end
+
+  defp right_replicate_index_period(1), do: Nx.tensor([0])
+
+  defp right_replicate_index_period(n) do
+    (n - 1) |> Nx.broadcast({n}) |> Nx.remainder(n)
+  end
+
+  defp padding_with_index(tensor, opts) do
+    opts = keyword!(opts, [:padding_config, :left_index_period, :right_index_period])
+
     apply_vectorized(tensor, fn tensor, offset ->
       padding_config = opts[:padding_config]
+      left_index_period = opts[:left_index_period]
+      right_index_period = opts[:right_index_period]
 
       unless padding_config do
         raise ArgumentError, "missing mandatory option :padding_config"
@@ -17045,7 +17242,7 @@ defmodule Nx do
 
             left_padding =
               if(left_padding > 0) do
-                idx_period = left_reflect_index_period(n)
+                idx_period = left_index_period.(n)
                 repetitions = div(left_padding, n) + 1
 
                 idx =
@@ -17058,7 +17255,7 @@ defmodule Nx do
 
             right_padding =
               if(right_padding > 0) do
-                idx_period = right_reflect_index_period(n)
+                idx_period = right_index_period.(n)
                 repetitions = div(right_padding, n) + 1
                 idx = idx_period |> Nx.tile([repetitions]) |> Nx.take(Nx.iota({right_padding}))
                 Nx.take(tensor, idx, axis: axis)
@@ -17084,24 +17281,6 @@ defmodule Nx do
         end
       )
     end)
-  end
-
-  defp left_reflect_index_period(1), do: Nx.tensor([0])
-
-  defp left_reflect_index_period(n) do
-    # Generates the indices for pre-reflecting on the axis
-    left = Nx.iota({n - 1}) |> Nx.add(1)
-    right = Nx.subtract(n - 2, Nx.iota({n - 1}))
-    Nx.concatenate([left, right])
-  end
-
-  defp right_reflect_index_period(1), do: Nx.tensor([0])
-
-  defp right_reflect_index_period(n) do
-    # Generates the indices for post-reflecting on the axis
-    left = Nx.subtract(n - 2, Nx.iota({n - 1}))
-    right = Nx.iota({n - 1}) |> Nx.add(1)
-    Nx.concatenate([left, right])
   end
 
   @doc """

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -3895,7 +3895,10 @@ defmodule Nx do
   end
 
   @doc """
-  Pads a tensor with a given value.
+  Pads a tensor with a given value or a given padding type.
+
+  The padding value can either be a scalar number (for constant padding) or an atom specifying the padding type.
+  The following types of padding are supported: :cyclic, :reflect, :mirror, :replicate.
 
   You must specify a padding configuration. A padding
   configuration is a list of tuples consisting of
@@ -4082,9 +4085,95 @@ defmodule Nx do
         ]
       >
 
-  ## Vectorized tensors
+  ### Cyclic padding
 
-  Like with the non-vectorized case, `pad_value` must be a non-vectorized scalar tensor.
+  Cyclic padding repeats the tensors existing values along each axis in their original order.
+
+      iex> Nx.pad(Nx.tensor([0, 1, 2]), :cyclic, [{3, 1}])
+      #Nx.Tensor<
+        s32[7]
+        [0, 1, 2, 0, 1, 2, 0]
+      >
+
+      iex> Nx.pad(Nx.tensor([[0, 1, 2], [3, 4, 5]], names: [:x, :y]), :cyclic, [{2, 0}, {2, 1}])
+      #Nx.Tensor<
+        s32[x: 4][y: 6]
+        [
+          [1, 2, 0, 1, 2, 0],
+          [4, 5, 3, 4, 5, 3],
+          [1, 2, 0, 1, 2, 0],
+          [4, 5, 3, 4, 5, 3]
+        ]
+      >
+
+  ### Mirror padding
+
+  Mirror padding repeats the tensors existing values along each axis in reverse order while including the outer most values.
+
+      iex> Nx.pad(Nx.tensor([0, 1, 2]), :mirror, [{3, 3}])
+      #Nx.Tensor<
+        s32[9]
+        [2, 1, 0, 0, 1, 2, 2, 1, 0]
+      >
+
+      iex> Nx.pad(Nx.tensor([[0, 1, 2], [3, 4, 5]], names: [:x, :y]), :mirror, [{1, 1}, {2, 2}])
+      #Nx.Tensor<
+        s32[x: 4][y: 7]
+        [
+          [1, 0, 0, 1, 2, 2, 1],
+          [1, 0, 0, 1, 2, 2, 1],
+          [4, 3, 3, 4, 5, 5, 4],
+          [4, 3, 3, 4, 5, 5, 4]
+        ]
+      >
+
+  ### Reflection padding
+
+  Reflection padding repeats the tensors existing values along each axis in reverse order skipping the outer most values.
+
+    iex> Nx.pad(Nx.tensor([0, 1, 2]), :reflect, [{3, 1}])
+    #Nx.Tensor<
+      s32[7]
+      [1, 2, 1, 0, 1, 2, 1]
+    >
+
+    iex> Nx.pad(Nx.tensor([[0, 1, 2], [3, 4, 5]], names: [:x, :y]), :reflect, [{2, 0}, {2, 1}])
+    #Nx.Tensor<
+      s32[x: 4][y: 6]
+      [
+        [2, 1, 0, 1, 2, 1],
+        [5, 4, 3, 4, 5, 4],
+        [2, 1, 0, 1, 2, 1],
+        [5, 4, 3, 4, 5, 4]
+      ]
+    >
+
+  ### Replicate padding
+
+  Replicate padding uses the tensors outer most values along each axis as constant padding values.
+
+    iex> Nx.pad(Nx.tensor([0, 1, 2]), :replicate, [{3, 1}])
+    #Nx.Tensor<
+      s32[7]
+      [0, 0, 0, 0, 1, 2, 2]
+    >
+
+    iex> Nx.pad(Nx.tensor([[0, 1, 2], [3, 4, 5]], names: [:x, :y]), :replicate, [{2, 2}, {2, 2}])
+    #Nx.Tensor<
+      s32[x: 6][y: 7]
+      [
+        [0, 0, 0, 1, 2, 2, 2],
+        [0, 0, 0, 1, 2, 2, 2],
+        [0, 0, 0, 1, 2, 2, 2],
+        [3, 3, 3, 4, 5, 5, 5],
+        [3, 3, 3, 4, 5, 5, 5],
+        [3, 3, 3, 4, 5, 5, 5]
+      ]
+    >
+
+  ### Vectorized tensors
+
+  Like with the non-vectorized case, `pad_value_or_type` must be a non-vectorized scalar tensor.
   Vectorized axes remain unchanged.
 
       iex> t = Nx.tensor([[1], [2], [3]], names: [nil, :data]) |> Nx.vectorize(:x)
@@ -4101,12 +4190,14 @@ defmodule Nx do
 
   """
   @doc type: :shape
-  def pad(tensor, pad_value, padding_config) when is_list(padding_config) do
+  def pad(tensor, pad_value_or_type, padding_config)
+      when is_list(padding_config) and
+             (is_number(pad_value_or_type) or is_tensor(pad_value_or_type)) do
     apply_vectorized(tensor, fn tensor, offset ->
-      output_type = binary_type(tensor, pad_value)
-      pad_value = to_tensor(pad_value)
+      output_type = binary_type(tensor, pad_value_or_type)
+      pad_value_or_type = to_tensor(pad_value_or_type)
 
-      if not (pad_value.shape == {} and pad_value.vectorized_axes == []) do
+      if not (pad_value_or_type.shape == {} and pad_value_or_type.vectorized_axes == []) do
         raise ArgumentError, "padding value must be a scalar and non-vectorized"
       end
 
@@ -4114,11 +4205,183 @@ defmodule Nx do
       shape = Nx.Shape.pad(tensor.shape, padding_config)
 
       out = %{tensor | type: output_type, shape: shape}
-      impl!(tensor, pad_value).pad(out, tensor, pad_value, padding_config)
+      impl!(tensor, pad_value_or_type).pad(out, tensor, pad_value_or_type, padding_config)
     end)
   end
 
-  ## Reflection
+  @padding_types [:cyclic, :mirror, :replicate, :reflect]
+  def pad(tensor, pad_value_or_type, padding_config) when is_atom(pad_value_or_type) do
+    {left_period, right_period} =
+      case pad_value_or_type do
+        :cyclic ->
+          {&left_cycle_index_period/1, &right_cycle_index_period/1}
+
+        :mirror ->
+          {&left_mirror_index_period/1, &right_mirror_index_period/1}
+
+        :reflect ->
+          {&left_reflect_index_period/1, &right_reflect_index_period/1}
+
+        :replicate ->
+          {&left_replicate_index_period/1, &right_replicate_index_period/1}
+
+        other ->
+          raise ArgumentError,
+                "expected padding type to be either of [#{Enum.join(Enum.map(@padding_types, &inspect/1), ", ")}], got #{inspect(other)}"
+      end
+
+    padding_with_index(tensor,
+      padding_config: padding_config,
+      left_index_period: left_period,
+      right_index_period: right_period
+    )
+  end
+
+  # n == 0 is handled at the call side
+  defp left_cycle_index_period(1), do: Nx.tensor([0])
+
+  defp left_cycle_index_period(n) do
+    n |> Nx.subtract(Nx.iota({n})) |> Nx.subtract(1) |> Nx.remainder(n)
+  end
+
+  # n == 0 is handled at the call side
+  defp right_cycle_index_period(1), do: Nx.tensor([0])
+
+  defp right_cycle_index_period(n) do
+    Nx.iota({n})
+  end
+
+  # n == 0 is handled at the call side
+  defp left_mirror_index_period(1), do: Nx.tensor([0])
+
+  defp left_mirror_index_period(n) do
+    # Generates the indices for pre-mirroring on the axis
+    left = Nx.iota({n})
+    right = Nx.subtract(n - 1, Nx.iota({n}))
+    Nx.concatenate([left, right])
+  end
+
+  # n == 0 is handled at the call side
+  defp right_mirror_index_period(1), do: Nx.tensor([0])
+
+  defp right_mirror_index_period(n) do
+    # Generates the indices for post-mirroring on the axis
+    left = Nx.subtract(n - 1, Nx.iota({n}))
+    right = Nx.iota({n})
+    Nx.concatenate([left, right])
+  end
+
+  # n == 0 is handled at the call side
+  defp left_reflect_index_period(1), do: Nx.tensor([0])
+
+  defp left_reflect_index_period(n) do
+    # Generates the indices for pre-reflecting on the axis
+    left = Nx.iota({n - 1}) |> Nx.add(1)
+    right = Nx.subtract(n - 2, Nx.iota({n - 1}))
+    Nx.concatenate([left, right])
+  end
+
+  # n == 0 is handled at the call side
+  defp right_reflect_index_period(1), do: Nx.tensor([0])
+
+  defp right_reflect_index_period(n) do
+    # Generates the indices for post-reflecting on the axis
+    left = Nx.subtract(n - 2, Nx.iota({n - 1}))
+    right = Nx.iota({n - 1}) |> Nx.add(1)
+    Nx.concatenate([left, right])
+  end
+
+  # n == 0 is handled at the call side
+  defp left_replicate_index_period(1), do: Nx.tensor([0])
+
+  defp left_replicate_index_period(n) do
+    0 |> Nx.broadcast({n})
+  end
+
+  # n == 0 is handled at the call side
+  defp right_replicate_index_period(1), do: Nx.tensor([0])
+
+  defp right_replicate_index_period(n) do
+    (n - 1) |> Nx.broadcast({n})
+  end
+
+  defp padding_with_index(tensor, opts) do
+    opts = keyword!(opts, [:padding_config, :left_index_period, :right_index_period])
+
+    apply_vectorized(tensor, fn tensor, offset ->
+      padding_config = opts[:padding_config]
+      left_index_period = opts[:left_index_period]
+      right_index_period = opts[:right_index_period]
+
+      unless padding_config do
+        raise ArgumentError, "missing mandatory option :padding_config"
+      end
+
+      padding_config = List.duplicate({0, 0}, offset) ++ padding_config
+
+      rank = Nx.rank(tensor)
+
+      unless rank > 0 do
+        raise ArgumentError, "expected tensor to have rank greater than 0"
+      end
+
+      axes = axes(tensor)
+
+      if rank != length(padding_config) do
+        raise ArgumentError, "expected to have one padding_config entry each tensor axis"
+      end
+
+      Enum.zip_reduce(
+        padding_config,
+        axes,
+        tensor,
+        fn
+          {left_padding, right_padding}, axis, tensor
+          when left_padding >= 0 and right_padding >= 0 ->
+            n = Nx.axis_size(tensor, axis)
+
+            left_padding =
+              if(left_padding > 0) do
+                idx_period = left_index_period.(n)
+                repetitions = div(left_padding, n) + 1
+
+                idx =
+                  Nx.tile(idx_period, [repetitions])
+                  |> Nx.take(Nx.iota({left_padding}))
+                  |> Nx.reverse()
+
+                Nx.take(tensor, idx, axis: axis)
+              end
+
+            right_padding =
+              if(right_padding > 0) do
+                idx_period = right_index_period.(n)
+                repetitions = div(right_padding, n) + 1
+                idx = idx_period |> Nx.tile([repetitions]) |> Nx.take(Nx.iota({right_padding}))
+                Nx.take(tensor, idx, axis: axis)
+              end
+
+            case({left_padding, right_padding}) do
+              {nil, nil} ->
+                tensor
+
+              {nil, right} ->
+                Nx.concatenate([tensor, right], axis: axis)
+
+              {left, nil} ->
+                Nx.concatenate([left, tensor], axis: axis)
+
+              {left, right} ->
+                Nx.concatenate([left, tensor, right], axis: axis)
+            end
+
+          padding, axis, _ ->
+            raise ArgumentError,
+                  "expected padding config for axis #{axis} to be of the format {left, right}, with left and right as non-negative integers, got: #{inspect(padding)}"
+        end
+      )
+    end)
+  end
 
   @doc """
   Returns the type of the tensor.
@@ -16979,6 +17242,8 @@ defmodule Nx do
     impl!(tensor).to_pointer(tensor, opts)
   end
 
+  ## Reflect
+
   @doc """
   Pads a tensor of rank 1 or greater along the given axes through periodic reflections.
 
@@ -16988,7 +17253,7 @@ defmodule Nx do
       which specify the length (0 or greater) of the reflection before and
       after the tensor along a each axis.
 
-  See also: `pad/3`, `cycle/2`, `replicate/2`, `mirror/2`
+  See also: `pad/3`
 
   ## Examples
 
@@ -17010,6 +17275,7 @@ defmodule Nx do
       >
   """
   @doc type: :shape
+  @deprecated "Use pad/3 instead"
   def reflect(tensor, opts \\ []) do
     opts = keyword!(opts, [:padding_config])
 
@@ -17018,269 +17284,6 @@ defmodule Nx do
       left_index_period: &left_reflect_index_period/1,
       right_index_period: &right_reflect_index_period/1
     )
-  end
-
-  defp left_reflect_index_period(1), do: Nx.tensor([0])
-
-  defp left_reflect_index_period(n) do
-    # Generates the indices for pre-reflecting on the axis
-    left = Nx.iota({n - 1}) |> Nx.add(1)
-    right = Nx.subtract(n - 2, Nx.iota({n - 1}))
-    Nx.concatenate([left, right])
-  end
-
-  defp right_reflect_index_period(1), do: Nx.tensor([0])
-
-  defp right_reflect_index_period(n) do
-    # Generates the indices for post-reflecting on the axis
-    left = Nx.subtract(n - 2, Nx.iota({n - 1}))
-    right = Nx.iota({n - 1}) |> Nx.add(1)
-    Nx.concatenate([left, right])
-  end
-
-  @doc """
-  Pads a tensor of rank 1 or greater along the given axes through periodic mirroring of its values.
-
-  ## Options
-
-    * `:padding_config` - A list of tuples in the format `{pre, post}`,
-      which specify the length (0 or greater) of the reflection before and
-      after the tensor along a each axis.
-
-  See also: `pad/3`, `cycle/2`, `replicate/2`, `reflect/2`
-
-  ## Examples
-
-      iex> Nx.mirror(Nx.tensor([0, 1, 2]), padding_config: [{3, 3}])
-      #Nx.Tensor<
-        s32[9]
-        [2, 1, 0, 0, 1, 2, 2, 1, 0]
-      >
-
-      iex> Nx.mirror(Nx.tensor([[0, 1, 2], [3, 4, 5]], names: [:x, :y]), padding_config: [{1, 1}, {2, 2}])
-      #Nx.Tensor<
-        s32[x: 4][y: 7]
-        [
-          [1, 0, 0, 1, 2, 2, 1],
-          [1, 0, 0, 1, 2, 2, 1],
-          [4, 3, 3, 4, 5, 5, 4],
-          [4, 3, 3, 4, 5, 5, 4]
-        ]
-      >
-  """
-  @doc type: :shape
-  def mirror(tensor, opts \\ []) do
-    opts = keyword!(opts, [:padding_config])
-
-    padding_with_index(tensor,
-      padding_config: opts[:padding_config],
-      left_index_period: &left_mirror_index_period/1,
-      right_index_period: &right_mirror_index_period/1
-    )
-  end
-
-  defp left_mirror_index_period(1), do: Nx.tensor([0])
-
-  defp left_mirror_index_period(n) do
-    # Generates the indices for pre-mirroring on the axis
-    left = Nx.iota({n})
-    right = Nx.subtract(n - 1, Nx.iota({n}))
-    Nx.concatenate([left, right])
-  end
-
-  defp right_mirror_index_period(1), do: Nx.tensor([0])
-
-  defp right_mirror_index_period(n) do
-    # Generates the indices for post-mirroring on the axis
-    left = Nx.subtract(n - 1, Nx.iota({n}))
-    right = Nx.iota({n})
-    Nx.concatenate([left, right])
-  end
-
-  @doc """
-  Pads a tensor of rank 1 or greater along the given axes through cyclic repetition of its values.
-
-  ## Options
-
-    * `:padding_config` - A list of tuples in the format `{pre, post}`,
-      which specify the length (0 or greater) of the reflection before and
-      after the tensor along a each axis.
-
-  See also: `pad/3`, `reflect/2`, `mirror/2`, `replicate/2`
-
-  ## Examples
-
-      iex> Nx.cycle(Nx.tensor([0, 1, 2]), padding_config: [{3, 1}])
-      #Nx.Tensor<
-        s32[7]
-        [0, 1, 2, 0, 1, 2, 0]
-      >
-
-      iex> Nx.cycle(Nx.tensor([[0, 1, 2], [3, 4, 5]], names: [:x, :y]), padding_config: [{2, 0}, {2, 1}])
-      #Nx.Tensor<
-        s32[x: 4][y: 6]
-        [
-          [1, 2, 0, 1, 2, 0],
-          [4, 5, 3, 4, 5, 3],
-          [1, 2, 0, 1, 2, 0],
-          [4, 5, 3, 4, 5, 3]
-        ]
-      >
-  """
-  @doc type: :shape
-  def cycle(tensor, opts \\ []) do
-    opts = keyword!(opts, [:padding_config])
-
-    padding_with_index(tensor,
-      padding_config: opts[:padding_config],
-      left_index_period: &left_cycle_index_period/1,
-      right_index_period: &right_cycle_index_period/1
-    )
-  end
-
-  defp left_cycle_index_period(1), do: Nx.tensor([0])
-
-  defp left_cycle_index_period(n) do
-    n |> Nx.subtract(Nx.iota({n})) |> Nx.subtract(1) |> Nx.remainder(n)
-  end
-
-  defp right_cycle_index_period(1), do: Nx.tensor([0])
-
-  defp right_cycle_index_period(n) do
-    Nx.iota({n})
-  end
-
-  @doc """
-  Pads a tensor of rank 1 or greater along the given axes through with its outer most values.
-
-  ## Options
-
-    * `:padding_config` - A list of tuples in the format `{pre, post}`,
-      which specify the length (0 or greater) of the reflection before and
-      after the tensor along a each axis.
-
-  See also: `pad/3`, `reflect/2`, `cycle/2`, `mirror/2`
-
-  ## Examples
-
-      iex> Nx.replicate(Nx.tensor([0, 1, 2]), padding_config: [{3, 1}])
-      #Nx.Tensor<
-        s32[7]
-        [0, 0, 0, 0, 1, 2, 2]
-      >
-
-      iex> Nx.replicate(Nx.tensor([[0, 1, 2], [3, 4, 5]], names: [:x, :y]), padding_config: [{2, 2}, {2, 2}])
-      #Nx.Tensor<
-        s32[x: 6][y: 7]
-        [
-          [0, 0, 0, 1, 2, 2, 2],
-          [0, 0, 0, 1, 2, 2, 2],
-          [0, 0, 0, 1, 2, 2, 2],
-          [3, 3, 3, 4, 5, 5, 5],
-          [3, 3, 3, 4, 5, 5, 5],
-          [3, 3, 3, 4, 5, 5, 5]
-        ]
-      >
-  """
-  @doc type: :shape
-  def replicate(tensor, opts \\ []) do
-    opts = keyword!(opts, [:padding_config])
-
-    padding_with_index(tensor,
-      padding_config: opts[:padding_config],
-      left_index_period: &left_replicate_index_period/1,
-      right_index_period: &right_replicate_index_period/1
-    )
-  end
-
-  defp left_replicate_index_period(1), do: Nx.tensor([0])
-
-  defp left_replicate_index_period(n) do
-    0 |> Nx.broadcast({n})
-  end
-
-  defp right_replicate_index_period(1), do: Nx.tensor([0])
-
-  defp right_replicate_index_period(n) do
-    (n - 1) |> Nx.broadcast({n}) |> Nx.remainder(n)
-  end
-
-  defp padding_with_index(tensor, opts) do
-    opts = keyword!(opts, [:padding_config, :left_index_period, :right_index_period])
-
-    apply_vectorized(tensor, fn tensor, offset ->
-      padding_config = opts[:padding_config]
-      left_index_period = opts[:left_index_period]
-      right_index_period = opts[:right_index_period]
-
-      unless padding_config do
-        raise ArgumentError, "missing mandatory option :padding_config"
-      end
-
-      padding_config = List.duplicate({0, 0}, offset) ++ padding_config
-
-      rank = Nx.rank(tensor)
-
-      unless rank > 0 do
-        raise ArgumentError, "expected tensor to have rank greater than 0"
-      end
-
-      axes = axes(tensor)
-
-      if rank != length(padding_config) do
-        raise ArgumentError, "expected to have one padding_config entry each tensor axis"
-      end
-
-      Enum.zip_reduce(
-        padding_config,
-        axes,
-        tensor,
-        fn
-          {left_padding, right_padding}, axis, tensor
-          when left_padding >= 0 and right_padding >= 0 ->
-            n = Nx.axis_size(tensor, axis)
-
-            left_padding =
-              if(left_padding > 0) do
-                idx_period = left_index_period.(n)
-                repetitions = div(left_padding, n) + 1
-
-                idx =
-                  Nx.tile(idx_period, [repetitions])
-                  |> Nx.take(Nx.iota({left_padding}))
-                  |> Nx.reverse()
-
-                Nx.take(tensor, idx, axis: axis)
-              end
-
-            right_padding =
-              if(right_padding > 0) do
-                idx_period = right_index_period.(n)
-                repetitions = div(right_padding, n) + 1
-                idx = idx_period |> Nx.tile([repetitions]) |> Nx.take(Nx.iota({right_padding}))
-                Nx.take(tensor, idx, axis: axis)
-              end
-
-            case({left_padding, right_padding}) do
-              {nil, nil} ->
-                tensor
-
-              {nil, right} ->
-                Nx.concatenate([tensor, right], axis: axis)
-
-              {left, nil} ->
-                Nx.concatenate([left, tensor], axis: axis)
-
-              {left, right} ->
-                Nx.concatenate([left, tensor, right], axis: axis)
-            end
-
-          padding, axis, _ ->
-            raise ArgumentError,
-                  "expected padding config for axis #{axis} to be of the format {left, right}, with left and right as non-negative integers, got: #{inspect(padding)}"
-        end
-      )
-    end)
   end
 
   @doc """

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -4257,7 +4257,7 @@ defmodule Nx do
   defp left_mirror_index_period(n) do
     # Generates the indices for pre-mirroring on the axis
     left = Nx.iota({n})
-    right = Nx.subtract(n - 1, Nx.iota({n}))
+    right = Nx.subtract(n - 1, left)
     Nx.concatenate([left, right])
   end
 
@@ -4266,8 +4266,9 @@ defmodule Nx do
 
   defp right_mirror_index_period(n) do
     # Generates the indices for post-mirroring on the axis
-    left = Nx.subtract(n - 1, Nx.iota({n}))
-    right = Nx.iota({n})
+    base = Nx.iota({n})
+    left = Nx.subtract(n - 1, base)
+    right = base
     Nx.concatenate([left, right])
   end
 
@@ -4276,8 +4277,9 @@ defmodule Nx do
 
   defp left_reflect_index_period(n) do
     # Generates the indices for pre-reflecting on the axis
-    left = Nx.iota({n - 1}) |> Nx.add(1)
-    right = Nx.subtract(n - 2, Nx.iota({n - 1}))
+    base = Nx.iota({n - 1})
+    left = base |> Nx.add(1)
+    right = Nx.subtract(n - 2, base)
     Nx.concatenate([left, right])
   end
 
@@ -4286,8 +4288,9 @@ defmodule Nx do
 
   defp right_reflect_index_period(n) do
     # Generates the indices for post-reflecting on the axis
-    left = Nx.subtract(n - 2, Nx.iota({n - 1}))
-    right = Nx.iota({n - 1}) |> Nx.add(1)
+    base = Nx.iota({n - 1})
+    left = Nx.subtract(n - 2, base)
+    right = base |> Nx.add(1)
     Nx.concatenate([left, right])
   end
 
@@ -4295,14 +4298,14 @@ defmodule Nx do
   defp left_replicate_index_period(1), do: Nx.tensor([0])
 
   defp left_replicate_index_period(n) do
-    0 |> Nx.broadcast({n})
+    Nx.broadcast(0, {n})
   end
 
   # n == 0 is handled at the call side
   defp right_replicate_index_period(1), do: Nx.tensor([0])
 
   defp right_replicate_index_period(n) do
-    (n - 1) |> Nx.broadcast({n})
+    Nx.broadcast(n - 1, {n})
   end
 
   defp padding_with_index(tensor, opts) do

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -3895,7 +3895,10 @@ defmodule Nx do
   end
 
   @doc """
-  Pads a tensor with a given value.
+  Pads a tensor with a given value or a given padding type.
+
+  The padding value can either be a scalar number (for constant padding) or an atom specifying the padding type.
+  The following types of padding are supported: :cyclic, :reflect, :mirror, :replicate.
 
   You must specify a padding configuration. A padding
   configuration is a list of tuples consisting of
@@ -4082,9 +4085,95 @@ defmodule Nx do
         ]
       >
 
-  ## Vectorized tensors
+  ### Cyclic padding
 
-  Like with the non-vectorized case, `pad_value` must be a non-vectorized scalar tensor.
+  Cyclic padding repeats the tensors existing values along each axis in their original order.
+
+      iex> Nx.pad(Nx.tensor([0, 1, 2]), :cyclic, [{3, 1}])
+      #Nx.Tensor<
+        s32[7]
+        [0, 1, 2, 0, 1, 2, 0]
+      >
+
+      iex> Nx.pad(Nx.tensor([[0, 1, 2], [3, 4, 5]], names: [:x, :y]), :cyclic, [{2, 0}, {2, 1}])
+      #Nx.Tensor<
+        s32[x: 4][y: 6]
+        [
+          [1, 2, 0, 1, 2, 0],
+          [4, 5, 3, 4, 5, 3],
+          [1, 2, 0, 1, 2, 0],
+          [4, 5, 3, 4, 5, 3]
+        ]
+      >
+
+  ### Mirror padding
+
+  Mirror padding repeats the tensors existing values along each axis in reverse order while including the outer most values.
+
+      iex> Nx.pad(Nx.tensor([0, 1, 2]), :mirror, [{3, 3}])
+      #Nx.Tensor<
+        s32[9]
+        [2, 1, 0, 0, 1, 2, 2, 1, 0]
+      >
+
+      iex> Nx.pad(Nx.tensor([[0, 1, 2], [3, 4, 5]], names: [:x, :y]), :mirror, [{1, 1}, {2, 2}])
+      #Nx.Tensor<
+        s32[x: 4][y: 7]
+        [
+          [1, 0, 0, 1, 2, 2, 1],
+          [1, 0, 0, 1, 2, 2, 1],
+          [4, 3, 3, 4, 5, 5, 4],
+          [4, 3, 3, 4, 5, 5, 4]
+        ]
+      >
+
+  ### Reflection padding
+
+  Reflection padding repeats the tensors existing values along each axis in reverse order skipping the outer most values.
+
+    iex> Nx.pad(Nx.tensor([0, 1, 2]), :reflect, [{3, 1}])
+    #Nx.Tensor<
+      s32[7]
+      [1, 2, 1, 0, 1, 2, 1]
+    >
+
+    iex> Nx.pad(Nx.tensor([[0, 1, 2], [3, 4, 5]], names: [:x, :y]), :reflect, [{2, 0}, {2, 1}])
+    #Nx.Tensor<
+      s32[x: 4][y: 6]
+      [
+        [2, 1, 0, 1, 2, 1],
+        [5, 4, 3, 4, 5, 4],
+        [2, 1, 0, 1, 2, 1],
+        [5, 4, 3, 4, 5, 4]
+      ]
+    >
+
+  ### Replicate padding
+
+  Replicate padding uses the tensors outer most values along each axis as constant padding values.
+
+    iex> Nx.pad(Nx.tensor([0, 1, 2]), :replicate, [{3, 1}])
+    #Nx.Tensor<
+      s32[7]
+      [0, 0, 0, 0, 1, 2, 2]
+    >
+
+    iex> Nx.pad(Nx.tensor([[0, 1, 2], [3, 4, 5]], names: [:x, :y]), :replicate, [{2, 2}, {2, 2}])
+    #Nx.Tensor<
+      s32[x: 6][y: 7]
+      [
+        [0, 0, 0, 1, 2, 2, 2],
+        [0, 0, 0, 1, 2, 2, 2],
+        [0, 0, 0, 1, 2, 2, 2],
+        [3, 3, 3, 4, 5, 5, 5],
+        [3, 3, 3, 4, 5, 5, 5],
+        [3, 3, 3, 4, 5, 5, 5]
+      ]
+    >
+
+  ### Vectorized tensors
+
+  Like with the non-vectorized case, `pad_value_or_type` must be a non-vectorized scalar tensor.
   Vectorized axes remain unchanged.
 
       iex> t = Nx.tensor([[1], [2], [3]], names: [nil, :data]) |> Nx.vectorize(:x)
@@ -4101,12 +4190,14 @@ defmodule Nx do
 
   """
   @doc type: :shape
-  def pad(tensor, pad_value, padding_config) when is_list(padding_config) do
+  def pad(tensor, pad_value_or_type, padding_config)
+      when is_list(padding_config) and
+             (is_number(pad_value_or_type) or is_tensor(pad_value_or_type)) do
     apply_vectorized(tensor, fn tensor, offset ->
-      output_type = binary_type(tensor, pad_value)
-      pad_value = to_tensor(pad_value)
+      output_type = binary_type(tensor, pad_value_or_type)
+      pad_value_or_type = to_tensor(pad_value_or_type)
 
-      if not (pad_value.shape == {} and pad_value.vectorized_axes == []) do
+      if not (pad_value_or_type.shape == {} and pad_value_or_type.vectorized_axes == []) do
         raise ArgumentError, "padding value must be a scalar and non-vectorized"
       end
 
@@ -4114,11 +4205,183 @@ defmodule Nx do
       shape = Nx.Shape.pad(tensor.shape, padding_config)
 
       out = %{tensor | type: output_type, shape: shape}
-      impl!(tensor, pad_value).pad(out, tensor, pad_value, padding_config)
+      impl!(tensor, pad_value_or_type).pad(out, tensor, pad_value_or_type, padding_config)
     end)
   end
 
-  ## Reflection
+  @padding_types [:cyclic, :mirror, :replicate, :reflect]
+  def pad(tensor, pad_value_or_type, padding_config) when is_atom(pad_value_or_type) do
+    {left_period, right_period} =
+      case pad_value_or_type do
+        :cyclic ->
+          {&left_cycle_index_period/1, &right_cycle_index_period/1}
+
+        :mirror ->
+          {&left_mirror_index_period/1, &right_mirror_index_period/1}
+
+        :reflect ->
+          {&left_reflect_index_period/1, &right_reflect_index_period/1}
+
+        :replicate ->
+          {&left_replicate_index_period/1, &right_replicate_index_period/1}
+
+        other ->
+          raise ArgumentError,
+                "expected padding type to be either of [#{Enum.join(Enum.map(@padding_types, &inspect/1), ", ")}], got #{inspect(other)}"
+      end
+
+    padding_with_index(tensor,
+      padding_config: padding_config,
+      left_index_period: left_period,
+      right_index_period: right_period
+    )
+  end
+
+  # n == 0 is handled at the call side
+  defp left_cycle_index_period(1), do: Nx.tensor([0])
+
+  defp left_cycle_index_period(n) do
+    n |> Nx.subtract(Nx.iota({n})) |> Nx.subtract(1) |> Nx.remainder(n)
+  end
+
+  # n == 0 is handled at the call side
+  defp right_cycle_index_period(1), do: Nx.tensor([0])
+
+  defp right_cycle_index_period(n) do
+    Nx.iota({n})
+  end
+
+  # n == 0 is handled at the call side
+  defp left_mirror_index_period(1), do: Nx.tensor([0])
+
+  defp left_mirror_index_period(n) do
+    # Generates the indices for pre-mirroring on the axis
+    left = Nx.iota({n})
+    right = Nx.subtract(n - 1, Nx.iota({n}))
+    Nx.concatenate([left, right])
+  end
+
+  # n == 0 is handled at the call side
+  defp right_mirror_index_period(1), do: Nx.tensor([0])
+
+  defp right_mirror_index_period(n) do
+    # Generates the indices for post-mirroring on the axis
+    left = Nx.subtract(n - 1, Nx.iota({n}))
+    right = Nx.iota({n})
+    Nx.concatenate([left, right])
+  end
+
+  # n == 0 is handled at the call side
+  defp left_reflect_index_period(1), do: Nx.tensor([0])
+
+  defp left_reflect_index_period(n) do
+    # Generates the indices for pre-reflecting on the axis
+    left = Nx.iota({n - 1}) |> Nx.add(1)
+    right = Nx.subtract(n - 2, Nx.iota({n - 1}))
+    Nx.concatenate([left, right])
+  end
+
+  # n == 0 is handled at the call side
+  defp right_reflect_index_period(1), do: Nx.tensor([0])
+
+  defp right_reflect_index_period(n) do
+    # Generates the indices for post-reflecting on the axis
+    left = Nx.subtract(n - 2, Nx.iota({n - 1}))
+    right = Nx.iota({n - 1}) |> Nx.add(1)
+    Nx.concatenate([left, right])
+  end
+
+  # n == 0 is handled at the call side
+  defp left_replicate_index_period(1), do: Nx.tensor([0])
+
+  defp left_replicate_index_period(n) do
+    0 |> Nx.broadcast({n})
+  end
+
+  # n == 0 is handled at the call side
+  defp right_replicate_index_period(1), do: Nx.tensor([0])
+
+  defp right_replicate_index_period(n) do
+    (n - 1) |> Nx.broadcast({n})
+  end
+
+  defp padding_with_index(tensor, opts) do
+    opts = keyword!(opts, [:padding_config, :left_index_period, :right_index_period])
+
+    apply_vectorized(tensor, fn tensor, offset ->
+      padding_config = opts[:padding_config]
+      left_index_period = opts[:left_index_period]
+      right_index_period = opts[:right_index_period]
+
+      unless padding_config do
+        raise ArgumentError, "missing mandatory option :padding_config"
+      end
+
+      padding_config = List.duplicate({0, 0}, offset) ++ padding_config
+
+      rank = Nx.rank(tensor)
+
+      unless rank > 0 do
+        raise ArgumentError, "expected tensor to have rank greater than 0"
+      end
+
+      axes = axes(tensor)
+
+      if rank != length(padding_config) do
+        raise ArgumentError, "expected to have one padding_config entry each tensor axis"
+      end
+
+      Enum.zip_reduce(
+        padding_config,
+        axes,
+        tensor,
+        fn
+          {left_padding, right_padding}, axis, tensor
+          when left_padding >= 0 and right_padding >= 0 ->
+            n = Nx.axis_size(tensor, axis)
+
+            left_padding =
+              if(left_padding > 0) do
+                idx_period = left_index_period.(n)
+                repetitions = div(left_padding, n) + 1
+
+                idx =
+                  Nx.tile(idx_period, [repetitions])
+                  |> Nx.take(Nx.iota({left_padding}))
+                  |> Nx.reverse()
+
+                Nx.take(tensor, idx, axis: axis)
+              end
+
+            right_padding =
+              if(right_padding > 0) do
+                idx_period = right_index_period.(n)
+                repetitions = div(right_padding, n) + 1
+                idx = idx_period |> Nx.tile([repetitions]) |> Nx.take(Nx.iota({right_padding}))
+                Nx.take(tensor, idx, axis: axis)
+              end
+
+            case({left_padding, right_padding}) do
+              {nil, nil} ->
+                tensor
+
+              {nil, right} ->
+                Nx.concatenate([tensor, right], axis: axis)
+
+              {left, nil} ->
+                Nx.concatenate([left, tensor], axis: axis)
+
+              {left, right} ->
+                Nx.concatenate([left, tensor, right], axis: axis)
+            end
+
+          padding, axis, _ ->
+            raise ArgumentError,
+                  "expected padding config for axis #{axis} to be of the format {left, right}, with left and right as non-negative integers, got: #{inspect(padding)}"
+        end
+      )
+    end)
+  end
 
   @doc """
   Returns the type of the tensor.
@@ -17331,6 +17594,8 @@ defmodule Nx do
     impl!(tensor).to_pointer(tensor, opts)
   end
 
+  ## Reflect
+
   @doc """
   Pads a tensor of rank 1 or greater along the given axes through periodic reflections.
 
@@ -17340,7 +17605,7 @@ defmodule Nx do
       which specify the length (0 or greater) of the reflection before and
       after the tensor along a each axis.
 
-  See also: `pad/3`, `cycle/2`, `replicate/2`, `mirror/2`
+  See also: `pad/3`
 
   ## Examples
 
@@ -17362,6 +17627,7 @@ defmodule Nx do
       >
   """
   @doc type: :shape
+  @deprecated "Use pad/3 instead"
   def reflect(tensor, opts \\ []) do
     opts = keyword!(opts, [:padding_config])
 
@@ -17370,269 +17636,6 @@ defmodule Nx do
       left_index_period: &left_reflect_index_period/1,
       right_index_period: &right_reflect_index_period/1
     )
-  end
-
-  defp left_reflect_index_period(1), do: Nx.tensor([0])
-
-  defp left_reflect_index_period(n) do
-    # Generates the indices for pre-reflecting on the axis
-    left = Nx.iota({n - 1}) |> Nx.add(1)
-    right = Nx.subtract(n - 2, Nx.iota({n - 1}))
-    Nx.concatenate([left, right])
-  end
-
-  defp right_reflect_index_period(1), do: Nx.tensor([0])
-
-  defp right_reflect_index_period(n) do
-    # Generates the indices for post-reflecting on the axis
-    left = Nx.subtract(n - 2, Nx.iota({n - 1}))
-    right = Nx.iota({n - 1}) |> Nx.add(1)
-    Nx.concatenate([left, right])
-  end
-
-  @doc """
-  Pads a tensor of rank 1 or greater along the given axes through periodic mirroring of its values.
-
-  ## Options
-
-    * `:padding_config` - A list of tuples in the format `{pre, post}`,
-      which specify the length (0 or greater) of the reflection before and
-      after the tensor along a each axis.
-
-  See also: `pad/3`, `cycle/2`, `replicate/2`, `reflect/2`
-
-  ## Examples
-
-      iex> Nx.mirror(Nx.tensor([0, 1, 2]), padding_config: [{3, 3}])
-      #Nx.Tensor<
-        s32[9]
-        [2, 1, 0, 0, 1, 2, 2, 1, 0]
-      >
-
-      iex> Nx.mirror(Nx.tensor([[0, 1, 2], [3, 4, 5]], names: [:x, :y]), padding_config: [{1, 1}, {2, 2}])
-      #Nx.Tensor<
-        s32[x: 4][y: 7]
-        [
-          [1, 0, 0, 1, 2, 2, 1],
-          [1, 0, 0, 1, 2, 2, 1],
-          [4, 3, 3, 4, 5, 5, 4],
-          [4, 3, 3, 4, 5, 5, 4]
-        ]
-      >
-  """
-  @doc type: :shape
-  def mirror(tensor, opts \\ []) do
-    opts = keyword!(opts, [:padding_config])
-
-    padding_with_index(tensor,
-      padding_config: opts[:padding_config],
-      left_index_period: &left_mirror_index_period/1,
-      right_index_period: &right_mirror_index_period/1
-    )
-  end
-
-  defp left_mirror_index_period(1), do: Nx.tensor([0])
-
-  defp left_mirror_index_period(n) do
-    # Generates the indices for pre-mirroring on the axis
-    left = Nx.iota({n})
-    right = Nx.subtract(n - 1, Nx.iota({n}))
-    Nx.concatenate([left, right])
-  end
-
-  defp right_mirror_index_period(1), do: Nx.tensor([0])
-
-  defp right_mirror_index_period(n) do
-    # Generates the indices for post-mirroring on the axis
-    left = Nx.subtract(n - 1, Nx.iota({n}))
-    right = Nx.iota({n})
-    Nx.concatenate([left, right])
-  end
-
-  @doc """
-  Pads a tensor of rank 1 or greater along the given axes through cyclic repetition of its values.
-
-  ## Options
-
-    * `:padding_config` - A list of tuples in the format `{pre, post}`,
-      which specify the length (0 or greater) of the reflection before and
-      after the tensor along a each axis.
-
-  See also: `pad/3`, `reflect/2`, `mirror/2`, `replicate/2`
-
-  ## Examples
-
-      iex> Nx.cycle(Nx.tensor([0, 1, 2]), padding_config: [{3, 1}])
-      #Nx.Tensor<
-        s32[7]
-        [0, 1, 2, 0, 1, 2, 0]
-      >
-
-      iex> Nx.cycle(Nx.tensor([[0, 1, 2], [3, 4, 5]], names: [:x, :y]), padding_config: [{2, 0}, {2, 1}])
-      #Nx.Tensor<
-        s32[x: 4][y: 6]
-        [
-          [1, 2, 0, 1, 2, 0],
-          [4, 5, 3, 4, 5, 3],
-          [1, 2, 0, 1, 2, 0],
-          [4, 5, 3, 4, 5, 3]
-        ]
-      >
-  """
-  @doc type: :shape
-  def cycle(tensor, opts \\ []) do
-    opts = keyword!(opts, [:padding_config])
-
-    padding_with_index(tensor,
-      padding_config: opts[:padding_config],
-      left_index_period: &left_cycle_index_period/1,
-      right_index_period: &right_cycle_index_period/1
-    )
-  end
-
-  defp left_cycle_index_period(1), do: Nx.tensor([0])
-
-  defp left_cycle_index_period(n) do
-    n |> Nx.subtract(Nx.iota({n})) |> Nx.subtract(1) |> Nx.remainder(n)
-  end
-
-  defp right_cycle_index_period(1), do: Nx.tensor([0])
-
-  defp right_cycle_index_period(n) do
-    Nx.iota({n})
-  end
-
-  @doc """
-  Pads a tensor of rank 1 or greater along the given axes through with its outer most values.
-
-  ## Options
-
-    * `:padding_config` - A list of tuples in the format `{pre, post}`,
-      which specify the length (0 or greater) of the reflection before and
-      after the tensor along a each axis.
-
-  See also: `pad/3`, `reflect/2`, `cycle/2`, `mirror/2`
-
-  ## Examples
-
-      iex> Nx.replicate(Nx.tensor([0, 1, 2]), padding_config: [{3, 1}])
-      #Nx.Tensor<
-        s32[7]
-        [0, 0, 0, 0, 1, 2, 2]
-      >
-
-      iex> Nx.replicate(Nx.tensor([[0, 1, 2], [3, 4, 5]], names: [:x, :y]), padding_config: [{2, 2}, {2, 2}])
-      #Nx.Tensor<
-        s32[x: 6][y: 7]
-        [
-          [0, 0, 0, 1, 2, 2, 2],
-          [0, 0, 0, 1, 2, 2, 2],
-          [0, 0, 0, 1, 2, 2, 2],
-          [3, 3, 3, 4, 5, 5, 5],
-          [3, 3, 3, 4, 5, 5, 5],
-          [3, 3, 3, 4, 5, 5, 5]
-        ]
-      >
-  """
-  @doc type: :shape
-  def replicate(tensor, opts \\ []) do
-    opts = keyword!(opts, [:padding_config])
-
-    padding_with_index(tensor,
-      padding_config: opts[:padding_config],
-      left_index_period: &left_replicate_index_period/1,
-      right_index_period: &right_replicate_index_period/1
-    )
-  end
-
-  defp left_replicate_index_period(1), do: Nx.tensor([0])
-
-  defp left_replicate_index_period(n) do
-    0 |> Nx.broadcast({n})
-  end
-
-  defp right_replicate_index_period(1), do: Nx.tensor([0])
-
-  defp right_replicate_index_period(n) do
-    (n - 1) |> Nx.broadcast({n}) |> Nx.remainder(n)
-  end
-
-  defp padding_with_index(tensor, opts) do
-    opts = keyword!(opts, [:padding_config, :left_index_period, :right_index_period])
-
-    apply_vectorized(tensor, fn tensor, offset ->
-      padding_config = opts[:padding_config]
-      left_index_period = opts[:left_index_period]
-      right_index_period = opts[:right_index_period]
-
-      unless padding_config do
-        raise ArgumentError, "missing mandatory option :padding_config"
-      end
-
-      padding_config = List.duplicate({0, 0}, offset) ++ padding_config
-
-      rank = Nx.rank(tensor)
-
-      unless rank > 0 do
-        raise ArgumentError, "expected tensor to have rank greater than 0"
-      end
-
-      axes = axes(tensor)
-
-      if rank != length(padding_config) do
-        raise ArgumentError, "expected to have one padding_config entry each tensor axis"
-      end
-
-      Enum.zip_reduce(
-        padding_config,
-        axes,
-        tensor,
-        fn
-          {left_padding, right_padding}, axis, tensor
-          when left_padding >= 0 and right_padding >= 0 ->
-            n = Nx.axis_size(tensor, axis)
-
-            left_padding =
-              if(left_padding > 0) do
-                idx_period = left_index_period.(n)
-                repetitions = div(left_padding, n) + 1
-
-                idx =
-                  Nx.tile(idx_period, [repetitions])
-                  |> Nx.take(Nx.iota({left_padding}))
-                  |> Nx.reverse()
-
-                Nx.take(tensor, idx, axis: axis)
-              end
-
-            right_padding =
-              if(right_padding > 0) do
-                idx_period = right_index_period.(n)
-                repetitions = div(right_padding, n) + 1
-                idx = idx_period |> Nx.tile([repetitions]) |> Nx.take(Nx.iota({right_padding}))
-                Nx.take(tensor, idx, axis: axis)
-              end
-
-            case({left_padding, right_padding}) do
-              {nil, nil} ->
-                tensor
-
-              {nil, right} ->
-                Nx.concatenate([tensor, right], axis: axis)
-
-              {left, nil} ->
-                Nx.concatenate([left, tensor], axis: axis)
-
-              {left, right} ->
-                Nx.concatenate([left, tensor, right], axis: axis)
-            end
-
-          padding, axis, _ ->
-            raise ArgumentError,
-                  "expected padding config for axis #{axis} to be of the format {left, right}, with left and right as non-negative integers, got: #{inspect(padding)}"
-        end
-      )
-    end)
   end
 
   @doc """

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -4123,7 +4123,7 @@ defmodule Nx do
   @padding_types [:cyclic, :mirror, :replicate, :reflect]
 
   @doc """
-  Pads a tensor at the start and end of each axis with a given value or a given padding type.
+  Pads a tensor at the start and end of each axis with a given constant value or via a given padding type.
 
   The padding value can either be a scalar number (for constant padding) or an atom specifying the padding type.
   The following types of padding are supported: :cyclic, :reflect, :mirror, :replicate.

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -4155,6 +4155,24 @@ defmodule Nx do
         ]
       >
 
+      iex> Nx.pad_outer(Nx.tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9]]), 0, [{-1, -1}, {-1, -1}])
+      #Nx.Tensor<
+        s32[1][1]
+        [
+          [5]
+        ]
+      >
+
+      iex> Nx.pad_outer(Nx.tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9]]), 0, [{1, -1}, {1, -1}])
+      #Nx.Tensor<
+        s32[3][3]
+        [
+          [0, 0, 0],
+          [0, 1, 2],
+          [0, 4, 5]
+        ]
+      >
+
   ### Cyclic Padding
 
   Cyclic padding repeats the tensors existing values along each axis in their original order.
@@ -4260,12 +4278,12 @@ defmodule Nx do
            padding_config)
         |> Enum.with_index()
         |> Enum.map(fn
-          {{a, b}, _ax} when is_integer(a) and is_integer(b) and a >= 0 and b >= 0 ->
+          {{a, b}, _ax} when is_integer(a) and is_integer(b) ->
             {a, b, 0}
 
           {pad, ax} ->
             raise ArgumentError,
-                  "expected padding config for axis #{ax} to be of the format {left, right}, with left and right as non-negative integers, got: #{inspect(pad)}"
+                  "expected padding config for axis #{ax} to be of the format {left, right}, with left and right as integers, got: #{inspect(pad)}"
         end)
 
       shape = Nx.Shape.pad(tensor.shape, padding_config)

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -3895,10 +3895,7 @@ defmodule Nx do
   end
 
   @doc """
-  Pads a tensor with a given value or a given padding type.
-
-  The padding value can either be a scalar number (for constant padding) or an atom specifying the padding type.
-  The following types of padding are supported: :cyclic, :reflect, :mirror, :replicate.
+  Pads a tensor with a given constant value.
 
   You must specify a padding configuration. A padding
   configuration is a list of tuples consisting of
@@ -3910,7 +3907,7 @@ defmodule Nx do
   the tensor is clipped on either end according to the
   padding width. Interior padding widths cannot be negative.
 
-  See also: `reflect/2`
+  See also: `reflect/2`, `pad_outer/3`
 
   ## Examples
 
@@ -4085,95 +4082,9 @@ defmodule Nx do
         ]
       >
 
-  ### Cyclic padding
-
-  Cyclic padding repeats the tensors existing values along each axis in their original order.
-
-      iex> Nx.pad(Nx.tensor([0, 1, 2]), :cyclic, [{3, 1}])
-      #Nx.Tensor<
-        s32[7]
-        [0, 1, 2, 0, 1, 2, 0]
-      >
-
-      iex> Nx.pad(Nx.tensor([[0, 1, 2], [3, 4, 5]], names: [:x, :y]), :cyclic, [{2, 0}, {2, 1}])
-      #Nx.Tensor<
-        s32[x: 4][y: 6]
-        [
-          [1, 2, 0, 1, 2, 0],
-          [4, 5, 3, 4, 5, 3],
-          [1, 2, 0, 1, 2, 0],
-          [4, 5, 3, 4, 5, 3]
-        ]
-      >
-
-  ### Mirror padding
-
-  Mirror padding repeats the tensors existing values along each axis in reverse order while including the outer most values.
-
-      iex> Nx.pad(Nx.tensor([0, 1, 2]), :mirror, [{3, 3}])
-      #Nx.Tensor<
-        s32[9]
-        [2, 1, 0, 0, 1, 2, 2, 1, 0]
-      >
-
-      iex> Nx.pad(Nx.tensor([[0, 1, 2], [3, 4, 5]], names: [:x, :y]), :mirror, [{1, 1}, {2, 2}])
-      #Nx.Tensor<
-        s32[x: 4][y: 7]
-        [
-          [1, 0, 0, 1, 2, 2, 1],
-          [1, 0, 0, 1, 2, 2, 1],
-          [4, 3, 3, 4, 5, 5, 4],
-          [4, 3, 3, 4, 5, 5, 4]
-        ]
-      >
-
-  ### Reflection padding
-
-  Reflection padding repeats the tensors existing values along each axis in reverse order skipping the outer most values.
-
-    iex> Nx.pad(Nx.tensor([0, 1, 2]), :reflect, [{3, 1}])
-    #Nx.Tensor<
-      s32[7]
-      [1, 2, 1, 0, 1, 2, 1]
-    >
-
-    iex> Nx.pad(Nx.tensor([[0, 1, 2], [3, 4, 5]], names: [:x, :y]), :reflect, [{2, 0}, {2, 1}])
-    #Nx.Tensor<
-      s32[x: 4][y: 6]
-      [
-        [2, 1, 0, 1, 2, 1],
-        [5, 4, 3, 4, 5, 4],
-        [2, 1, 0, 1, 2, 1],
-        [5, 4, 3, 4, 5, 4]
-      ]
-    >
-
-  ### Replicate padding
-
-  Replicate padding uses the tensors outer most values along each axis as constant padding values.
-
-    iex> Nx.pad(Nx.tensor([0, 1, 2]), :replicate, [{3, 1}])
-    #Nx.Tensor<
-      s32[7]
-      [0, 0, 0, 0, 1, 2, 2]
-    >
-
-    iex> Nx.pad(Nx.tensor([[0, 1, 2], [3, 4, 5]], names: [:x, :y]), :replicate, [{2, 2}, {2, 2}])
-    #Nx.Tensor<
-      s32[x: 6][y: 7]
-      [
-        [0, 0, 0, 1, 2, 2, 2],
-        [0, 0, 0, 1, 2, 2, 2],
-        [0, 0, 0, 1, 2, 2, 2],
-        [3, 3, 3, 4, 5, 5, 5],
-        [3, 3, 3, 4, 5, 5, 5],
-        [3, 3, 3, 4, 5, 5, 5]
-      ]
-    >
-
   ### Vectorized tensors
 
-  Like with the non-vectorized case, `pad_value_or_type` must be a non-vectorized scalar tensor.
+  Like with the non-vectorized case, `pad_value` must be a non-vectorized scalar tensor.
   Vectorized axes remain unchanged.
 
       iex> t = Nx.tensor([[1], [2], [3]], names: [nil, :data]) |> Nx.vectorize(:x)
@@ -4190,7 +4101,151 @@ defmodule Nx do
 
   """
   @doc type: :shape
-  def pad(tensor, pad_value_or_type, padding_config)
+  def pad(tensor, pad_value, padding_config)
+      when is_list(padding_config) and
+             (is_number(pad_value) or is_tensor(pad_value)) do
+    apply_vectorized(tensor, fn tensor, offset ->
+      output_type = binary_type(tensor, pad_value)
+      pad_value = to_tensor(pad_value)
+
+      if not (pad_value.shape == {} and pad_value.vectorized_axes == []) do
+        raise ArgumentError, "padding value must be a scalar and non-vectorized"
+      end
+
+      padding_config = List.duplicate({0, 0, 0}, offset) ++ padding_config
+      shape = Nx.Shape.pad(tensor.shape, padding_config)
+
+      out = %{tensor | type: output_type, shape: shape}
+      impl!(tensor, pad_value).pad(out, tensor, pad_value, padding_config)
+    end)
+  end
+
+  @padding_types [:cyclic, :mirror, :replicate, :reflect]
+
+  @doc """
+  Pads a tensor at the start and end of each axis with a given value or a given padding type.
+
+  The padding value can either be a scalar number (for constant padding) or an atom specifying the padding type.
+  The following types of padding are supported: :cyclic, :reflect, :mirror, :replicate.
+
+  You must specify a padding configuration. A padding
+  configuration is a list of tuples consisting of
+  `{pad_width_low, pad_width_high}` for each dimension in the
+  input tensor. The padding configuration must be of the same length
+  as the tensor shape.
+
+  Padding widths can be negative. If they are negative,
+  the tensor is clipped on either end according to the
+  padding width. Interior padding widths cannot be negative.
+
+  See also: `reflect/2`
+
+  ## Examples
+
+  ### Constant Padding
+
+      iex> Nx.pad_outer(Nx.tensor([[1, 2, 3], [4, 5, 6]]), 0, [{1, 1}, {1, 1}])
+      #Nx.Tensor<
+        s32[4][5]
+        [
+          [0, 0, 0, 0, 0],
+          [0, 1, 2, 3, 0],
+          [0, 4, 5, 6, 0],
+          [0, 0, 0, 0, 0]
+        ]
+      >
+
+  ### Cyclic Padding
+
+  Cyclic padding repeats the tensors existing values along each axis in their original order.
+
+      iex> Nx.pad_outer(Nx.tensor([0, 1, 2]), :cyclic, [{3, 1}])
+      #Nx.Tensor<
+        s32[7]
+        [0, 1, 2, 0, 1, 2, 0]
+      >
+
+      iex> Nx.pad_outer(Nx.tensor([[0, 1, 2], [3, 4, 5]], names: [:x, :y]), :cyclic, [{2, 0}, {2, 1}])
+      #Nx.Tensor<
+        s32[x: 4][y: 6]
+        [
+          [1, 2, 0, 1, 2, 0],
+          [4, 5, 3, 4, 5, 3],
+          [1, 2, 0, 1, 2, 0],
+          [4, 5, 3, 4, 5, 3]
+        ]
+      >
+
+  ### Mirror padding
+
+  Mirror padding repeats the tensors existing values along each axis in reverse order while including the outer most values.
+
+      iex> Nx.pad_outer(Nx.tensor([0, 1, 2]), :mirror, [{3, 3}])
+      #Nx.Tensor<
+        s32[9]
+        [2, 1, 0, 0, 1, 2, 2, 1, 0]
+      >
+
+      iex> Nx.pad_outer(Nx.tensor([[0, 1, 2], [3, 4, 5]], names: [:x, :y]), :mirror, [{1, 1}, {2, 2}])
+      #Nx.Tensor<
+        s32[x: 4][y: 7]
+        [
+          [1, 0, 0, 1, 2, 2, 1],
+          [1, 0, 0, 1, 2, 2, 1],
+          [4, 3, 3, 4, 5, 5, 4],
+          [4, 3, 3, 4, 5, 5, 4]
+        ]
+      >
+
+  ### Reflection padding
+
+  Reflection padding repeats the tensors existing values along each axis in reverse order skipping the outer most values.
+
+    iex> Nx.pad_outer(Nx.tensor([0, 1, 2]), :reflect, [{3, 1}])
+    #Nx.Tensor<
+      s32[7]
+      [1, 2, 1, 0, 1, 2, 1]
+    >
+
+    iex> Nx.pad_outer(Nx.tensor([[0, 1, 2], [3, 4, 5]], names: [:x, :y]), :reflect, [{2, 0}, {2, 1}])
+    #Nx.Tensor<
+      s32[x: 4][y: 6]
+      [
+        [2, 1, 0, 1, 2, 1],
+        [5, 4, 3, 4, 5, 4],
+        [2, 1, 0, 1, 2, 1],
+        [5, 4, 3, 4, 5, 4]
+      ]
+    >
+
+  ### Replicate padding
+
+  Replicate padding uses the tensors outer most values along each axis as constant padding values.
+
+    iex> Nx.pad_outer(Nx.tensor([0, 1, 2]), :replicate, [{3, 1}])
+    #Nx.Tensor<
+      s32[7]
+      [0, 0, 0, 0, 1, 2, 2]
+    >
+
+    iex> Nx.pad_outer(Nx.tensor([[0, 1, 2], [3, 4, 5]], names: [:x, :y]), :replicate, [{2, 2}, {2, 2}])
+    #Nx.Tensor<
+      s32[x: 6][y: 7]
+      [
+        [0, 0, 0, 1, 2, 2, 2],
+        [0, 0, 0, 1, 2, 2, 2],
+        [0, 0, 0, 1, 2, 2, 2],
+        [3, 3, 3, 4, 5, 5, 5],
+        [3, 3, 3, 4, 5, 5, 5],
+        [3, 3, 3, 4, 5, 5, 5]
+      ]
+    >
+
+  See also: `reflect/2`, `pad/3`
+  """
+
+  @doc type: :shape
+  def pad_outer(tensor, pad_value_or_type, padding_config)
       when is_list(padding_config) and
              (is_number(pad_value_or_type) or is_tensor(pad_value_or_type)) do
     apply_vectorized(tensor, fn tensor, offset ->
@@ -4201,7 +4256,19 @@ defmodule Nx do
         raise ArgumentError, "padding value must be a scalar and non-vectorized"
       end
 
-      padding_config = List.duplicate({0, 0, 0}, offset) ++ padding_config
+      padding_config =
+        (List.duplicate({0, 0, 0}, offset) ++
+           padding_config)
+        |> Enum.with_index()
+        |> Enum.map(fn
+          {{a, b}, _ax} when is_integer(a) and is_integer(b) and a >= 0 and b >= 0 ->
+            {a, b, 0}
+
+          {pad, ax} ->
+            raise ArgumentError,
+                  "expected padding config for axis #{ax} to be of the format {left, right}, with left and right as non-negative integers, got: #{inspect(pad)}"
+        end)
+
       shape = Nx.Shape.pad(tensor.shape, padding_config)
 
       out = %{tensor | type: output_type, shape: shape}
@@ -4209,8 +4276,7 @@ defmodule Nx do
     end)
   end
 
-  @padding_types [:cyclic, :mirror, :replicate, :reflect]
-  def pad(tensor, pad_value_or_type, padding_config) when is_atom(pad_value_or_type) do
+  def pad_outer(tensor, pad_value_or_type, padding_config) when is_atom(pad_value_or_type) do
     {left_period, right_period} =
       case pad_value_or_type do
         :cyclic ->
@@ -17624,7 +17690,7 @@ defmodule Nx do
       >
   """
   @doc type: :shape
-  @deprecated "Use pad/3 instead"
+  @deprecated "Use pad_outer/3 instead"
   def reflect(tensor, opts \\ []) do
     opts = keyword!(opts, [:padding_config])
 

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -17340,7 +17340,7 @@ defmodule Nx do
       which specify the length (0 or greater) of the reflection before and
       after the tensor along a each axis.
 
-  See also: `pad/3`
+  See also: `pad/3`, `cycle/2`, `replicate/2`, `mirror/2`
 
   ## Examples
 
@@ -17365,8 +17365,205 @@ defmodule Nx do
   def reflect(tensor, opts \\ []) do
     opts = keyword!(opts, [:padding_config])
 
+    padding_with_index(tensor,
+      padding_config: opts[:padding_config],
+      left_index_period: &left_reflect_index_period/1,
+      right_index_period: &right_reflect_index_period/1
+    )
+  end
+
+  defp left_reflect_index_period(1), do: Nx.tensor([0])
+
+  defp left_reflect_index_period(n) do
+    # Generates the indices for pre-reflecting on the axis
+    left = Nx.iota({n - 1}) |> Nx.add(1)
+    right = Nx.subtract(n - 2, Nx.iota({n - 1}))
+    Nx.concatenate([left, right])
+  end
+
+  defp right_reflect_index_period(1), do: Nx.tensor([0])
+
+  defp right_reflect_index_period(n) do
+    # Generates the indices for post-reflecting on the axis
+    left = Nx.subtract(n - 2, Nx.iota({n - 1}))
+    right = Nx.iota({n - 1}) |> Nx.add(1)
+    Nx.concatenate([left, right])
+  end
+
+  @doc """
+  Pads a tensor of rank 1 or greater along the given axes through periodic mirroring of its values.
+
+  ## Options
+
+    * `:padding_config` - A list of tuples in the format `{pre, post}`,
+      which specify the length (0 or greater) of the reflection before and
+      after the tensor along a each axis.
+
+  See also: `pad/3`, `cycle/2`, `replicate/2`, `reflect/2`
+
+  ## Examples
+
+      iex> Nx.mirror(Nx.tensor([0, 1, 2]), padding_config: [{3, 3}])
+      #Nx.Tensor<
+        s32[9]
+        [2, 1, 0, 0, 1, 2, 2, 1, 0]
+      >
+
+      iex> Nx.mirror(Nx.tensor([[0, 1, 2], [3, 4, 5]], names: [:x, :y]), padding_config: [{1, 1}, {2, 2}])
+      #Nx.Tensor<
+        s32[x: 4][y: 7]
+        [
+          [1, 0, 0, 1, 2, 2, 1],
+          [1, 0, 0, 1, 2, 2, 1],
+          [4, 3, 3, 4, 5, 5, 4],
+          [4, 3, 3, 4, 5, 5, 4]
+        ]
+      >
+  """
+  @doc type: :shape
+  def mirror(tensor, opts \\ []) do
+    opts = keyword!(opts, [:padding_config])
+
+    padding_with_index(tensor,
+      padding_config: opts[:padding_config],
+      left_index_period: &left_mirror_index_period/1,
+      right_index_period: &right_mirror_index_period/1
+    )
+  end
+
+  defp left_mirror_index_period(1), do: Nx.tensor([0])
+
+  defp left_mirror_index_period(n) do
+    # Generates the indices for pre-mirroring on the axis
+    left = Nx.iota({n})
+    right = Nx.subtract(n - 1, Nx.iota({n}))
+    Nx.concatenate([left, right])
+  end
+
+  defp right_mirror_index_period(1), do: Nx.tensor([0])
+
+  defp right_mirror_index_period(n) do
+    # Generates the indices for post-mirroring on the axis
+    left = Nx.subtract(n - 1, Nx.iota({n}))
+    right = Nx.iota({n})
+    Nx.concatenate([left, right])
+  end
+
+  @doc """
+  Pads a tensor of rank 1 or greater along the given axes through cyclic repetition of its values.
+
+  ## Options
+
+    * `:padding_config` - A list of tuples in the format `{pre, post}`,
+      which specify the length (0 or greater) of the reflection before and
+      after the tensor along a each axis.
+
+  See also: `pad/3`, `reflect/2`, `mirror/2`, `replicate/2`
+
+  ## Examples
+
+      iex> Nx.cycle(Nx.tensor([0, 1, 2]), padding_config: [{3, 1}])
+      #Nx.Tensor<
+        s32[7]
+        [0, 1, 2, 0, 1, 2, 0]
+      >
+
+      iex> Nx.cycle(Nx.tensor([[0, 1, 2], [3, 4, 5]], names: [:x, :y]), padding_config: [{2, 0}, {2, 1}])
+      #Nx.Tensor<
+        s32[x: 4][y: 6]
+        [
+          [1, 2, 0, 1, 2, 0],
+          [4, 5, 3, 4, 5, 3],
+          [1, 2, 0, 1, 2, 0],
+          [4, 5, 3, 4, 5, 3]
+        ]
+      >
+  """
+  @doc type: :shape
+  def cycle(tensor, opts \\ []) do
+    opts = keyword!(opts, [:padding_config])
+
+    padding_with_index(tensor,
+      padding_config: opts[:padding_config],
+      left_index_period: &left_cycle_index_period/1,
+      right_index_period: &right_cycle_index_period/1
+    )
+  end
+
+  defp left_cycle_index_period(1), do: Nx.tensor([0])
+
+  defp left_cycle_index_period(n) do
+    n |> Nx.subtract(Nx.iota({n})) |> Nx.subtract(1) |> Nx.remainder(n)
+  end
+
+  defp right_cycle_index_period(1), do: Nx.tensor([0])
+
+  defp right_cycle_index_period(n) do
+    Nx.iota({n})
+  end
+
+  @doc """
+  Pads a tensor of rank 1 or greater along the given axes through with its outer most values.
+
+  ## Options
+
+    * `:padding_config` - A list of tuples in the format `{pre, post}`,
+      which specify the length (0 or greater) of the reflection before and
+      after the tensor along a each axis.
+
+  See also: `pad/3`, `reflect/2`, `cycle/2`, `mirror/2`
+
+  ## Examples
+
+      iex> Nx.replicate(Nx.tensor([0, 1, 2]), padding_config: [{3, 1}])
+      #Nx.Tensor<
+        s32[7]
+        [0, 0, 0, 0, 1, 2, 2]
+      >
+
+      iex> Nx.replicate(Nx.tensor([[0, 1, 2], [3, 4, 5]], names: [:x, :y]), padding_config: [{2, 2}, {2, 2}])
+      #Nx.Tensor<
+        s32[x: 6][y: 7]
+        [
+          [0, 0, 0, 1, 2, 2, 2],
+          [0, 0, 0, 1, 2, 2, 2],
+          [0, 0, 0, 1, 2, 2, 2],
+          [3, 3, 3, 4, 5, 5, 5],
+          [3, 3, 3, 4, 5, 5, 5],
+          [3, 3, 3, 4, 5, 5, 5]
+        ]
+      >
+  """
+  @doc type: :shape
+  def replicate(tensor, opts \\ []) do
+    opts = keyword!(opts, [:padding_config])
+
+    padding_with_index(tensor,
+      padding_config: opts[:padding_config],
+      left_index_period: &left_replicate_index_period/1,
+      right_index_period: &right_replicate_index_period/1
+    )
+  end
+
+  defp left_replicate_index_period(1), do: Nx.tensor([0])
+
+  defp left_replicate_index_period(n) do
+    0 |> Nx.broadcast({n})
+  end
+
+  defp right_replicate_index_period(1), do: Nx.tensor([0])
+
+  defp right_replicate_index_period(n) do
+    (n - 1) |> Nx.broadcast({n}) |> Nx.remainder(n)
+  end
+
+  defp padding_with_index(tensor, opts) do
+    opts = keyword!(opts, [:padding_config, :left_index_period, :right_index_period])
+
     apply_vectorized(tensor, fn tensor, offset ->
       padding_config = opts[:padding_config]
+      left_index_period = opts[:left_index_period]
+      right_index_period = opts[:right_index_period]
 
       unless padding_config do
         raise ArgumentError, "missing mandatory option :padding_config"
@@ -17397,7 +17594,7 @@ defmodule Nx do
 
             left_padding =
               if(left_padding > 0) do
-                idx_period = left_reflect_index_period(n)
+                idx_period = left_index_period.(n)
                 repetitions = div(left_padding, n) + 1
 
                 idx =
@@ -17410,7 +17607,7 @@ defmodule Nx do
 
             right_padding =
               if(right_padding > 0) do
-                idx_period = right_reflect_index_period(n)
+                idx_period = right_index_period.(n)
                 repetitions = div(right_padding, n) + 1
                 idx = idx_period |> Nx.tile([repetitions]) |> Nx.take(Nx.iota({right_padding}))
                 Nx.take(tensor, idx, axis: axis)
@@ -17436,24 +17633,6 @@ defmodule Nx do
         end
       )
     end)
-  end
-
-  defp left_reflect_index_period(1), do: Nx.tensor([0])
-
-  defp left_reflect_index_period(n) do
-    # Generates the indices for pre-reflecting on the axis
-    left = Nx.iota({n - 1}) |> Nx.add(1)
-    right = Nx.subtract(n - 2, Nx.iota({n - 1}))
-    Nx.concatenate([left, right])
-  end
-
-  defp right_reflect_index_period(1), do: Nx.tensor([0])
-
-  defp right_reflect_index_period(n) do
-    # Generates the indices for post-reflecting on the axis
-    left = Nx.subtract(n - 2, Nx.iota({n - 1}))
-    right = Nx.iota({n - 1}) |> Nx.add(1)
-    Nx.concatenate([left, right])
   end
 
   @doc """

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -4082,7 +4082,7 @@ defmodule Nx do
         ]
       >
 
-  ### Vectorized tensors
+  ## Vectorized tensors
 
   Like with the non-vectorized case, `pad_value` must be a non-vectorized scalar tensor.
   Vectorized axes remain unchanged.
@@ -4138,7 +4138,7 @@ defmodule Nx do
   the tensor is clipped on either end according to the
   padding width. Interior padding widths cannot be negative.
 
-  See also: `reflect/2`
+  See also: `reflect/2`, `pad/3`
 
   ## Examples
 
@@ -4241,7 +4241,6 @@ defmodule Nx do
       ]
     >
 
-  See also: `reflect/2`, `pad/3`
   """
 
   @doc type: :shape

--- a/nx/test/nx/vectorize_test.exs
+++ b/nx/test/nx/vectorize_test.exs
@@ -415,7 +415,7 @@ defmodule Nx.VectorizeTest do
         4 3 4 5 4 3 4
       ] |> Nx.vectorize(:rows)
 
-      assert result == Nx.reflect(input, padding_config: [{3, 1}])
+      assert result == Nx.pad(input, :reflect, [{3, 1}])
     end
   end
 

--- a/nx/test/nx/vectorize_test.exs
+++ b/nx/test/nx/vectorize_test.exs
@@ -415,7 +415,7 @@ defmodule Nx.VectorizeTest do
         4 3 4 5 4 3 4
       ] |> Nx.vectorize(:rows)
 
-      assert result == Nx.pad(input, :reflect, [{3, 1}])
+      assert result == Nx.pad_outer(input, :reflect, [{3, 1}])
     end
   end
 

--- a/nx/test/nx_test.exs
+++ b/nx/test/nx_test.exs
@@ -3107,23 +3107,23 @@ defmodule NxTest do
 
   describe "reflect/2" do
     test "reflects over axes of size 1" do
-      assert Nx.tensor([1, 1, 1, 1]) == Nx.reflect(Nx.tensor([1]), padding_config: [{2, 1}])
+      assert Nx.tensor([1, 1, 1, 1]) == Nx.pad(Nx.tensor([1]), :reflect, [{2, 1}])
 
       assert Nx.tensor([[[1, 1, 1, 1]]]) ==
-               Nx.reflect(Nx.tensor([[[1]]]), padding_config: [{0, 0}, {0, 0}, {2, 1}])
+               Nx.pad(Nx.tensor([[[1]]]), :reflect, [{0, 0}, {0, 0}, {2, 1}])
     end
 
     test "semantic error on invalid padding config" do
       assert_raise ArgumentError,
                    "expected padding config for axis 0 to be of the format {left, right}, with left and right as non-negative integers, got: {0}",
                    fn ->
-                     Nx.reflect(Nx.tensor([0]), padding_config: [{0}])
+                     Nx.pad(Nx.tensor([0]), :reflect, [{0}])
                    end
 
       assert_raise ArgumentError,
                    "expected padding config for axis 2 to be of the format {left, right}, with left and right as non-negative integers, got: {-1, 0}",
                    fn ->
-                     Nx.reflect(Nx.tensor([[[0]]]), padding_config: [{0, 0}, {0, 0}, {-1, 0}])
+                     Nx.pad(Nx.tensor([[[0]]]), :reflect, [{0, 0}, {0, 0}, {-1, 0}])
                    end
     end
   end

--- a/nx/test/nx_test.exs
+++ b/nx/test/nx_test.exs
@@ -3116,23 +3116,23 @@ defmodule NxTest do
 
   describe "reflect/2" do
     test "reflects over axes of size 1" do
-      assert Nx.tensor([1, 1, 1, 1]) == Nx.pad(Nx.tensor([1]), :reflect, [{2, 1}])
+      assert Nx.tensor([1, 1, 1, 1]) == Nx.pad_outer(Nx.tensor([1]), :reflect, [{2, 1}])
 
       assert Nx.tensor([[[1, 1, 1, 1]]]) ==
-               Nx.pad(Nx.tensor([[[1]]]), :reflect, [{0, 0}, {0, 0}, {2, 1}])
+               Nx.pad_outer(Nx.tensor([[[1]]]), :reflect, [{0, 0}, {0, 0}, {2, 1}])
     end
 
     test "semantic error on invalid padding config" do
       assert_raise ArgumentError,
                    "expected padding config for axis 0 to be of the format {left, right}, with left and right as non-negative integers, got: {0}",
                    fn ->
-                     Nx.pad(Nx.tensor([0]), :reflect, [{0}])
+                     Nx.pad_outer(Nx.tensor([0]), :reflect, [{0}])
                    end
 
       assert_raise ArgumentError,
                    "expected padding config for axis 2 to be of the format {left, right}, with left and right as non-negative integers, got: {-1, 0}",
                    fn ->
-                     Nx.pad(Nx.tensor([[[0]]]), :reflect, [{0, 0}, {0, 0}, {-1, 0}])
+                     Nx.pad_outer(Nx.tensor([[[0]]]), :reflect, [{0, 0}, {0, 0}, {-1, 0}])
                    end
     end
   end

--- a/nx/test/nx_test.exs
+++ b/nx/test/nx_test.exs
@@ -3116,23 +3116,23 @@ defmodule NxTest do
 
   describe "reflect/2" do
     test "reflects over axes of size 1" do
-      assert Nx.tensor([1, 1, 1, 1]) == Nx.reflect(Nx.tensor([1]), padding_config: [{2, 1}])
+      assert Nx.tensor([1, 1, 1, 1]) == Nx.pad(Nx.tensor([1]), :reflect, [{2, 1}])
 
       assert Nx.tensor([[[1, 1, 1, 1]]]) ==
-               Nx.reflect(Nx.tensor([[[1]]]), padding_config: [{0, 0}, {0, 0}, {2, 1}])
+               Nx.pad(Nx.tensor([[[1]]]), :reflect, [{0, 0}, {0, 0}, {2, 1}])
     end
 
     test "semantic error on invalid padding config" do
       assert_raise ArgumentError,
                    "expected padding config for axis 0 to be of the format {left, right}, with left and right as non-negative integers, got: {0}",
                    fn ->
-                     Nx.reflect(Nx.tensor([0]), padding_config: [{0}])
+                     Nx.pad(Nx.tensor([0]), :reflect, [{0}])
                    end
 
       assert_raise ArgumentError,
                    "expected padding config for axis 2 to be of the format {left, right}, with left and right as non-negative integers, got: {-1, 0}",
                    fn ->
-                     Nx.reflect(Nx.tensor([[[0]]]), padding_config: [{0, 0}, {0, 0}, {-1, 0}])
+                     Nx.pad(Nx.tensor([[[0]]]), :reflect, [{0, 0}, {0, 0}, {-1, 0}])
                    end
     end
   end


### PR DESCRIPTION
Until now only constante padding (`Nx.pad/3`) and reflection padding `Nx.reflect/2` are supported by Nx.

This pull request adds `Nx.cycle/2` for cyclic padding, `Nx.replicate/2` for using the outmost value along each axis as pad value and `Nx.mirror/2` which behaves similar to `Nx.reflect/2` but does repeat the edge values.

I did already propose especially the cyclic padding in https://github.com/elixir-nx/nx/issues/1708