### PR TITLE
fix(exla): lower f64 rsqrt as 1/sqrt(x) for IEEE-correct rounding

### DIFF
--- a/exla/lib/exla/mlir/value.ex
+++ b/exla/lib/exla/mlir/value.ex
@@ -123,7 +123,6 @@ defmodule EXLA.MLIR.Value do
     erf: "chlo.erf",
     erfc: "chlo.erfc",
     erf_inv: "chlo.erf_inv",
-    rsqrt: "stablehlo.rsqrt",
     negate: "stablehlo.negate",
     count_leading_zeros: "stablehlo.count_leading_zeros",
     population_count: "stablehlo.popcnt",
@@ -136,6 +135,42 @@ defmodule EXLA.MLIR.Value do
     def unquote(op)(%Value{function: func} = operand, typespec) do
       result_types = typespecs_to_mlir_types([typespec])
       op(func, unquote(op_name), [operand], result_types, []) |> one!()
+    end
+  end
+
+  # `stablehlo.rsqrt` is in StableHLO's implementation-defined-precision bucket,
+  # so XLA's CPU/GPU backends are free to lower it to a fused approximation
+  # (e.g. `vrsqrtps` + a Newton iteration) that is up to 1 ULP off from the
+  # IEEE-correctly-rounded value of `1/sqrt(x)`. Both `stablehlo.sqrt` and
+  # `stablehlo.divide` *are* in the correctly-rounded bucket, so for f64 we
+  # lower `rsqrt` as an explicit `1/sqrt(x)`.
+  #
+  # The catch: XLA's algebraic simplifier rewrites `divide(constant(1), sqrt(x))`
+  # back into `rsqrt(x)` after compilation, undoing the decomposition. We
+  # insert a `stablehlo.optimization_barrier` between `sqrt` and `divide` to
+  # block that pattern match.
+  #
+  # f32 keeps the fast `stablehlo.rsqrt` path because ML workloads (LayerNorm,
+  # attention) rely on the fused approximate instruction for throughput.
+  def rsqrt(%Value{function: func} = operand, typespec) do
+    case typespec.type do
+      {:f, 64} ->
+        result_types = typespecs_to_mlir_types([typespec])
+        scalar_typespec = Typespec.to_shape(typespec, {})
+        one_scalar = constant(func, [1.0], scalar_typespec)
+        one = broadcast_in_dim(one_scalar, [], typespec)
+        sqrt_x = sqrt(operand, typespec)
+
+        # Block XLA's algebraic simplifier from folding `1/sqrt(x)` back into
+        # `stablehlo.rsqrt(x)`, which would defeat the precision fix.
+        sqrt_x_barrier =
+          op(func, "stablehlo.optimization_barrier", [sqrt_x], result_types, []) |> one!()
+
+        divide(one, sqrt_x_barrier, typespec)
+
+      _ ->
+        result_types = typespecs_to_mlir_types([typespec])
+        op(func, "stablehlo.rsqrt", [operand], result_types, []) |> one!()
     end
   end
 

--- a/exla/test/exla/backend_test.exs
+++ b/exla/test/exla/backend_test.exs
@@ -28,6 +28,25 @@ defmodule EXLA.BackendTest do
   doctest Nx,
     except: [:moduledoc] ++ @excluded_doctests
 
+  test "rsqrt is IEEE-correctly rounded for f64" do
+    # Regression for the recurring f64 rsqrt doctest failure.
+    #
+    # `stablehlo.rsqrt` is in StableHLO's implementation-defined-precision
+    # bucket, so backends are free to lower it to a fused approximation
+    # (e.g. AVX `vrsqrtps` + Newton iteration) that may be 1 ULP off from the
+    # IEEE-correctly-rounded value of `1/sqrt(x)`. Both `stablehlo.sqrt` and
+    # `stablehlo.divide` *are* in the correctly-rounded bucket, so EXLA lowers
+    # f64 `rsqrt` as an explicit `1/sqrt(x)` and the result must match
+    # Erlang's `:math.sqrt` bit-for-bit.
+    #
+    # Concretely: the round-to-nearest-even f64 of `1/sqrt(3)` is
+    # `0.5773502691896258`. The fused approximation returned
+    # `0.5773502691896257` — exactly 1 ULP low.
+    result = Nx.rsqrt(Nx.tensor([1.0, 2.0, 3.0], type: :f64))
+    expected = [1.0, 1.0 / :math.sqrt(2.0), 1.0 / :math.sqrt(3.0)]
+    assert Nx.to_flat_list(result) == expected
+  end
+
   test "Nx.to_binary/1" do
     t = Nx.tensor([1, 2, 3, 4], backend: EXLA.Backend)
     assert Nx.to_binary(t) == <<1::32-native, 2::32-native, 3::32-native, 4::32-native>>


