### PR TITLE
Implement EXLA hooks via host callback without outfeed

### DIFF
--- a/exla/c_src/exla/custom_calls/runtime_callback.cc
+++ b/exla/c_src/exla/custom_calls/runtime_callback.cc
@@ -1,80 +1,86 @@
 #include "runtime_callback_bridge.h"
 
 #include <cstring>
-#include <vector>
 #include <string>
+#include <vector>
 
 #include "xla/ffi/api/ffi.h"
 #include "xla/ffi/ffi_api.h"
 
 namespace ffi = xla::ffi;
 
+namespace exla::callback_bridge {
+
+Arg::Arg(const xla::ffi::AnyBuffer &buf) {
+  dtype = buf.element_type();
+  auto d = buf.dimensions();
+  dims.assign(d.begin(), d.end());
+  data = reinterpret_cast<const uint8_t *>(buf.untyped_data());
+  size_bytes = buf.size_bytes();
+}
+
+OutputBuffer::OutputBuffer(const xla::ffi::AnyBuffer &buf) {
+  data = static_cast<uint8_t *>(buf.untyped_data());
+  size = ffi::ByteWidth(buf.element_type()) *
+         static_cast<size_t>(buf.element_count());
+}
+
+} // namespace exla::callback_bridge
+
 namespace {
 
-ffi::Error
-exla_runtime_callback_impl(ffi::RemainingArgs args,
-                           ffi::Span<const int64_t> callback_id_words,
-                           uint64_t callback_id_size, ffi::RemainingRets rets) {
-  if (args.size() == 0) {
+ffi::Error exla_runtime_callback_impl(
+    ffi::RemainingArgs args, ffi::Span<const int64_t> callback_id_words,
+    uint64_t callback_id_size, uint64_t num_aliased_data_outputs,
+    ffi::RemainingRets rets) {
+  // We currently only support leading aliased outputs, but this is just
+  // a way to make things easier. We can extend this to support index-based
+  // aliasing in the future.
+
+  // args[0] = callback_server_pid, args[1..] = leaf operands
+
+  if (args.size() < 1) {
     return ffi::Error(ffi::ErrorCode::kInternal,
-                      "runtime callback missing callback server pid operand");
+                      "host callback missing callback server pid operand");
   }
 
-  const size_t callback_args_end = args.size();
-
-  // Collect all input tensors into lightweight payload views.
   std::vector<exla::callback_bridge::Arg> inputs;
-  inputs.reserve(callback_args_end - 1);
-  exla::callback_bridge::Arg callback_server_pid_arg;
+  inputs.reserve(args.size() - 1);
 
-  for (size_t i = 0; i < args.size(); ++i) {
-    auto maybe_buf_or = args.get<ffi::AnyBuffer>(i);
-    if (!maybe_buf_or) {
-      return maybe_buf_or.error();
+  auto callback_server_pid_or = args.get<ffi::AnyBuffer>(0);
+  if (!callback_server_pid_or) {
+    return callback_server_pid_or.error();
+  }
+  exla::callback_bridge::Arg callback_server_pid_arg(*callback_server_pid_or);
+
+  for (size_t i = 1; i < args.size(); ++i) {
+    auto buf_or = args.get<ffi::AnyBuffer>(i);
+    if (!buf_or) {
+      return buf_or.error();
     }
 
-    ffi::AnyBuffer buf = *maybe_buf_or;
-
-    exla::callback_bridge::Arg tensor;
-    tensor.dtype = buf.element_type();
-
-    auto dims = buf.dimensions();
-    tensor.dims.assign(dims.begin(), dims.end());
-
-    tensor.data = reinterpret_cast<const uint8_t *>(buf.untyped_data());
-    tensor.size_bytes = buf.size_bytes();
-
-    if (i == 0) {
-      callback_server_pid_arg = std::move(tensor);
-    } else {
-      inputs.push_back(std::move(tensor));
-    }
+    inputs.push_back(exla::callback_bridge::Arg(*buf_or));
   }
 
-  // Prepare output buffer descriptors so the callback bridge can write results
-  // directly into the final destination buffers.
+  // rets[0 .. num_aliased_data_outputs-1] are aliased to the input operands;
+  // the callback is not expected to fill them.
+  // Non-aliased outputs (runtime_call results) start at
+  // num_aliased_data_outputs.
   std::vector<exla::callback_bridge::OutputBuffer> outputs;
-  outputs.reserve(rets.size());
+  size_t first_real_ret = static_cast<size_t>(num_aliased_data_outputs);
+  outputs.reserve(rets.size() > first_real_ret ? rets.size() - first_real_ret
+                                               : 0);
 
-  for (size_t i = 0; i < rets.size(); ++i) {
-    auto maybe_ret_or = rets.get<ffi::AnyBuffer>(i);
-    if (!maybe_ret_or) {
-      return maybe_ret_or.error();
+  for (size_t i = first_real_ret; i < rets.size(); ++i) {
+    auto ret_or = rets.get<ffi::AnyBuffer>(i);
+    if (!ret_or) {
+      return ret_or.error();
     }
 
-    ffi::Result<ffi::AnyBuffer> ret = *maybe_ret_or;
-    ffi::AnyBuffer out = *ret;
-
-    exla::callback_bridge::OutputBuffer buf;
-    buf.data = static_cast<uint8_t *>(out.untyped_data());
-    buf.size = ffi::ByteWidth(out.element_type()) *
-               static_cast<size_t>(out.element_count());
-
-    outputs.push_back(buf);
+    ffi::Result<ffi::AnyBuffer> ret = *ret_or;
+    outputs.push_back(exla::callback_bridge::OutputBuffer(*ret));
   }
 
-  // Call back into Elixir through the bridge. On success, the bridge writes
-  // results directly into the provided output buffers.
   exla::callback_bridge::Result result =
       exla::callback_bridge::InvokeRuntimeCallback(
           callback_id_words, callback_id_size, callback_server_pid_arg, inputs,
@@ -94,6 +100,7 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(exla_runtime_callback, exla_runtime_callback_impl,
                                   .RemainingArgs()
                                   .Attr<ffi::Span<const int64_t>>("callback_id")
                                   .Attr<uint64_t>("callback_id_size")
+                                  .Attr<uint64_t>("num_aliased_data_outputs")
                                   .RemainingRets());
 
 XLA_FFI_REGISTER_HANDLER(ffi::GetXlaFfiApi(), "exla_runtime_callback", "Host",

--- a/exla/c_src/exla/custom_calls/runtime_callback_bridge.h
+++ b/exla/c_src/exla/custom_calls/runtime_callback_bridge.h
@@ -20,6 +20,9 @@ struct Arg {
   std::vector<int64_t> dims;
   const uint8_t *data = nullptr;
   size_t size_bytes = 0;
+
+  Arg() = default;
+  Arg(const xla::ffi::AnyBuffer &buf);
 };
 
 // Result of an Elixir callback. On success, data has already been copied into
@@ -35,6 +38,8 @@ struct Result {
 struct OutputBuffer {
   uint8_t *data = nullptr;
   size_t size = 0;
+
+  OutputBuffer(const xla::ffi::AnyBuffer &buf);
 };
 
 // Per-callback pending state used to synchronize between the XLA host thread

--- a/exla/c_src/exla/custom_calls/runtime_callback_cuda.cc
+++ b/exla/c_src/exla/custom_calls/runtime_callback_cuda.cc
@@ -15,23 +15,33 @@ namespace ffi = xla::ffi;
 
 namespace {
 
+exla::callback_bridge::Arg arg_from_host_buffer(const ffi::AnyBuffer &buf,
+                                                std::vector<uint8_t> &host_buf) {
+  exla::callback_bridge::Arg tensor;
+  tensor.dtype = buf.element_type();
+  auto dims = buf.dimensions();
+  tensor.dims.assign(dims.begin(), dims.end());
+  tensor.data = host_buf.data();
+  tensor.size_bytes = host_buf.size();
+  return tensor;
+}
+
 ffi::Error exla_runtime_callback_cuda_impl(
     CUstream stream, ffi::RemainingArgs args,
     ffi::Span<const int64_t> callback_id_words, uint64_t callback_id_size,
+    uint64_t num_aliased_data_outputs,
     ffi::RemainingRets rets) {
-  if (args.size() == 0) {
+  // args[0] = callback_server_pid, args[1..] = leaf operands
+  if (args.size() < 1) {
     return ffi::Error(ffi::ErrorCode::kInternal,
-                      "runtime callback missing callback server pid operand");
+                      "host callback missing callback server pid operand");
   }
 
-  const size_t callback_args_end = args.size();
-
-  // Keep host buffers alive for the duration of the callback.
   std::vector<std::vector<uint8_t>> host_input_buffers;
-  host_input_buffers.reserve(callback_args_end);
+  host_input_buffers.reserve(args.size());
 
   std::vector<exla::callback_bridge::Arg> inputs;
-  inputs.reserve(callback_args_end - 1);
+  inputs.reserve(args.size() - 1);
   exla::callback_bridge::Arg callback_server_pid_arg;
 
   for (size_t i = 0; i < args.size(); ++i) {
@@ -41,6 +51,7 @@ ffi::Error exla_runtime_callback_cuda_impl(
     }
 
     ffi::AnyBuffer buf = *maybe_buf_or;
+
     size_t size_bytes = buf.size_bytes();
 
     host_input_buffers.emplace_back(size_bytes);
@@ -62,12 +73,8 @@ ffi::Error exla_runtime_callback_cuda_impl(
                             cudaGetErrorString(err));
     }
 
-    exla::callback_bridge::Arg tensor;
-    tensor.dtype = buf.element_type();
-    auto dims = buf.dimensions();
-    tensor.dims.assign(dims.begin(), dims.end());
-    tensor.data = host_buf.data();
-    tensor.size_bytes = size_bytes;
+    exla::callback_bridge::Arg tensor = arg_from_host_buffer(buf, host_buf);
+
     if (i == 0) {
       callback_server_pid_arg = std::move(tensor);
     } else {
@@ -75,17 +82,20 @@ ffi::Error exla_runtime_callback_cuda_impl(
     }
   }
 
-  // Outputs: host staging buffers; bridge will write into these, then we H→D.
+  // rets[0 .. num_aliased_data_outputs-1] are aliased to input operands;
+  // non-aliased outputs start at num_aliased_data_outputs.
+  size_t first_real_ret = static_cast<size_t>(num_aliased_data_outputs);
+
   std::vector<std::vector<uint8_t>> host_output_buffers;
-  host_output_buffers.reserve(rets.size());
+  host_output_buffers.reserve(rets.size() > first_real_ret ? rets.size() - first_real_ret : 0);
 
   std::vector<exla::callback_bridge::OutputBuffer> outputs;
-  outputs.reserve(rets.size());
+  outputs.reserve(rets.size() > first_real_ret ? rets.size() - first_real_ret : 0);
 
   std::vector<void *> device_output_ptrs;
-  device_output_ptrs.reserve(rets.size());
+  device_output_ptrs.reserve(rets.size() > first_real_ret ? rets.size() - first_real_ret : 0);
 
-  for (size_t i = 0; i < rets.size(); ++i) {
+  for (size_t i = first_real_ret; i < rets.size(); ++i) {
     auto maybe_ret_or = rets.get<ffi::AnyBuffer>(i);
     if (!maybe_ret_or) {
       return maybe_ret_or.error();
@@ -117,7 +127,7 @@ ffi::Error exla_runtime_callback_cuda_impl(
     return ffi::Error(ffi::ErrorCode::kInternal, result.error);
   }
 
-  for (size_t i = 0; i < rets.size(); ++i) {
+  for (size_t i = 0; i < device_output_ptrs.size(); ++i) {
     size_t size = outputs[i].size;
     cudaError_t err =
         cudaMemcpyAsync(device_output_ptrs[i], host_output_buffers[i].data(),
@@ -141,6 +151,7 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(
         .RemainingArgs()
         .Attr<ffi::Span<const int64_t>>("callback_id")
         .Attr<uint64_t>("callback_id_size")
+        .Attr<uint64_t>("num_aliased_data_outputs")
         .RemainingRets());
 
 XLA_FFI_REGISTER_HANDLER(ffi::GetXlaFfiApi(), "exla_runtime_callback", "CUDA",
@@ -151,7 +162,7 @@ XLA_FFI_REGISTER_HANDLER(ffi::GetXlaFfiApi(), "exla_runtime_callback", "CUDA",
 namespace {
 
 ffi::Error exla_runtime_callback_cuda_stub(
-    ffi::RemainingArgs, ffi::Span<const int64_t>, uint64_t,
+    ffi::RemainingArgs, ffi::Span<const int64_t>, uint64_t, uint64_t,
     ffi::RemainingRets) {
   return ffi::Error(ffi::ErrorCode::kUnimplemented,
                     "EXLA was not compiled with CUDA support. This error means your EXLA compilation is out of sync with your libexla.so NIF.");
@@ -165,6 +176,7 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(
         .RemainingArgs()
         .Attr<ffi::Span<const int64_t>>("callback_id")
         .Attr<uint64_t>("callback_id_size")
+        .Attr<uint64_t>("num_aliased_data_outputs")
         .RemainingRets());
 
 XLA_FFI_REGISTER_HANDLER(ffi::GetXlaFfiApi(), "exla_runtime_callback", "CUDA",

--- a/exla/config/config.exs
+++ b/exla/config/config.exs
@@ -1,3 +1,5 @@
 import Config
 
 config :exla, :add_backend_on_inspect, config_env() != :test
+
+config :logger, :default_formatter, metadata: [:test, :test_module, :file, :line]

--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -791,56 +791,6 @@ defmodule EXLA.Defn do
     {[], cache}
   end
 
-  defp add_host_hook_callback(cache, state, id, name, callback, tensor_expr) do
-    %{
-      client: %EXLA.Client{platform: platform},
-      callback_pid_value: callback_pid_value
-    } = state
-
-    outfeed = get_outfeed(cache)
-
-    if name in outfeed.used_hooks do
-      case platform do
-        p when p in [:host, :cuda] ->
-          {reverse_arg_values, cache} =
-            Composite.reduce(tensor_expr, {[], cache}, fn %T{} = expr, {acc, cache} ->
-              {value, cache} = recur_operator(expr, state, cache) |> unwrap_single_tensor!()
-              {[value | acc], cache}
-            end)
-
-          arg_values = Enum.reverse(reverse_arg_values)
-          arg_template = Nx.to_template(tensor_expr)
-          callback_spec = {:named, name, callback}
-
-          cache = add_callback(cache, {id, callback_spec, nil, arg_template})
-
-          unless callback_pid_value do
-            raise "internal bug: hook callback pid operand is missing"
-          end
-
-          leaf_typespecs = Enum.map(arg_values, &Value.get_typespec/1)
-          num_aliased = length(leaf_typespecs)
-
-          Value.host_callback(
-            [callback_pid_value | arg_values],
-            leaf_typespecs,
-            id,
-            num_aliased
-          )
-
-          cache
-
-        other ->
-          raise """
-          hooks are currently only supported for EXLA CPU (platform: :host) and CUDA (platform: :cuda),
-          but the active EXLA client is configured for platform #{inspect(other)}.
-          """
-      end
-    else
-      cache
-    end
-  end
-
   defp cached_recur_operator(
          :runtime_call,
          %T{data: %Expr{id: id, args: [tensor_expr, fun, out_template, opts]}} = expr,
@@ -917,6 +867,56 @@ defmodule EXLA.Defn do
   defp cached_recur_operator(op, expr, state, cache) do
     {args, cache} = Tree.apply_args(expr, cache, &recur_operator(&1, state, &2))
     {to_operator(op, args, expr, state), cache}
+  end
+
+  defp add_host_hook_callback(cache, state, id, name, callback, tensor_expr) do
+    %{
+      client: %EXLA.Client{platform: platform},
+      callback_pid_value: callback_pid_value
+    } = state
+
+    outfeed = get_outfeed(cache)
+
+    if name in outfeed.used_hooks do
+      case platform do
+        p when p in [:host, :cuda] ->
+          {reverse_arg_values, cache} =
+            Composite.reduce(tensor_expr, {[], cache}, fn %T{} = expr, {acc, cache} ->
+              {value, cache} = recur_operator(expr, state, cache) |> unwrap_single_tensor!()
+              {[value | acc], cache}
+            end)
+
+          arg_values = Enum.reverse(reverse_arg_values)
+          arg_template = Nx.to_template(tensor_expr)
+          callback_spec = {:named, name, callback}
+
+          cache = add_callback(cache, {id, callback_spec, nil, arg_template})
+
+          unless callback_pid_value do
+            raise "internal bug: hook callback pid operand is missing"
+          end
+
+          leaf_typespecs = Enum.map(arg_values, &Value.get_typespec/1)
+          num_aliased = length(leaf_typespecs)
+
+          Value.host_callback(
+            [callback_pid_value | arg_values],
+            leaf_typespecs,
+            id,
+            num_aliased
+          )
+
+          cache
+
+        other ->
+          raise """
+          hooks are currently only supported for EXLA CPU (platform: :host) and CUDA (platform: :cuda),
+          but the active EXLA client is configured for platform #{inspect(other)}.
+          """
+      end
+    else
+      cache
+    end
   end
 
   defp cast_custom_call_operands(call_args, :default), do: call_args

--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -234,7 +234,7 @@ defmodule EXLA.Defn do
          run_options,
          is_sharded?
        )
-       when Outfeed.will_outfeed(outfeed) or Outfeed.has_runtime_calls(outfeed) do
+       when Outfeed.has_infeed_flags(outfeed) or Outfeed.has_callbacks(outfeed) do
     if is_sharded? do
       raise ArgumentError, "outfeed is not supported for sharded execution yet"
     end
@@ -320,6 +320,7 @@ defmodule EXLA.Defn do
        ) do
     {cache, options} = Keyword.pop(options, :cache, true)
     {hooks, options} = Keyword.pop(options, :hooks, %{})
+
     {debug?, options} = Keyword.pop(options, :debug, false)
     {lazy_transfers, options} = Keyword.pop(options, :lazy_transfers, :opt_in)
 
@@ -365,7 +366,10 @@ defmodule EXLA.Defn do
         :timer.tc(fn ->
           expr_cache_fun.({key, args_key, lazy_transfers}, fn ->
             expr = fun.(vars)
-            inputs_and_hooks = Outfeed.used_inputs_and_hooks(expr, used_inputs, lazy_transfers)
+
+            inputs_and_hooks =
+              Outfeed.used_inputs_and_hooks(expr, used_inputs, lazy_transfers)
+
             {expr, {make_ref(), Nx.to_template(expr), inputs_and_hooks}}
           end)
         end)
@@ -423,10 +427,10 @@ defmodule EXLA.Defn do
                 end)
               end
 
-              # Only create the token when we know it will actually be
-              # used, that is: streaming, lazy transfers or hooks
+              # Only create the token when it will actually be used, that is:
+              # streaming (infeed/outfeed) or lazy transfers
               outfeed =
-                if reverse_infeeds != [] or hooks != %{} or defined_hooks != %{} do
+                if reverse_infeeds != [] do
                   outfeed
                   |> Outfeed.with_token(Value.create_token(builder))
                   |> Outfeed.add_infeeds(builder, reverse_infeeds)
@@ -490,6 +494,7 @@ defmodule EXLA.Defn do
       if evaled && cache, do: check_recompilation(key, args_key)
 
       outfeed = Outfeed.with_user_hooks(outfeed, hooks)
+
       {executable, {used_inputs, outputs, outfeed, inputs_and_typespecs}}
     end)
   end
@@ -769,48 +774,81 @@ defmodule EXLA.Defn do
     end
   end
 
-  defp cached_recur_operator(
-         :runtime_call,
-         %T{data: %Expr{id: id, args: [tensor_expr, fun, out_template, opts]}} = expr,
-         %{client: %EXLA.Client{platform: :host}, callback_pid_value: callback_pid_value} =
-           state,
-         cache
-       ) do
-    # Flatten the tensor_or_container expression into its tensor leaves so we
-    # can compile each as an independent operand to the host callback.
-    tensor_exprs = Composite.flatten_list([tensor_expr])
+  defp cached_recur_operator(:attach_token, %T{data: %Expr{args: [token, expr]}}, state, cache) do
+    {op, cache} = recur_operator(expr, state, cache)
+    {_, cache} = recur_operator(token, state, cache)
+    {op, cache}
+  end
 
-    {arg_values, cache} =
-      Enum.map_reduce(tensor_exprs, cache, fn arg, cache ->
-        recur_operator(arg, state, cache) |> unwrap_single_tensor!()
+  defp cached_recur_operator(:token, %T{data: %Expr{args: [token]}}, state, cache) do
+    cache =
+      List.foldr(token.hooks, cache, fn %{name: name, expr: expr, callback: callback}, cache ->
+        {_, cache} = recur_flatten(expr, state, cache)
+        id = make_ref()
+        add_host_hook_callback(cache, state, id, name, callback, expr)
       end)
 
-    # Build a template container for the tensor_or_container argument so the
-    # callback server can reconstruct the full structure from a flat list of
-    # decoded tensors.
-    arg_template = Nx.to_template(tensor_expr)
+    {[], cache}
+  end
 
-    cache = add_runtime_callback(cache, {id, fun, out_template, arg_template, opts})
+  defp add_host_hook_callback(cache, state, id, name, callback, tensor_expr) do
+    %{
+      client: %EXLA.Client{platform: platform},
+      callback_pid_value: callback_pid_value
+    } = state
 
-    typespecs = container_to_typespecs(out_template)
+    outfeed = get_outfeed(cache)
 
-    unless callback_pid_value do
-      raise "internal bug: runtime_call callback pid operand is missing"
+    if name in outfeed.used_hooks do
+      case platform do
+        p when p in [:host, :cuda] ->
+          {reverse_arg_values, cache} =
+            Composite.reduce(tensor_expr, {[], cache}, fn %T{} = expr, {acc, cache} ->
+              {value, cache} = recur_operator(expr, state, cache) |> unwrap_single_tensor!()
+              {[value | acc], cache}
+            end)
+
+          arg_values = Enum.reverse(reverse_arg_values)
+          arg_template = Nx.to_template(tensor_expr)
+          callback_spec = {:named, name, callback}
+
+          cache = add_callback(cache, {id, callback_spec, nil, arg_template})
+
+          unless callback_pid_value do
+            raise "internal bug: hook callback pid operand is missing"
+          end
+
+          leaf_typespecs = Enum.map(arg_values, &Value.get_typespec/1)
+          num_aliased = length(leaf_typespecs)
+
+          Value.host_callback(
+            [callback_pid_value | arg_values],
+            leaf_typespecs,
+            id,
+            num_aliased
+          )
+
+          cache
+
+        other ->
+          raise """
+          hooks are currently only supported for EXLA CPU (platform: :host) and CUDA (platform: :cuda),
+          but the active EXLA client is configured for platform #{inspect(other)}.
+          """
+      end
+    else
+      cache
     end
-
-    results =
-      Value.runtime_call([callback_pid_value | arg_values], typespecs, id)
-
-    {wrap_tuple_result(results, expr), cache}
   end
 
   defp cached_recur_operator(
          :runtime_call,
          %T{data: %Expr{id: id, args: [tensor_expr, fun, out_template, opts]}} = expr,
-         %{client: %EXLA.Client{platform: :cuda}, callback_pid_value: callback_pid_value} =
+         %{client: %EXLA.Client{platform: platform}, callback_pid_value: callback_pid_value} =
            state,
          cache
-       ) do
+       )
+       when platform in [:host, :cuda] do
     tensor_exprs = Composite.flatten_list([tensor_expr])
 
     {arg_values, cache} =
@@ -819,17 +857,15 @@ defmodule EXLA.Defn do
       end)
 
     arg_template = Nx.to_template(tensor_expr)
-
-    cache = add_runtime_callback(cache, {id, fun, out_template, arg_template, opts})
-
     typespecs = container_to_typespecs(out_template)
+
+    cache = add_callback(cache, {id, fun, out_template, arg_template, opts})
 
     unless callback_pid_value do
       raise "internal bug: runtime_call callback pid operand is missing"
     end
 
-    results =
-      Value.runtime_call([callback_pid_value | arg_values], typespecs, id)
+    results = Value.runtime_call([callback_pid_value | arg_values], typespecs, id)
 
     {wrap_tuple_result(results, expr), cache}
   end
@@ -876,30 +912,6 @@ defmodule EXLA.Defn do
       )
 
     {[p, l, u], cache}
-  end
-
-  defp cached_recur_operator(:attach_token, %T{data: %Expr{args: [token, expr]}}, state, cache) do
-    {op, cache} = recur_operator(expr, state, cache)
-    {_, cache} = recur_operator(token, state, cache)
-    {op, cache}
-  end
-
-  defp cached_recur_operator(:token, %T{data: %Expr{args: [token]}}, state, cache) do
-    builder = state.builder
-
-    cache =
-      List.foldr(token.hooks, cache, fn %{name: name, expr: expr}, cache ->
-        # First traverse the child because if it has hooks,
-        # we need to handle them first
-        {tuple, cache} = recur_flatten(expr, state, cache)
-
-        cache
-        |> get_outfeed()
-        |> Outfeed.maybe_add_function_hook(builder, tuple, name, expr)
-        |> then(&put_outfeed(cache, &1))
-      end)
-
-    {[], cache}
   end
 
   defp cached_recur_operator(op, expr, state, cache) do
@@ -1728,7 +1740,7 @@ defmodule EXLA.Defn do
     )
   end
 
-  ## Cache and hook helpers helpers
+  ## Cache and hook helpers
 
   defp no_token_cache(),
     do: %{__MODULE__ => Outfeed.empty()}
@@ -1751,10 +1763,10 @@ defmodule EXLA.Defn do
 
   defp put_outfeed(cache, outfeed), do: %{cache | __MODULE__ => outfeed}
 
-  defp add_runtime_callback(cache, runtime_callback) do
+  defp add_callback(cache, callback) do
     cache
     |> get_outfeed()
-    |> Outfeed.add_runtime_callback(runtime_callback)
+    |> Outfeed.add_callback(callback)
     |> then(&put_outfeed(cache, &1))
   end
 

--- a/exla/lib/exla/defn/outfeed.ex
+++ b/exla/lib/exla/defn/outfeed.ex
@@ -13,10 +13,10 @@ defmodule EXLA.Defn.Outfeed do
   defstruct user_hooks: %{},
             default_hooks: %{},
             used_hooks: [],
-            compiled_hooks: %{},
+            infeed_flags: %{},
+            callbacks: %{},
             token: nil,
-            infeeds: [],
-            runtime_callbacks: %{}
+            infeeds: []
 
   ## Functional API
 
@@ -79,8 +79,8 @@ defmodule EXLA.Defn.Outfeed do
 
   ## Struct API
 
-  defguard will_outfeed(outfeed) when outfeed.compiled_hooks != %{}
-  defguard has_runtime_calls(outfeed) when outfeed.runtime_callbacks != %{}
+  defguard has_infeed_flags(outfeed) when outfeed.infeed_flags != %{}
+  defguard has_callbacks(outfeed) when map_size(outfeed.callbacks) > 0
 
   @doc """
   An empty outfeed to be used when not outfeeding is supported.
@@ -92,7 +92,8 @@ defmodule EXLA.Defn.Outfeed do
   @doc """
   An outfeed struct to track the need for outfeeds during compilation.
   """
-  def new(user_hooks, default_hooks) when is_map(user_hooks) and is_map(default_hooks) do
+  def new(user_hooks, default_hooks)
+      when is_map(user_hooks) and is_map(default_hooks) do
     # Hooks with default callbacks or user callbacks are part of the cache key
     used_hooks =
       Enum.sort(for {k, v} <- default_hooks, v != nil or Map.has_key?(user_hooks, k), do: k)
@@ -105,9 +106,10 @@ defmodule EXLA.Defn.Outfeed do
   end
 
   @doc """
-  Sets the user hooks to outfeed.
+  Sets the user hooks for callbacks.
   """
-  def with_user_hooks(%Outfeed{} = outfeed, user_hooks), do: %{outfeed | user_hooks: user_hooks}
+  def with_user_hooks(%Outfeed{} = outfeed, user_hooks),
+    do: %{outfeed | user_hooks: user_hooks}
 
   @doc """
   Sets the token to outfeed.
@@ -115,66 +117,50 @@ defmodule EXLA.Defn.Outfeed do
   def with_token(%Outfeed{} = outfeed, token), do: %{outfeed | token: token}
 
   @doc """
-  Adds a runtime callback to outfeed.
+  Registers a host callback to outfeed.
+
+  `invoke` is either a callback spec (`{:fn, fun}` or `{:named, name, callback}`) for
+  side-effect-only callbacks, or a function for callbacks that return tensors.
+  When `out_template` is `nil`, the callback is invoked for side effects only and
+  the native reply is an empty list.
   """
-  def add_runtime_callback(
-        %Outfeed{runtime_callbacks: runtime_callbacks} = outfeed,
-        {id, fun, out_template, arg_template}
-      ) do
-    callback = {fun, out_template, arg_template, nil}
-    %{outfeed | runtime_callbacks: Map.put(runtime_callbacks, id, callback)}
+  def add_callback(%Outfeed{} = outfeed, {id, invoke, out_template, arg_template}) do
+    add_callback(outfeed, {id, invoke, out_template, arg_template, nil})
   end
 
-  def add_runtime_callback(
-        %Outfeed{runtime_callbacks: runtime_callbacks} = outfeed,
-        {id, fun, out_template, arg_template, opts}
+  def add_callback(
+        %Outfeed{callbacks: callbacks} = outfeed,
+        {id, invoke, out_template, arg_template, opts}
       ) do
-    callback = {fun, out_template, arg_template, opts}
-    %{outfeed | runtime_callbacks: Map.put(runtime_callbacks, id, callback)}
+    callback = {invoke, out_template, arg_template, opts}
+    %{outfeed | callbacks: Map.put(callbacks, id, callback)}
   end
 
   @doc """
-  Adds an infeed hook.
+  Adds lazy-transfer infeed flags to the computation.
   """
   def add_infeeds(%Outfeed{} = outfeed, builder, entries) do
-    %{compiled_hooks: compiled_hooks, token: token} = outfeed
+    %{infeed_flags: infeed_flags, token: token} = outfeed
 
     # Reversed because higher depth comes first
-    {infeeds, {compiled_hooks, token}} =
+    {infeeds, {infeed_flags, token}} =
       entries
       |> List.keysort(1, :desc)
-      |> Enum.map_reduce({compiled_hooks, token}, fn
-        {pos, _, typespec}, {compiled_hooks, token} ->
-          next_flag = next_hook(compiled_hooks)
-          compiled_hooks = Map.put(compiled_hooks, next_flag, {:infeed, pos, typespec})
+      |> Enum.map_reduce({infeed_flags, token}, fn
+        {pos, _, typespec}, {infeed_flags, token} ->
+          next_flag = next_infeed_flag(infeed_flags)
+          infeed_flags = Map.put(infeed_flags, next_flag, {:infeed, pos, typespec})
 
           token = Value.outfeed(Value.constant(builder, [next_flag], flag_typespec()), token)
           {token, [input]} = Value.infeed(token, [typespec])
 
-          {{pos, input}, {compiled_hooks, token}}
+          {{pos, input}, {infeed_flags, token}}
       end)
 
-    %{outfeed | compiled_hooks: compiled_hooks, token: token, infeeds: infeeds}
+    %{outfeed | infeed_flags: infeed_flags, token: token, infeeds: infeeds}
   end
 
   defp flag_typespec(), do: EXLA.Typespec.tensor({:u, 16}, {})
-
-  @doc """
-  Adds a function hook if it has a callback defined for it.
-  """
-  def maybe_add_function_hook(%Outfeed{} = outfeed, builder, tuple, name, expr) do
-    cond do
-      name in outfeed.used_hooks ->
-        {outfeed, flag, typespecs} = outfeed_flat_tuple(outfeed, builder, tuple)
-        put_in(outfeed.compiled_hooks[flag], {:function, typespecs, name, Nx.to_template(expr)})
-
-      outfeed.token ->
-        outfeed
-
-      true ->
-        raise "hooks are not supported inside #{builder.name}"
-    end
-  end
 
   @doc """
   Closes the outfeed at the end of a pipeline.
@@ -183,32 +169,36 @@ defmodule EXLA.Defn.Outfeed do
   """
   def close(outfeed, builder)
 
-  def close(%Outfeed{} = outfeed, %Function{} = builder)
-      when will_outfeed(outfeed),
-      do:
-        update_in(
-          outfeed.token,
-          &Value.outfeed(Value.constant(builder, [0], flag_typespec()), &1)
-        )
+  def close(
+        %Outfeed{token: token, infeed_flags: infeed_flags} = outfeed,
+        %Function{} = builder
+      )
+      when not is_nil(token) do
+    if active_infeed_flags?(infeed_flags) do
+      %{outfeed | token: Value.outfeed(Value.constant(builder, [0], flag_typespec()), token)}
+    else
+      outfeed
+    end
+  end
 
   def close(%Outfeed{} = outfeed, _builder),
     do: outfeed
 
-  defp outfeed_flat_tuple(%Outfeed{token: token, compiled_hooks: ch} = outfeed, builder, tuple) do
-    flag = next_hook(ch)
-    token = Value.outfeed(Value.constant(builder, [flag], flag_typespec()), token)
-    typespecs = Enum.map(tuple, &Value.get_typespec/1)
-
-    token =
-      Enum.reduce(tuple, token, fn elem, token ->
-        Value.outfeed(elem, token)
-      end)
-
-    {%{outfeed | token: token}, flag, typespecs}
+  defp active_infeed_flags?(infeed_flags) do
+    Enum.any?(infeed_flags, fn
+      {_key, {:infeed, _, _}} -> true
+      _ -> false
+    end)
   end
 
-  # The index 0 is served for closing streams
-  defp next_hook(compiled_hooks), do: map_size(compiled_hooks) + 1
+  # The index 0 is reserved for closing the outfeed stream
+  defp next_infeed_flag(infeed_flags) do
+    infeed_flags
+    |> Map.keys()
+    |> Enum.filter(&is_integer/1)
+    |> Enum.max(fn -> 0 end)
+    |> Kernel.+(1)
+  end
 
   ## Process API
 
@@ -227,21 +217,22 @@ defmodule EXLA.Defn.Outfeed do
     %{client: client, device_id: device_id} = executable
 
     %{
-      compiled_hooks: compiled_hooks,
+      infeed_flags: infeed_flags,
       default_hooks: default_hooks,
       user_hooks: user_hooks,
-      runtime_callbacks: runtime_callbacks
+      callbacks: callbacks
     } =
       outfeed
 
     hooks = Map.merge(default_hooks, user_hooks)
+    callbacks = resolve_callbacks(callbacks, hooks)
 
     Task.Supervisor.start_child(EXLA.Defn.TaskSupervisor, fn ->
-      init(client, device_id, hooks, compiled_hooks, infeeds, runtime_callbacks, group_leader)
+      init(client, device_id, infeed_flags, infeeds, callbacks, group_leader)
     end)
   end
 
-  defp init(client, device_id, hooks, compiled_hooks, infeeds, rt_callbacks, group_leader) do
+  defp init(client, device_id, infeed_flags, infeeds, callbacks, group_leader) do
     Process.flag(:trap_exit, true)
     # Copy the group leader so we report to the proper device
     Process.group_leader(self(), group_leader)
@@ -249,23 +240,21 @@ defmodule EXLA.Defn.Outfeed do
     ref = make_ref()
     typespec = EXLA.Typespec.tensor({:u, 16}, {})
 
-    loop(client, device_id, ref, typespec, hooks, compiled_hooks, infeeds, rt_callbacks)
+    loop(client, device_id, ref, typespec, infeed_flags, infeeds, callbacks)
   end
 
-  defp loop(client, device_id, ref, typespec, hooks, compiled_hooks, infeeds, rt_callbacks) do
-    if compiled_hooks != %{} do
-      # If we're not outfeeding, we only need to handle the runtime callback
-      # and executable stop messaging
+  defp loop(client, device_id, ref, typespec, infeed_flags, infeeds, callbacks) do
+    if active_infeed_flags?(infeed_flags) do
       :ok = EXLA.Client.from_outfeed(client, device_id, [typespec], self(), ref)
     end
 
     receive do
       {^ref, <<0::native-unsigned-16>>} ->
         # Outfeed is done, now we wait for the computation to finish
-        loop(client, device_id, ref, typespec, hooks, %{}, infeeds, rt_callbacks)
+        loop(client, device_id, ref, typespec, drop_infeed_flags(infeed_flags), infeeds, callbacks)
 
       {^ref, <<flag::native-unsigned-16>>} ->
-        case Map.fetch!(compiled_hooks, flag) do
+        case Map.fetch!(infeed_flags, flag) do
           {:infeed, index, data_typespec} ->
             data =
               case Map.fetch!(infeeds, index) do
@@ -274,83 +263,78 @@ defmodule EXLA.Defn.Outfeed do
               end
 
             EXLA.Client.to_infeed(client, device_id, [{data, data_typespec}])
-            loop(client, device_id, ref, typespec, hooks, compiled_hooks, infeeds, rt_callbacks)
 
-          {:function, typespecs, name, template} ->
-            fun = Map.fetch!(hooks, name)
-            length = length(typespecs)
-            parent = self()
-            ref = make_ref()
-            pid = spawn(fn -> apply_hook(parent, ref, length, fun, template) end)
-            :ok = EXLA.Client.from_outfeed(client, device_id, typespecs, pid, ref)
-
-            receive do
-              ^ref ->
-                loop(
-                  client,
-                  device_id,
-                  ref,
-                  typespec,
-                  hooks,
-                  compiled_hooks,
-                  infeeds,
-                  rt_callbacks
-                )
-            end
+            loop(client, device_id, ref, typespec, infeed_flags, infeeds, callbacks)
         end
 
       {:exla_runtime_call, callback_id, args_spec, reply_tag} ->
-        send_runtime_callback_reply(rt_callbacks, callback_id, args_spec, reply_tag)
-        loop(client, device_id, ref, typespec, hooks, compiled_hooks, infeeds, rt_callbacks)
+        send_callback_reply(callbacks, callback_id, args_spec, reply_tag)
+        loop(client, device_id, ref, typespec, infeed_flags, infeeds, callbacks)
 
       :stop ->
         :ok
 
       other ->
         Logger.debug("EXLA.Outfeed ignoring unexpected message: #{inspect(other)}")
-        loop(client, device_id, ref, typespec, hooks, compiled_hooks, infeeds, rt_callbacks)
+        loop(client, device_id, ref, typespec, infeed_flags, infeeds, callbacks)
     end
   end
 
-  defp apply_hook(parent, ref, length, fun, template) do
-    buffers =
-      for _ <- 1..length//1 do
-        receive do
-          {^ref, binary} -> binary
-        end
-      end
-
-    send(parent, ref)
-    fun.(EXLA.Defn.Buffers.to_nx!(buffers, template))
+  defp drop_infeed_flags(infeed_flags) do
+    keys = for {k, _} <- infeed_flags, is_integer(k), do: k
+    Map.drop(infeed_flags, keys)
   end
 
-  defp send_runtime_callback_reply(runtime_callbacks, callback_id, args_spec, reply_tag) do
+  defp resolve_callbacks(callbacks, hooks) do
+    Map.new(callbacks, fn {id, {invoke, out_template, arg_template, opts}} ->
+      {id, {resolve_invoke(invoke, hooks), out_template, arg_template, opts}}
+    end)
+  end
+
+  defp resolve_invoke(fun, _hooks) when is_function(fun), do: fun
+
+  defp resolve_invoke({:fn, fun}, _hooks), do: {:fn, fun}
+
+  defp resolve_invoke({:named, name, callback}, hooks) do
+    case hooks[name] || callback do
+      nil -> {:named, name, nil}
+      fun -> {:fn, fun}
+    end
+  end
+
+  defp send_callback_reply(callbacks, callback_id, args_spec, reply_tag) do
     reply =
       try do
-        case Map.fetch(runtime_callbacks, callback_id) do
-          {:ok, {fun, out_template, arg_template, opts}} ->
-            args_spec
-            |> decode_callback_args(arg_template)
-            |> run_runtime_callback(fun, out_template, opts)
-            |> encode_runtime_callback_reply()
-
+        with {:ok, callback} <- Map.fetch(callbacks, callback_id),
+             {:ok, tensor_args} <- materialize_callback_args(callback, args_spec) do
+          callback
+          |> invoke_callback(tensor_args)
+          |> encode_callback_reply()
+        else
           :error ->
             Logger.error(
               "EXLA.Outfeed received callback id #{inspect(callback_id)} that is not registered"
             )
 
-            encode_runtime_callback_reply({:error, :unknown_callback})
+            encode_callback_reply({:error, :unknown_callback})
+
+          {:error, _} = error ->
+            error
         end
       rescue
         exception ->
           send(self(), :stop)
-          {:error, {:exception, Exception.message(exception)}}
+          {:error, {:exception, Exception.format(:error, exception, __STACKTRACE__)}}
       catch
         kind, reason ->
           send(self(), :stop)
-          {:error, {kind, format_runtime_callback_reason(reason)}}
+          {:error, {kind, Exception.format(kind, reason, __STACKTRACE__)}}
       end
 
+    deliver_native_reply(reply_tag, reply)
+  end
+
+  defp deliver_native_reply(reply_tag, reply) do
     try do
       case reply do
         {:ok, payload} ->
@@ -367,28 +351,36 @@ defmodule EXLA.Defn.Outfeed do
     end
   end
 
-  defp format_runtime_callback_reason(reason) when is_binary(reason), do: reason
-  defp format_runtime_callback_reason(reason), do: inspect(reason)
+  defp invoke_callback({invoke, nil, _arg_template, _opts}, tensor_args) do
+    invoke_side_effect(invoke, tensor_args)
+  end
 
-  defp run_runtime_callback({:error, reason}, _fun, _out_template, _opts), do: {:error, reason}
+  defp invoke_callback({fun, out_template, _arg_template, opts}, tensor_args)
+       when is_function(fun) do
+    run_runtime_callback({:ok, tensor_args}, fun, out_template, opts)
+  end
 
-  defp run_runtime_callback({:ok, tensor_args}, fun, nil, opts) do
+  defp invoke_side_effect({:fn, fun}, tensor_args) when is_function(fun, 1) do
+    run_side_effect(fun, tensor_args)
+  end
+
+  defp invoke_side_effect({:named, _, nil}, _tensor_args) do
+    {:ok, []}
+  end
+
+  defp run_side_effect(fun, tensor_args) when is_function(fun, 1) do
     try do
-      if opts do
-        fun.(tensor_args, opts)
-      else
-        fun.(tensor_args)
-      end
+      fun.(tensor_args)
+      {:ok, []}
     rescue
       exception ->
-        {:error, {:exception, exception, __STACKTRACE__}}
+        {:error, {:exception, Exception.format(:error, exception, __STACKTRACE__)}}
     catch
       kind, reason ->
-        {:error, {kind, reason}}
+        {:error, {kind, Exception.format(kind, reason, __STACKTRACE__)}}
     end
   end
 
-  defp run_runtime_callback({:ok, tensor_args}, fun, out_template, opts) do
     result =
       try do
         if opts do
@@ -417,21 +409,21 @@ defmodule EXLA.Defn.Outfeed do
     end
   end
 
-  defp decode_callback_args(args_spec, arg_template) when is_list(args_spec) do
-    materialize_callback_args(arg_template, args_spec)
+  defp materialize_callback_args({_, _, arg_template, _}, args_spec) when is_list(args_spec) do
+    materialize_callback_tensors(arg_template, args_spec)
   catch
     {:error, reason} ->
-      raise ArgumentError, "invalid args_spec #{inspect(reason)}"
+      {:error, {:decode_failed, ArgumentError.exception("invalid args_spec #{inspect(reason)}")}}
   end
 
-  defp decode_callback_args(other, _arg_template) do
-    raise ArgumentError, "invalid args_spec #{inspect(other)}"
+  defp materialize_callback_args({_, _, _arg_template, _}, other) do
+    {:error, {:invalid_args_spec, other}}
   end
 
-  defp encode_runtime_callback_reply(:ok), do: {:ok, []}
-  defp encode_runtime_callback_reply({:ok, value}), do: {:ok, encode_callback_outputs(value)}
+  defp encode_callback_reply({:ok, []}), do: {:ok, []}
+  defp encode_callback_reply({:ok, value}), do: {:ok, encode_callback_outputs(value)}
 
-  defp encode_runtime_callback_reply({:error, {:shape_mismatch, left, right}}) do
+  defp encode_callback_reply({:error, {:shape_mismatch, left, right}}) do
     msg =
       "expected the runtime_call function to match the given output template " <>
         "#{inspect(right)}, got: #{inspect(left)}"
@@ -439,7 +431,7 @@ defmodule EXLA.Defn.Outfeed do
     raise ArgumentError.exception(msg)
   end
 
-  defp encode_runtime_callback_reply({:error, {:invalid_result, left, right}}) do
+  defp encode_callback_reply({:error, {:invalid_result, left, right}}) do
     msg =
       "expected the runtime_call function to return a value compatible with the output " <>
         "template #{inspect(right)}, got: #{inspect(left)}"
@@ -447,37 +439,52 @@ defmodule EXLA.Defn.Outfeed do
     raise ArgumentError.exception(msg)
   end
 
-  defp encode_runtime_callback_reply({:error, {:decode_failed, exception}}) do
+  defp encode_callback_reply({:error, {:undefined_hook, message}}) do
+    raise ArgumentError.exception(message)
+  end
+
+  defp encode_callback_reply({:error, {:decode_failed, exception}}) do
     msg = Exception.message(exception)
     msg = "failed to decode Elixir callback arguments: #{msg}"
     raise ArgumentError.exception(msg)
   end
 
-  defp encode_runtime_callback_reply({:error, {:invalid_args_spec, other}}) do
+  defp encode_callback_reply({:error, {:invalid_args_spec, other}}) do
     msg = "invalid args_spec for Elixir callback: #{inspect(other)}"
     raise ArgumentError.exception(msg)
   end
 
-  defp encode_runtime_callback_reply({:error, :unknown_callback}) do
+  defp encode_callback_reply({:error, :unknown_callback}) do
     msg = "unknown EXLA runtime_call callback id"
     raise RuntimeError.exception(msg)
   end
 
-  defp encode_runtime_callback_reply({:error, {:exception, exception, _stack}}) do
+  defp encode_callback_reply({:error, {:exception, exception, _stack}}) do
     raise exception
   end
 
-  defp encode_runtime_callback_reply({:error, {kind, reason}}) do
+  defp encode_callback_reply({:error, {kind, reason}}) when is_binary(reason) do
+    msg = "Elixir callback #{kind}: #{reason}"
+    raise RuntimeError.exception(msg)
+  end
+
+  defp encode_callback_reply({:error, {kind, reason}}) do
     msg = "Elixir callback #{kind}: #{inspect(reason)}"
     raise RuntimeError.exception(msg)
   end
 
-  defp encode_runtime_callback_reply({:error, reason}) do
+  defp encode_callback_reply({:error, reason}) do
     msg = "Elixir callback error: #{inspect(reason)}"
     raise RuntimeError.exception(msg)
   end
 
-  defp materialize_callback_args(arg_template, args_spec) do
+  defp maybe_revectorize(decoded, %Nx.Tensor{vectorized_axes: axes}) when axes != [] do
+    Nx.vectorize(decoded, axes)
+  end
+
+  defp maybe_revectorize(decoded, _template), do: decoded
+
+  defp materialize_callback_tensors(arg_template, args_spec) do
     {container, remaining} =
       Composite.traverse(arg_template, args_spec, fn
         %Nx.Tensor{} = template, [{bin, {type, shape_list}} | rest] ->
@@ -485,6 +492,7 @@ defmodule EXLA.Defn.Outfeed do
             bin
             |> Nx.from_binary(type)
             |> Nx.reshape(List.to_tuple(shape_list))
+            |> maybe_revectorize(template)
 
           if Nx.compatible?(decoded, template) do
             {decoded, rest}
@@ -500,6 +508,8 @@ defmodule EXLA.Defn.Outfeed do
       [] -> {:ok, container}
       _ -> {:error, {:invalid_args_spec, :extra_values}}
     end
+  catch
+    :throw, {:error, _} = error -> error
   end
 
   defp encode_callback_outputs(container) do

--- a/exla/lib/exla/defn/outfeed.ex
+++ b/exla/lib/exla/defn/outfeed.ex
@@ -251,7 +251,15 @@ defmodule EXLA.Defn.Outfeed do
     receive do
       {^ref, <<0::native-unsigned-16>>} ->
         # Outfeed is done, now we wait for the computation to finish
-        loop(client, device_id, ref, typespec, drop_infeed_flags(infeed_flags), infeeds, callbacks)
+        loop(
+          client,
+          device_id,
+          ref,
+          typespec,
+          drop_infeed_flags(infeed_flags),
+          infeeds,
+          callbacks
+        )
 
       {^ref, <<flag::native-unsigned-16>>} ->
         case Map.fetch!(infeed_flags, flag) do

--- a/exla/lib/exla/defn/outfeed.ex
+++ b/exla/lib/exla/defn/outfeed.ex
@@ -381,6 +381,7 @@ defmodule EXLA.Defn.Outfeed do
     end
   end
 
+  defp run_runtime_callback({:ok, tensor_args}, fun, out_template, opts) do
     result =
       try do
         if opts do

--- a/exla/lib/exla/mlir/value.ex
+++ b/exla/lib/exla/mlir/value.ex
@@ -696,6 +696,67 @@ defmodule EXLA.MLIR.Value do
     op(func, "stablehlo.create_token", [], result_types) |> one!()
   end
 
+  def after_all([%Value{function: func} | _] = tokens) do
+    result_types = [type_token()]
+    op(func, "stablehlo.after_all", tokens, result_types) |> one!()
+  end
+
+  @doc false
+  def host_callback(
+        [%Value{} = callback_pid | leaf_operands],
+        leaf_typespecs,
+        callback_id,
+        num_aliased_data_outputs \\ 0
+      ) do
+    [%Value{function: func} | _] = [callback_pid | leaf_operands]
+    result_types = typespecs_to_mlir_types(leaf_typespecs)
+
+    {callback_id_words, callback_id_size} = term_to_int64_list(callback_id)
+
+    # Build output_operand_aliases for aliased (pass-through) outputs.
+    # Inputs: [cb_pid(0), leaf_0(1), leaf_1(2), ...]
+    # Aliased outputs occupy indices 0..num_aliased_data_outputs-1.
+    # For a single aliased output: tuple_indices = [] (no tuple wrapping).
+    # For multiple aliased outputs: tuple_indices = [i] (tuple element index).
+    aliases =
+      if num_aliased_data_outputs > 0 do
+        total_outputs = length(leaf_typespecs)
+
+        Enum.map(0..(num_aliased_data_outputs - 1), fn i ->
+          output_tuple_indices =
+            if total_outputs == 1, do: "[]", else: "[#{i}]"
+
+          "#stablehlo.output_operand_alias<output_tuple_indices = #{output_tuple_indices}, operand_index = #{i + 1}, operand_tuple_indices = []>"
+        end)
+      else
+        []
+      end
+
+    attributes =
+      [
+        call_target_name: attr_string("exla_runtime_callback"),
+        api_version: attr_i32(4),
+        has_side_effect: attr_boolean(true),
+        backend_config:
+          attr_dict(
+            callback_id: attr_array_i64_elements(callback_id_words),
+            callback_id_size: attr_ui64(callback_id_size),
+            num_aliased_data_outputs: attr_ui64(num_aliased_data_outputs)
+          )
+      ]
+
+    attributes =
+      if aliases != [] do
+        Keyword.put(attributes, :output_operand_aliases, join_list(aliases))
+      else
+        attributes
+      end
+
+    op(func, "stablehlo.custom_call", [callback_pid | leaf_operands], result_types,
+      attributes: attributes
+    )
+  end
+
   def call(%Function{} = func, args, %Function{} = computation, typespecs) do
     result_types = typespecs_to_mlir_types(typespecs)
     attributes = [callee: attr_symbol_reference(computation.name)]
@@ -795,32 +856,16 @@ defmodule EXLA.MLIR.Value do
   Builds a StableHLO `custom_call` that targets the EXLA Elixir callback bridge.
 
   The `callback_id` is typically the underlying `Nx.Defn.Expr` id of the
-  `:runtime_call` node. It is encoded as a binary (via `:erlang.term_to_binary/1`)
-  and then represented as a list of 64-bit words in the custom call attributes.
+  `:runtime_call` or `:io_call` node. It is encoded as a binary (via
+  `:erlang.term_to_binary/1`) and then represented as a list of 64-bit words in
+  the custom call attributes.
   """
   def runtime_call(
-        [%Value{function: func} | _] = operands,
+        [%Value{} = callback_pid | leaf_operands],
         typespecs,
         callback_id
       ) do
-    result_types = typespecs_to_mlir_types(typespecs)
-
-    {callback_id_words, callback_id_size} =
-      term_to_int64_list(callback_id)
-
-    attributes = [
-      call_target_name: attr_string("exla_runtime_callback"),
-      # api_version 4 enables the typed FFI API used by our callback handler.
-      api_version: attr_i32(4),
-      has_side_effect: attr_boolean(true),
-      backend_config:
-        attr_dict(
-          callback_id: attr_array_i64_elements(callback_id_words),
-          callback_id_size: attr_ui64(callback_id_size)
-        )
-    ]
-
-    op(func, "stablehlo.custom_call", operands, result_types, attributes: attributes)
+    host_callback([callback_pid | leaf_operands], typespecs, callback_id, 0)
   end
 
   defp term_to_int64_list(term) do

--- a/exla/lib/exla/mlir/value.ex
+++ b/exla/lib/exla/mlir/value.ex
@@ -696,11 +696,6 @@ defmodule EXLA.MLIR.Value do
     op(func, "stablehlo.create_token", [], result_types) |> one!()
   end
 
-  def after_all([%Value{function: func} | _] = tokens) do
-    result_types = [type_token()]
-    op(func, "stablehlo.after_all", tokens, result_types) |> one!()
-  end
-
   @doc false
   def host_callback(
         [%Value{} = callback_pid | leaf_operands],

--- a/exla/mix.exs
+++ b/exla/mix.exs
@@ -70,8 +70,7 @@ defmodule EXLA.MixProject do
 
   defp deps do
     [
-      {:nx, "~> 0.12.0"},
-      # {:nx, path: "../nx"},
+      {:nx, path: "../nx"},
       {:telemetry, "~> 0.4.0 or ~> 1.0"},
       {:xla, "~> 0.10.0", runtime: false},
       {:fine, "~> 0.1", runtime: false},

--- a/exla/test/exla/defn/api_test.exs
+++ b/exla/test/exla/defn/api_test.exs
@@ -320,102 +320,102 @@ defmodule EXLA.Defn.APITest do
     end
   end
 
-    defn hook_raises(a, b) do
-      hook(a + b, :raises, fn _ -> raise "boom" end)
-    end
+  defn hook_raises(a, b) do
+    hook(a + b, :raises, fn _ -> raise "boom" end)
+  end
 
-    @tag :capture_log
-    test "halts callback server when hook raises" do
-      {_pid, ref} =
-        spawn_monitor(fn ->
-          EXLA.jit(&hook_raises/2).(2, 3)
-        end)
+  @tag :capture_log
+  test "halts callback server when hook raises" do
+    {_pid, ref} =
+      spawn_monitor(fn ->
+        EXLA.jit(&hook_raises/2).(2, 3)
+      end)
 
-      assert_receive {:DOWN, ^ref, :process, _, {%RuntimeError{message: message}, _}}
-      assert message =~ "boom"
-    end
+    assert_receive {:DOWN, ^ref, :process, _, {%RuntimeError{message: message}, _}}
+    assert message =~ "boom"
+  end
 
-    defn side_effect_hooks(a, b) do
-      b = hook(b, :b)
-      a = hook(a, :a)
-      a + b
-    end
+  defn side_effect_hooks(a, b) do
+    b = hook(b, :b)
+    a = hook(a, :a)
+    a + b
+  end
 
-    test "executes hooks as side effects" do
-      parent = self()
-      send_value = fn value -> send(parent, Nx.to_number(value)) end
+  test "executes hooks as side effects" do
+    parent = self()
+    send_value = fn value -> send(parent, Nx.to_number(value)) end
 
-      assert_equal(
-        EXLA.jit(&side_effect_hooks/2, hooks: %{a: send_value, b: send_value}).(1, 2),
-        Nx.tensor(3)
-      )
+    assert_equal(
+      EXLA.jit(&side_effect_hooks/2, hooks: %{a: send_value, b: send_value}).(1, 2),
+      Nx.tensor(3)
+    )
 
-      assert_received 2
-      assert_received 1
-    end
+    assert_received 2
+    assert_received 1
+  end
 
-    defn hook_ordered(a, b) do
-      b = hook(b, :b)
-      a = hook(a, :a)
-      a + b
-    end
+  defn hook_ordered(a, b) do
+    b = hook(b, :b)
+    a = hook(a, :a)
+    a + b
+  end
 
-    test "executes hooks in sequence" do
-      parent = self()
-      send_value = fn value -> send(parent, Nx.to_number(value)) end
+  test "executes hooks in sequence" do
+    parent = self()
+    send_value = fn value -> send(parent, Nx.to_number(value)) end
 
-      assert_equal(
-        EXLA.jit(&hook_ordered/2, hooks: %{a: send_value, b: send_value}).(1, 2),
-        Nx.tensor(3)
-      )
+    assert_equal(
+      EXLA.jit(&hook_ordered/2, hooks: %{a: send_value, b: send_value}).(1, 2),
+      Nx.tensor(3)
+    )
 
-      assert_received 2
-      assert_received 1
-    end
+    assert_received 2
+    assert_received 1
+  end
 
-    defn hook_chain(a, b, c) do
-      a = hook(a, :a)
-      b = hook(b, :b)
-      c = hook(c, :c)
-      a + c + b
-    end
+  defn hook_chain(a, b, c) do
+    a = hook(a, :a)
+    b = hook(b, :b)
+    c = hook(c, :c)
+    a + c + b
+  end
 
-    test "executes independent hooks in program order" do
-      parent = self()
-      counter = :counters.new(1, [])
+  test "executes independent hooks in program order" do
+    parent = self()
+    counter = :counters.new(1, [])
 
-      send_value =
-        fn value ->
-          current_counter = :counters.get(counter, 1)
-          :counters.add(counter, 1, 1)
-          send(parent, {:tag, Nx.to_number(value), current_counter})
-        end
+    send_value =
+      fn value ->
+        current_counter = :counters.get(counter, 1)
+        :counters.add(counter, 1, 1)
+        send(parent, {:tag, Nx.to_number(value), current_counter})
+      end
 
-      send_value_with_delay =
-        fn value ->
-          Process.sleep(500)
-          send_value.(value)
-        end
+    send_value_with_delay =
+      fn value ->
+        Process.sleep(500)
+        send_value.(value)
+      end
 
-      assert_equal(
-        EXLA.jit(&hook_chain/3,
-          hooks: %{a: send_value, b: send_value_with_delay, c: send_value}
-        ).(1, 2, 3),
-        Nx.tensor(6)
-      )
+    assert_equal(
+      EXLA.jit(&hook_chain/3,
+        hooks: %{a: send_value, b: send_value_with_delay, c: send_value}
+      ).(1, 2, 3),
+      Nx.tensor(6)
+    )
 
-      assert_received {:tag, 1, 0}
-      assert_received {:tag, 2, 1}
-      assert_received {:tag, 3, 2}
-    end
+    assert_received {:tag, 1, 0}
+    assert_received {:tag, 2, 1}
+    assert_received {:tag, 3, 2}
+  end
 
-    defn hook_passthrough(a, b) do
-      hook(a + b, &Function.identity/1)
-    end
+  defn hook_passthrough(a, b) do
+    hook(a + b, &Function.identity/1)
+  end
 
-    test "executes hook with anonymous function callback" do
-      assert_equal(EXLA.jit(&hook_passthrough/2).(2, 3), Nx.tensor(5))
-    end
+  test "executes hook with anonymous function callback" do
+    assert_equal(EXLA.jit(&hook_passthrough/2).(2, 3), Nx.tensor(5))
+  end
 
   describe "block ops via Evaluator with EXLA.Backend" do
     # Regression test: before the fix, eval_apply(:block, ...) wrapped block_apply_default

--- a/exla/test/exla/defn/api_test.exs
+++ b/exla/test/exla/defn/api_test.exs
@@ -320,6 +320,103 @@ defmodule EXLA.Defn.APITest do
     end
   end
 
+    defn hook_raises(a, b) do
+      hook(a + b, :raises, fn _ -> raise "boom" end)
+    end
+
+    @tag :capture_log
+    test "halts callback server when hook raises" do
+      {_pid, ref} =
+        spawn_monitor(fn ->
+          EXLA.jit(&hook_raises/2).(2, 3)
+        end)
+
+      assert_receive {:DOWN, ^ref, :process, _, {%RuntimeError{message: message}, _}}
+      assert message =~ "boom"
+    end
+
+    defn side_effect_hooks(a, b) do
+      b = hook(b, :b)
+      a = hook(a, :a)
+      a + b
+    end
+
+    test "executes hooks as side effects" do
+      parent = self()
+      send_value = fn value -> send(parent, Nx.to_number(value)) end
+
+      assert_equal(
+        EXLA.jit(&side_effect_hooks/2, hooks: %{a: send_value, b: send_value}).(1, 2),
+        Nx.tensor(3)
+      )
+
+      assert_received 2
+      assert_received 1
+    end
+
+    defn hook_ordered(a, b) do
+      b = hook(b, :b)
+      a = hook(a, :a)
+      a + b
+    end
+
+    test "executes hooks in sequence" do
+      parent = self()
+      send_value = fn value -> send(parent, Nx.to_number(value)) end
+
+      assert_equal(
+        EXLA.jit(&hook_ordered/2, hooks: %{a: send_value, b: send_value}).(1, 2),
+        Nx.tensor(3)
+      )
+
+      assert_received 2
+      assert_received 1
+    end
+
+    defn hook_chain(a, b, c) do
+      a = hook(a, :a)
+      b = hook(b, :b)
+      c = hook(c, :c)
+      a + c + b
+    end
+
+    test "executes independent hooks in program order" do
+      parent = self()
+      counter = :counters.new(1, [])
+
+      send_value =
+        fn value ->
+          current_counter = :counters.get(counter, 1)
+          :counters.add(counter, 1, 1)
+          send(parent, {:tag, Nx.to_number(value), current_counter})
+        end
+
+      send_value_with_delay =
+        fn value ->
+          Process.sleep(500)
+          send_value.(value)
+        end
+
+      assert_equal(
+        EXLA.jit(&hook_chain/3,
+          hooks: %{a: send_value, b: send_value_with_delay, c: send_value}
+        ).(1, 2, 3),
+        Nx.tensor(6)
+      )
+
+      assert_received {:tag, 1, 0}
+      assert_received {:tag, 2, 1}
+      assert_received {:tag, 3, 2}
+    end
+
+    defn hook_passthrough(a, b) do
+      hook(a + b, &Function.identity/1)
+    end
+
+    test "executes hook with anonymous function callback" do
+      assert_equal(EXLA.jit(&hook_passthrough/2).(2, 3), Nx.tensor(5))
+    end
+
   describe "block ops via Evaluator with EXLA.Backend" do
     # Regression test: before the fix, eval_apply(:block, ...) wrapped block_apply_default
     # in a Nx.Defn.Compiler.fun and passed it to backend.block. EXLA.Backend.block JIT-traces

--- a/exla/test/support/exla_case.ex
+++ b/exla/test/support/exla_case.ex
@@ -12,6 +12,18 @@ defmodule EXLA.Case do
     end
   end
 
+  setup tags do
+    # Set Logger metadata to track which test emits logs
+    if tags[:test] do
+      Logger.metadata(
+        test: tags[:test],
+        test_module: inspect(tags[:module])
+      )
+    end
+
+    :ok
+  end
+
   def to_binary_backend(tensor) do
     Nx.backend_copy(tensor, Nx.BinaryBackend)
   end


### PR DESCRIPTION
## Summary

Splits the EXLA side of #1761 into a standalone change (per maintainer feedback from @josevalim and @polvalente).

- Replaces the outfeed u16-flag hook protocol with XLA `host_callback` / `exla_runtime_callback` for hook side effects and runtime calls
- Keeps the existing Nx API unchanged (`hook/3`, `:hooks`, `%Nx.Defn.Token{}`) so this can land independently
- Unifies host and CUDA runtime callback paths; outfeed is retained only for lazy-transfer infeed
- Adds ordering and side-effect regression tests in `exla/test/exla/defn/api_test.exs`

Part 1 of 2. Follow-up: rename hooks → `io_call` and remove tokens from Nx (stacked PR).

Supersedes the EXLA portions of #1761.

## Test plan

- [x] `cd exla && mix test test/exla/defn/api_test.exs` (26 tests, 0 failures)


Made with [Cursor](https://cursor.com)