### PR DESCRIPTION
Tracks #1727. Replaces the previous skip / unskip dance from #1704.

## Problem

`Nx.rsqrt/1` for f64 returns values 1 ULP off the IEEE-correctly-rounded result, surfacing as the recurring `Nx.rsqrt/1` doctest failure in `EXLA.BackendTest`:

```
left:  [1.0, 0.7071067811865476, 0.5773502691896257]   ← EXLA
right: [1.0, 0.7071067811865475, 0.5773502691896258]   ← Erlang :math
```

It's not flaky — it's deterministically wrong wherever the approximate-precision lowering fires. Full root-cause writeup in #1727.

## Fix

`stablehlo.rsqrt` is in StableHLO's implementation-defined-precision bucket; both `stablehlo.sqrt` and `stablehlo.divide` are in the correctly-rounded bucket. So for f64, lower `rsqrt(x)` as an explicit `1/sqrt(x)`:

```elixir
def rsqrt(%Value{function: func} = operand, typespec) do
  case typespec.type do
    {:f, 64} ->
      result_types = typespecs_to_mlir_types([typespec])
      scalar_typespec = Typespec.to_shape(typespec, {})
      one_scalar = constant(func, [1.0], scalar_typespec)
      one = broadcast_in_dim(one_scalar, [], typespec)
      sqrt_x = sqrt(operand, typespec)

      sqrt_x_barrier =
        op(func, "stablehlo.optimization_barrier", [sqrt_x], result_types, []) |> one!()

      divide(one, sqrt_x_barrier, typespec)

    _ ->
      result_types = typespecs_to_mlir_types([typespec])
      op(func, "stablehlo.rsqrt", [operand], result_types, []) |> one!()
  end
end
```

### The `optimization_barrier`

XLA's algebraic simplifier rewrites `divide(constant(1), sqrt(x))` back into `stablehlo.rsqrt(x)` after lowering, undoing the decomposition. A `stablehlo.optimization_barrier` between `sqrt` and `divide` blocks the pattern match. Without it, this PR is a no-op — verified locally.

### What this does **not** change

`f32` (and complex types) still go through the fast `stablehlo.rsqrt` path. ML workloads (LayerNorm, attention norm) rely on the fused approximate instruction for throughput, and the f32 doctests aren't currently failing. Only f64 is touched.

## Regression test

Added `test "rsqrt is IEEE-correctly rounded for f64"` in `EXLA.BackendTest`. Bit-exact `==` against `:math.sqrt`, not `assert_in_delta` — tolerance would hide the very bug being fixed. Comment captures the StableHLO bucket and the simplifier interaction so future maintainers can decide when the workaround is safe to remove.

## Test plan

- [x] New regression test fails before the fix, passes after
- [x] Existing `Nx.rsqrt/1` doctest now passes (no longer needs to be skipped)
- [x] Full `mix test test/exla/backend_test.exs` — 21 tests / 9 failures (down from 20 / 10 on `main`); all 9 remaining failures are pre-existing on `main` and unrelated (Nx.atan2, conv, covariance, variance, weighted_mean)
- [x] `mix test test/exla/defn/expr_test.exs` — 294/0 unchanged

## Removability

When the corresponding XLA-side fix lands and EXLA bumps to a version containing it, this entire PR can be reverted in one commit — the inline comment makes the rationale explicit.

## Related

- #1727 — tracking issue for the broader f64 transcendental precision class
- #1704 — prior rollback that misdiagnosed the failure as flakiness
- #1703 — sibling precision fix (`precision: :highest` in EXLA tests, TF32 matmul, distinct issue)