### PR TITLE
fix: Nx.Defn.Graph should keep nested scopes hermetic

### DIFF
--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -3619,16 +3619,12 @@ defmodule Nx do
           raise ArgumentError,
                 "split must be an integer greater than zero and less than the length of the given axis"
 
-        is_float(split) and float_split_index > 0 and float_split_index < axis_size ->
+        float_split_index > 0 and float_split_index < axis_size ->
           {float_split_index, axis_size - float_split_index}
-
-        is_float(split) ->
-          raise ArgumentError,
-                "split must be a float such that 0 < split and ceil(split * axis_size) < 1"
 
         true ->
           raise ArgumentError,
-                "invalid split received, expected a float or an integer, got: #{inspect(split)}"
+                "split must be a float such that 0 < split and ceil(split * axis_size) < 1"
       end
 
     {

--- a/nx/lib/nx/binary_backend.ex
+++ b/nx/lib/nx/binary_backend.ex
@@ -527,13 +527,11 @@ defmodule Nx.BinaryBackend do
         right_batch_item_bits = right_batch_item_length * right_size
 
         <<_::bitstring-size(^left_offset_bits),
-          left_batch_item_binary::bitstring-size(^left_batch_item_bits),
-          _::bitstring>> =
+          left_batch_item_binary::bitstring-size(^left_batch_item_bits), _::bitstring>> =
           left_binary
 
         <<_::bitstring-size(^right_offset_bits),
-          right_batch_item_binary::bitstring-size(^right_batch_item_bits),
-          _::bitstring>> =
+          right_batch_item_binary::bitstring-size(^right_batch_item_bits), _::bitstring>> =
           right_binary
 
         bin_dot(
@@ -1781,8 +1779,7 @@ defmodule Nx.BinaryBackend do
             before_slice_size = current - previous
 
             <<before_offset::bitstring-size(^before_slice_size),
-              current_bitstring::bitstring-size(^target_chunk),
-              to_traverse::bitstring>> =
+              current_bitstring::bitstring-size(^target_chunk), to_traverse::bitstring>> =
               to_traverse
 
             updated_elements =

--- a/nx/lib/nx/binary_backend.ex
+++ b/nx/lib/nx/binary_backend.ex
@@ -2086,7 +2086,7 @@ defmodule Nx.BinaryBackend do
                 %Complex{re: re} ->
                   number_to_binary(trunc(re), output_type)
 
-                _ when is_number(x) ->
+                x when is_number(x) ->
                   number_to_binary(trunc(x), output_type)
 
                 :nan ->
@@ -2132,7 +2132,7 @@ defmodule Nx.BinaryBackend do
               {_, :nan} -> false
               {:infinity, _} -> true
               {_, :infinity} -> false
-              {a, b} -> a >= b
+              {a, b} when is_number(a) and is_number(b) -> a >= b
             end
           end
 
@@ -2146,7 +2146,7 @@ defmodule Nx.BinaryBackend do
               {_, :nan} -> true
               {:infinity, _} -> false
               {_, :infinity} -> true
-              {a, b} -> a <= b
+              {a, b} when is_number(a) and is_number(b) -> a <= b
             end
           end
       end

--- a/nx/lib/nx/defn/graph.ex
+++ b/nx/lib/nx/defn/graph.ex
@@ -132,8 +132,12 @@ defmodule Nx.Defn.Graph do
 
   @doc """
   Executes the stage chain with the given arguments.
+
+  `opts` is an optional keyword list forwarded to `Nx.Defn.jit_apply/3`
+  for each stage, allowing the caller to control the compiler and other
+  JIT options.
   """
-  def run(chain, args) do
+  def run(chain, args, opts \\ []) when is_list(opts) do
     scope =
       Enum.with_index(args, fn arg, idx -> {{nil, idx}, arg} end)
       |> Map.new()
@@ -147,7 +151,7 @@ defmodule Nx.Defn.Graph do
             Map.fetch!(scope, source)
           end)
 
-        case Nx.Defn.jit_apply(fn _ -> expr end, [List.to_tuple(args)]) do
+        case Nx.Defn.jit_apply(fn _ -> expr end, [List.to_tuple(args)], opts) do
           %T{} = tensor ->
             {tensor, Map.put(scope, {id, 0}, tensor)}
 

--- a/nx/lib/nx/defn/graph.ex
+++ b/nx/lib/nx/defn/graph.ex
@@ -155,7 +155,7 @@ defmodule Nx.Defn.Graph do
           %T{} = tensor ->
             {tensor, Map.put(scope, {id, 0}, tensor)}
 
-          tuple ->
+          tuple when is_tuple(tuple) ->
             {_idx, scope} =
               tuple
               |> Tuple.to_list()
@@ -164,6 +164,13 @@ defmodule Nx.Defn.Graph do
               end)
 
             {tuple, scope}
+
+          # Arbitrary container (map/struct). Intermediate stages always emit a
+          # tuple of tensors, so this only occurs for the final stage, whose
+          # output is the chain's return value and has no downstream consumers;
+          # thread it through without indexing it into the scope.
+          other ->
+            {other, scope}
         end
       end)
 
@@ -736,7 +743,7 @@ defmodule Nx.Defn.Graph do
     {ans, {Map.put(cache, id, ans), state}}
   end
 
-  defp composite_rewrite_subtree(container, state, acc \\ %{used_args: %{}})
+  defp composite_rewrite_subtree(container, state, acc \\ %{used_args: %{}, cache: %{}})
 
   defp composite_rewrite_subtree(container, state, acc) when is_list(container) do
     Enum.map_reduce(container, acc, fn
@@ -755,7 +762,26 @@ defmodule Nx.Defn.Graph do
     Composite.traverse(container, acc, &rewrite_subtree(&1, state, &2))
   end
 
-  defp rewrite_subtree(%T{data: %Expr{id: id, op: :parameter}} = expr, state, acc) do
+  # Memoize per node id within a single `composite_rewrite_subtree` pass. The
+  # rewrite is pure given a fixed `nodes_to_replace` (constant for one pass), so
+  # a shared subtree need only be rewritten once. Without this, a heavily-shared
+  # DAG (e.g. a many-layer transformer graph) is walked once per incoming edge,
+  # which is exponential. `used_args` is an id-keyed map, so collecting a node's
+  # parameters once is sufficient; revisits return the cached node untouched.
+  defp rewrite_subtree(%T{data: %Expr{id: id}} = expr, state, acc) do
+    case acc.cache do
+      %{^id => cached} ->
+        {cached, acc}
+
+      _ ->
+        {res, acc} = do_rewrite_subtree(expr, state, acc)
+        {res, %{acc | cache: Map.put(acc.cache, id, res)}}
+    end
+  end
+
+  defp rewrite_subtree(other, state, acc), do: do_rewrite_subtree(other, state, acc)
+
+  defp do_rewrite_subtree(%T{data: %Expr{id: id, op: :parameter}} = expr, state, acc) do
     case state.nodes_to_replace do
       %{^id => res} ->
         # This parameter is being replaced by a stage output - collect the replacement
@@ -770,7 +796,7 @@ defmodule Nx.Defn.Graph do
     end
   end
 
-  defp rewrite_subtree(
+  defp do_rewrite_subtree(
          %T{data: %Expr{op: :block, id: id, args: [struct, in_args, subexpr, fun]}} = expr,
          state,
          acc
@@ -789,7 +815,7 @@ defmodule Nx.Defn.Graph do
     end
   end
 
-  defp rewrite_subtree(
+  defp do_rewrite_subtree(
          %T{data: %Expr{op: :while, id: id, args: [initial, arg, pred, block]}} = expr,
          state,
          acc
@@ -806,7 +832,7 @@ defmodule Nx.Defn.Graph do
     end
   end
 
-  defp rewrite_subtree(
+  defp do_rewrite_subtree(
          %T{data: %Expr{op: :cond, id: id, args: [clauses, last]}} = expr,
          state,
          acc
@@ -831,7 +857,7 @@ defmodule Nx.Defn.Graph do
     end
   end
 
-  defp rewrite_subtree(%T{data: %Expr{op: :fun, id: id}} = expr, state, acc) do
+  defp do_rewrite_subtree(%T{data: %Expr{op: :fun, id: id}} = expr, state, acc) do
     case state.nodes_to_replace do
       %{^id => res} ->
         {res, put_in(acc.used_args[id], res)}
@@ -842,7 +868,7 @@ defmodule Nx.Defn.Graph do
     end
   end
 
-  defp rewrite_subtree(
+  defp do_rewrite_subtree(
          %T{data: %Expr{id: id, op: :elem, args: [tuple_expr, index]}} = expr,
          state,
          acc
@@ -875,7 +901,27 @@ defmodule Nx.Defn.Graph do
     end
   end
 
-  defp rewrite_subtree(%T{data: %Expr{id: id, args: args}} = expr, state, acc) do
+  defp do_rewrite_subtree(
+         %T{data: %Expr{op: :runtime_call, id: id, args: [tensor_expr, callback, out, opts]}} = expr,
+         state,
+         acc
+       ) do
+    case state.nodes_to_replace do
+      %{^id => res} ->
+        {res, put_in(acc.used_args[id], res)}
+
+      _ ->
+        # The operands live in `tensor_expr` (an Nx container, usually a tuple);
+        # `callback`/`out`/`opts` are opaque. The generic clause's list handling
+        # skips non-list container elements, which would drop the operands'
+        # parameters from `used_args`. Traverse them here (mirrors
+        # `Nx.Defn.Tree.apply_args/4`'s `:runtime_call` clause).
+        {tensor_expr, acc} = composite_rewrite_subtree(tensor_expr, state, acc)
+        {put_in(expr.data.args, [tensor_expr, callback, out, opts]), acc}
+    end
+  end
+
+  defp do_rewrite_subtree(%T{data: %Expr{id: id, args: args}} = expr, state, acc) do
     case state.nodes_to_replace do
       %{^id => res} ->
         # nodes_to_replace always contains a param
@@ -887,5 +933,5 @@ defmodule Nx.Defn.Graph do
     end
   end
 
-  defp rewrite_subtree(other, _, acc), do: {other, acc}
+  defp do_rewrite_subtree(other, _, acc), do: {other, acc}
 end

--- a/nx/lib/nx/defn/graph.ex
+++ b/nx/lib/nx/defn/graph.ex
@@ -902,7 +902,8 @@ defmodule Nx.Defn.Graph do
   end
 
   defp do_rewrite_subtree(
-         %T{data: %Expr{op: :runtime_call, id: id, args: [tensor_expr, callback, out, opts]}} = expr,
+         %T{data: %Expr{op: :runtime_call, id: id, args: [tensor_expr, callback, out, opts]}} =
+           expr,
          state,
          acc
        ) do

--- a/nx/lib/nx/defn/graph.ex
+++ b/nx/lib/nx/defn/graph.ex
@@ -190,6 +190,9 @@ defmodule Nx.Defn.Graph do
       nodes_to_replace: %{},
       expr_split_fn: normalized_fn,
       split_acc: initial_acc,
+      # When true, split decisions are forced to :none. Used while traversing
+      # inside a `cond` so conditionally-executed computation is never hoisted.
+      force_none: false,
       # args is a map of id -> {stage_id, output_container_position}
       args: %{}
     }
@@ -291,12 +294,21 @@ defmodule Nx.Defn.Graph do
           :elem ->
             eval_apply(:elem, ans, {cache, state})
 
+          :while ->
+            eval_while(ans, {cache, state})
+
+          :cond ->
+            eval_cond(ans, {cache, state})
+
+          :fun ->
+            eval_fun(ans, {cache, state})
+
           _ ->
             # First process the arguments with the current accumulator
             {args, {cache, state}} = Nx.Defn.Tree.apply_args(ans, {cache, state}, &eval/2)
 
             # Then check if we should split based on this node
-            {split_decision, new_acc} = state.expr_split_fn.(ans, state.split_acc)
+            {split_decision, new_acc} = split_decision(ans, state)
             state = %{state | split_acc: new_acc}
 
             case split_decision do
@@ -321,6 +333,140 @@ defmodule Nx.Defn.Graph do
 
   defp eval(other, {cache, state}) do
     {other, {cache, state}}
+  end
+
+  # Returns the split decision for `ans`, honoring `force_none`. While traversing
+  # inside a `cond`, splits must never be initiated (that would hoist conditionally
+  # executed computation out of the branch), so we force `:none`.
+  defp split_decision(_ans, %{force_none: true} = state), do: {:none, state.split_acc}
+  defp split_decision(ans, state), do: state.expr_split_fn.(ans, state.split_acc)
+
+  # `while` introduces a hermetic sub-scope: only `initial` (args[0]) belongs to the
+  # parent scope. `arg`/`pred`/`block` reference sub-scope parameters and must remain
+  # opaque, so we never traverse, hoist, or parameterize them here.
+  defp eval_while(
+         %T{data: %Expr{id: id, args: [initial, arg, pred, block]}} = ans,
+         {cache, state}
+       ) do
+    {initial, {cache, state}} = composite_eval(initial, state, cache)
+    ans = put_in(ans.data.args, [initial, arg, pred, block])
+
+    {split_decision, new_acc} = split_decision(ans, state)
+    state = %{state | split_acc: new_acc}
+
+    case split_decision do
+      :none ->
+        {ans, {Map.put(cache, id, ans), state}}
+
+      :after ->
+        split_after(ans, ans.data.args, {cache, state})
+
+      :before ->
+        while_split_before(ans, initial, {cache, state})
+
+      :both ->
+        {before_result, {cache, state}} = while_split_before(ans, initial, {cache, state})
+        split_after(before_result, before_result.data.args, {cache, state})
+    end
+  end
+
+  # `:before` for a `while` hoists only the parent-scope operands, i.e. the tensor
+  # leaves of `initial`, keeping the loop sub-scope intact.
+  defp while_split_before(
+         %T{data: %Expr{args: [_initial, arg, pred, block]}} = ans,
+         initial,
+         {cache, state}
+       ) do
+    nodes_to_replace = state.nodes_to_replace
+    stage_id = make_ref()
+
+    {new_initial, {tensor_args, _out_position, state}} =
+      Composite.traverse(initial, {[], 0, state}, fn
+        %T{data: %Expr{op: :parameter}} = leaf, {tensor_args, out_position, state} ->
+          state =
+            case Map.has_key?(state.args, leaf.data.id) do
+              false ->
+                %{state | args: Map.put(state.args, leaf.data.id, {stage_id, out_position})}
+
+              true ->
+                state
+            end
+
+          {leaf, {tensor_args, out_position, state}}
+
+        %T{} = leaf, {tensor_args, out_position, state} ->
+          param = Expr.parameter(leaf, map_size(state.args))
+
+          state = %{
+            state
+            | args: Map.put(state.args, param.data.id, {stage_id, out_position}),
+              nodes_to_replace: Map.put(state.nodes_to_replace, leaf.data.id, param)
+          }
+
+          {param, {[leaf | tensor_args], out_position + 1, state}}
+      end)
+
+    case tensor_args do
+      [] ->
+        # No parent-scope computations to hoist, so there is no prior stage to
+        # create. Leave the while inline; for `:both` the caller's `split_after`
+        # still isolates it in its own stage.
+        {ans, {cache, state}}
+
+      _ ->
+        new_expr = put_in(ans.data.args, [new_initial, arg, pred, block])
+        stage_expr = List.to_tuple(Enum.reverse(tensor_args))
+
+        state =
+          update_in(
+            state.expression_chain,
+            &[{stage_id, stage_expr, nodes_to_replace} | &1]
+          )
+
+        cache = Map.put(cache, new_expr.data.id, new_expr)
+        {new_expr, {cache, state}}
+    end
+  end
+
+  # `cond` shares the parent scope: its predicates and clause bodies reference
+  # parent-scope tensors directly. We traverse them to collect/remap parent-scope
+  # dependencies (forcing :none so no conditionally-executed work is hoisted), but
+  # treat the `cond` itself as an opaque unit for splitting.
+  defp eval_cond(%T{data: %Expr{id: id, args: [clauses, last]}} = ans, {cache, state}) do
+    outer_force_none = state.force_none
+    state = %{state | force_none: true}
+
+    {clauses, {cache, state}} =
+      Enum.map_reduce(clauses, {cache, state}, fn {pred, body}, {cache, state} ->
+        {pred, {cache, state}} = eval(pred, {cache, state})
+        {body, {cache, state}} = composite_eval(body, state, cache)
+        {{pred, body}, {cache, state}}
+      end)
+
+    {last, {cache, state}} = composite_eval(last, state, cache)
+    state = %{state | force_none: outer_force_none}
+
+    ans = put_in(ans.data.args, [clauses, last])
+
+    {split_decision, new_acc} = split_decision(ans, state)
+    state = %{state | split_acc: new_acc}
+
+    case split_decision do
+      :none ->
+        {ans, {Map.put(cache, id, ans), state}}
+
+      # A `cond` exposes no top-level hoistable operands, so every split decision
+      # collapses to isolating the opaque node in its own stage. Routing through
+      # `split_before` would wrongly hoist `last`.
+      _ ->
+        split_after(ans, ans.data.args, {cache, state})
+    end
+  end
+
+  # `fun` wraps a hermetic body (defn closures receive all external values as
+  # arguments), so it is an opaque leaf. Function values are not splittable.
+  defp eval_fun(%T{data: %Expr{id: id}} = ans, {cache, state}) do
+    {ans, {Map.put(cache, id, ans), state}}
   end
 
   defp split_before(expr, args, {cache, state}) do
@@ -444,31 +590,87 @@ defmodule Nx.Defn.Graph do
 
     # The stage computes the current expression with its original args
     new_expr = put_in(expr.data.args, args)
-    stage_expr = {new_expr}
 
-    # Create a parameter that represents the output of this stage
-    result_param = Expr.parameter(new_expr, map_size(state.args))
+    case new_expr do
+      %T{type: {:tuple, _}, data: %Expr{op: op}} when op in [:while, :cond] ->
+        split_after_tuple(new_expr, stage_id, nodes_to_replace, {cache, state})
 
-    # Update state to track this stage output
+      _ ->
+        stage_expr = {new_expr}
+
+        # Create a parameter that represents the output of this stage
+        result_param = Expr.parameter(new_expr, map_size(state.args))
+
+        # Update state to track this stage output
+        state = %{
+          state
+          | args: Map.put(state.args, result_param.data.id, {stage_id, 0}),
+            nodes_to_replace: Map.put(state.nodes_to_replace, new_expr.data.id, result_param)
+        }
+
+        state =
+          update_in(
+            state.expression_chain,
+            &[
+              {stage_id, stage_expr, nodes_to_replace}
+              | &1
+            ]
+          )
+
+        cache = Map.put(cache, result_param.data.id, result_param)
+
+        {result_param, {cache, state}}
+    end
+  end
+
+  # A tuple-typed opaque node (e.g. a multi-value `while`/`cond`) cannot be carried
+  # across a stage boundary as a single value: the evaluator does not accept
+  # tuple-valued parameters. We therefore flatten it into one stage output per tuple
+  # element and replace the node with a literal tuple of per-element parameters, so
+  # downstream `elem/2` projections resolve directly to those parameters.
+  defp split_after_tuple(new_expr, stage_id, nodes_to_replace, {cache, state}) do
+    leaves = tuple_output_leaves(new_expr)
+    elems = Expr.tuple(new_expr, leaves)
+
+    {params, state} =
+      elems
+      |> Tuple.to_list()
+      |> Enum.with_index()
+      |> Enum.map_reduce(state, fn {elem_expr, index}, state ->
+        param = Expr.parameter(elem_expr, map_size(state.args))
+        state = %{state | args: Map.put(state.args, param.data.id, {stage_id, index})}
+        {param, state}
+      end)
+
+    result = List.to_tuple(params)
+
     state = %{
       state
-      | args: Map.put(state.args, result_param.data.id, {stage_id, 0}),
-        nodes_to_replace: Map.put(state.nodes_to_replace, new_expr.data.id, result_param)
+      | nodes_to_replace: Map.put(state.nodes_to_replace, new_expr.data.id, result)
     }
 
     state =
       update_in(
         state.expression_chain,
         &[
-          {stage_id, stage_expr, nodes_to_replace}
+          {stage_id, elems, nodes_to_replace}
           | &1
         ]
       )
 
-    cache = Map.put(cache, result_param.data.id, result_param)
+    cache = Map.put(cache, new_expr.data.id, result)
 
-    {result_param, {cache, state}}
+    {result, {cache, state}}
   end
+
+  # Output element templates for an opaque control-flow node, used to project its
+  # tuple result into per-element stage outputs. For `while` the carried `arg`
+  # mirrors the output shape; for `cond` the `last` clause is the output template.
+  defp tuple_output_leaves(%T{data: %Expr{op: :while, args: [_initial, arg, _pred, _block]}}),
+    do: Composite.flatten_list([arg])
+
+  defp tuple_output_leaves(%T{data: %Expr{op: :cond, args: [_clauses, last]}}),
+    do: Composite.flatten_list([last])
 
   defp split_both(expr, args, {cache, state}) do
     # For :both mode, we need to check if split_before would create intermediate computations
@@ -584,6 +786,59 @@ defmodule Nx.Defn.Graph do
   end
 
   defp rewrite_subtree(
+         %T{data: %Expr{op: :while, id: id, args: [initial, arg, pred, block]}} = expr,
+         state,
+         acc
+       ) do
+    case state.nodes_to_replace do
+      %{^id => res} ->
+        {res, put_in(acc.used_args[id], res)}
+
+      _ ->
+        # Only `initial` belongs to the parent scope; the loop sub-scope
+        # (arg/pred/block) is hermetic and kept as is.
+        {initial, acc} = composite_rewrite_subtree(initial, state, acc)
+        {put_in(expr.data.args, [initial, arg, pred, block]), acc}
+    end
+  end
+
+  defp rewrite_subtree(
+         %T{data: %Expr{op: :cond, id: id, args: [clauses, last]}} = expr,
+         state,
+         acc
+       ) do
+    case state.nodes_to_replace do
+      %{^id => res} ->
+        {res, put_in(acc.used_args[id], res)}
+
+      _ ->
+        # `cond` shares the parent scope, so we must recurse into preds/bodies/last
+        # to remap parameters. The generic clause's `composite_rewrite_subtree` does
+        # not descend into the `{pred, body}` tuples.
+        {clauses, acc} =
+          Enum.map_reduce(clauses, acc, fn {pred, body}, acc ->
+            {pred, acc} = rewrite_subtree(pred, state, acc)
+            {body, acc} = composite_rewrite_subtree(body, state, acc)
+            {{pred, body}, acc}
+          end)
+
+        {last, acc} = composite_rewrite_subtree(last, state, acc)
+        {put_in(expr.data.args, [clauses, last]), acc}
+    end
+  end
+
+  defp rewrite_subtree(%T{data: %Expr{op: :fun, id: id}} = expr, state, acc) do
+    case state.nodes_to_replace do
+      %{^id => res} ->
+        {res, put_in(acc.used_args[id], res)}
+
+      _ ->
+        # `fun` wraps a hermetic body, so it is kept opaque.
+        {expr, acc}
+    end
+  end
+
+  defp rewrite_subtree(
          %T{data: %Expr{id: id, op: :elem, args: [tuple_expr, index]}} = expr,
          state,
          acc
@@ -608,11 +863,8 @@ defmodule Nx.Defn.Graph do
             param = Expr.parameter(elem_expr, index)
             {param, put_in(acc.used_args[elem_expr.data.id], param)}
 
-          # Tuple tensor: create a parameter pointing to this index
-          %T{type: {:tuple, _}} ->
-            param = Expr.parameter(expr, index)
-            {param, put_in(acc.used_args[param.data.id], param)}
-
+          # Otherwise the tuple is computed in this stage (e.g. an opaque `while`/`cond`
+          # still inline, or a tuple-output op); keep the `elem` projection as is.
           _ ->
             {put_in(expr.data.args, [tuple_expr, index]), acc}
         end

--- a/nx/test/nx/defn/composite_test.exs
+++ b/nx/test/nx/defn/composite_test.exs
@@ -24,8 +24,7 @@ defmodule Nx.Defn.CompositeTest do
                 Nx.tensor(1),
                 Nx.tensor(3, type: {:c, 64}),
                 Nx.tensor(4, type: {:c, 64})
-              },
-              Nx.tensor(2, type: {:c, 64})} ==
+              }, Nx.tensor(2, type: {:c, 64})} ==
                Composite.traverse(
                  {1, Complex.new(2), Nx.tensor(3)},
                  0,

--- a/nx/test/nx/defn/graph_test.exs
+++ b/nx/test/nx/defn/graph_test.exs
@@ -1,6 +1,8 @@
 defmodule Nx.Defn.GraphTest do
   use ExUnit.Case, async: true
 
+  import Nx.Defn
+
   alias Nx.Defn.Graph
   alias Nx.Defn.Graph.Stage
 
@@ -8,6 +10,47 @@ defmodule Nx.Defn.GraphTest do
   alias Nx.Defn.Expr
 
   doctest Nx.Defn.Graph
+
+  defn count(x), do: while(x, Nx.less(x, 10), do: Nx.add(x, 1))
+
+  defn pre_while(x) do
+    a = Nx.multiply(x, 2)
+    w = while a, Nx.less(a, 10), do: Nx.add(a, 1)
+    Nx.add(w, 100)
+  end
+
+  defn tuple_while(x) do
+    y = Nx.multiply(x, 2)
+
+    {a, b} =
+      while {x, y}, Nx.less(x, 10) do
+        {Nx.add(x, 1), Nx.add(y, 2)}
+      end
+
+    Nx.add(a, b)
+  end
+
+  defn tuple_while_params(x, y) do
+    {a, b} =
+      while {x, y}, Nx.less(x, 10) do
+        {Nx.add(x, 1), Nx.add(y, 2)}
+      end
+
+    Nx.add(a, b)
+  end
+
+  defn pre_cond(x, y) do
+    a = Nx.add(x, y)
+
+    c =
+      cond do
+        Nx.greater(a, 5) -> Nx.add(a, 1)
+        true -> Nx.subtract(a, 1)
+      end
+
+    d = Nx.multiply(c, 2)
+    Nx.add(d, 100)
+  end
 
   describe "split/2" do
     test "simple expression with 1 split and no common nodes" do
@@ -783,4 +826,176 @@ defmodule Nx.Defn.GraphTest do
       assert Graph.run(chain_both, args) == expected_result
     end
   end
+
+  describe "split with control flow" do
+    test "tail-position while split :before keeps the loop sub-scope opaque" do
+      x = Nx.tensor(0, type: :s32)
+      expr = Nx.Defn.debug_expr(&count/1).(x)
+
+      stages =
+        Graph.split(expr, fn
+          %T{data: %Expr{op: :while}} -> :before
+          _ -> :none
+        end)
+
+      # The loop condition (`less`) and body (`add`) must never leak out of the
+      # while sub-scope as stage outputs.
+      ops_in_stage_outputs =
+        for stage <- stages,
+            output <- stage.expr |> wrap_outputs(),
+            %T{data: %Expr{op: op}} <- Nx.Defn.Composite.flatten_list([output]),
+            do: op
+
+      refute :less in ops_in_stage_outputs
+
+      # The while node passes through as a single opaque unit.
+      assert Enum.any?(stages, fn stage ->
+               stage.expr
+               |> wrap_outputs()
+               |> Enum.any?(&match?(%T{data: %Expr{op: :while}}, &1))
+             end)
+
+      assert Graph.run(stages, [x]) |> Nx.to_number() == 10
+    end
+
+    test "non-tail while split :both isolates the pre/while/post stages" do
+      x = Nx.tensor(1, type: :s32)
+
+      ground_truth =
+        Nx.Defn.jit(&pre_while/1, compiler: Nx.Defn.Evaluator).(x)
+        |> Nx.to_number()
+
+      assert ground_truth == 110
+
+      expr = Nx.Defn.debug_expr(&pre_while/1).(x)
+
+      stages =
+        Graph.split(expr, fn
+          %T{data: %Expr{op: :while}} -> :both
+          _ -> :none
+        end)
+
+      assert [stage_0, stage_1, stage_2] = stages
+
+      # stage 0: the pre-while computation (multiply)
+      assert {%T{data: %Expr{op: :multiply}}} = stage_0.expr
+
+      # stage 1: the while node, sub-scope untouched
+      assert {%T{data: %Expr{op: :while, args: [initial, _arg, pred, block]}}} = stage_1.expr
+      assert %T{data: %Expr{op: :parameter}} = initial
+      assert %T{data: %Expr{op: :less}} = pred
+      assert %T{data: %Expr{op: :add}} = block
+
+      # stage 2: the post-while computation (add 100)
+      assert %T{data: %Expr{op: :add}} = stage_2.expr
+
+      assert Graph.run(stages, [x]) |> Nx.to_number() == 110
+    end
+
+    test "multi-value (tuple-carry) while round-trips in every split mode" do
+      x = Nx.tensor(0, type: :s32)
+
+      ground_truth =
+        Nx.Defn.jit(&tuple_while/1, compiler: Nx.Defn.Evaluator).(x)
+        |> Nx.to_number()
+
+      expr = Nx.Defn.debug_expr(&tuple_while/1).(x)
+
+      for mode <- [:none, :before, :after, :both] do
+        stages =
+          Graph.split(expr, fn
+            %T{data: %Expr{op: :while}} -> mode
+            _ -> :none
+          end)
+
+        assert Graph.run(stages, [x]) |> Nx.to_number() == ground_truth,
+               "tuple-carry while failed for split mode #{inspect(mode)}"
+      end
+    end
+
+    test "tuple-carry while with all-parameter initial round-trips in every split mode" do
+      x = Nx.tensor(0, type: :s32)
+      y = Nx.tensor(5, type: :s32)
+
+      ground_truth =
+        Nx.Defn.jit(&tuple_while_params/2, compiler: Nx.Defn.Evaluator).(x, y)
+        |> Nx.to_number()
+
+      expr = Nx.Defn.debug_expr(&tuple_while_params/2).(x, y)
+
+      for mode <- [:none, :before, :after, :both] do
+        stages =
+          Graph.split(expr, fn
+            %T{data: %Expr{op: :while}} -> mode
+            _ -> :none
+          end)
+
+        assert Graph.run(stages, [x, y]) |> Nx.to_number() == ground_truth,
+               "all-parameter tuple-carry while failed for split mode #{inspect(mode)}"
+      end
+    end
+
+    test "cond passes through intact when splitting an unrelated node" do
+      x = Nx.tensor(3, type: :s32)
+      y = Nx.tensor(4, type: :s32)
+
+      ground_truth =
+        Nx.Defn.jit(&pre_cond/2, compiler: Nx.Defn.Evaluator).(x, y)
+        |> Nx.to_number()
+
+      expr = Nx.Defn.debug_expr(&pre_cond/2).(x, y)
+
+      # Split before the multiply, which feeds the cond. The cond must not be
+      # split apart and its parent-scope dependency (`b`) must be remapped.
+      stages =
+        Graph.split(expr, fn
+          %T{data: %Expr{op: :multiply}} -> :before
+          _ -> :none
+        end)
+
+      assert length(stages) >= 2
+
+      # The cond node survives intact in one of the stages.
+      assert Enum.any?(stages, fn stage ->
+               stage.expr |> wrap_outputs() |> Enum.any?(&contains_op?(&1, :cond))
+             end)
+
+      assert Graph.run(stages, [x, y]) |> Nx.to_number() == ground_truth
+    end
+
+    test "cond split :after isolates the cond in its own stage" do
+      x = Nx.tensor(10, type: :s32)
+      y = Nx.tensor(20, type: :s32)
+
+      ground_truth =
+        Nx.Defn.jit(&pre_cond/2, compiler: Nx.Defn.Evaluator).(x, y)
+        |> Nx.to_number()
+
+      expr = Nx.Defn.debug_expr(&pre_cond/2).(x, y)
+
+      stages =
+        Graph.split(expr, fn
+          %T{data: %Expr{op: :cond}} -> :after
+          _ -> :none
+        end)
+
+      assert Graph.run(stages, [x, y]) |> Nx.to_number() == ground_truth
+    end
+  end
+
+  defp wrap_outputs(expr) when is_tuple(expr), do: Tuple.to_list(expr)
+  defp wrap_outputs(expr), do: [expr]
+
+  defp contains_op?(%T{data: %Expr{op: target}}, target), do: true
+
+  defp contains_op?(%T{} = expr, target) do
+    {_, found} =
+      Nx.Defn.Tree.apply_args(expr, false, fn arg, found ->
+        {arg, found or contains_op?(arg, target)}
+      end)
+
+    found
+  end
+
+  defp contains_op?(_other, _target), do: false
 end

--- a/nx/test/nx/defn/graph_test.exs
+++ b/nx/test/nx/defn/graph_test.exs
@@ -1,3 +1,8 @@
+defmodule Nx.Defn.GraphTest.RuntimeCallback do
+  @moduledoc false
+  def add_pair({a, b}, _opts), do: Nx.add(a, b)
+end
+
 defmodule Nx.Defn.GraphTest do
   use ExUnit.Case, async: true
 
@@ -983,8 +988,109 @@ defmodule Nx.Defn.GraphTest do
     end
   end
 
+  describe "split/run regression coverage" do
+    # The second rewrite pass (`composite_rewrite_subtree`) runs on every stage's
+    # expression, including the final stage even with no splits. Without per-id
+    # memoization, a heavily-shared DAG is walked once per incoming edge, which is
+    # exponential. A doubling chain of depth `n` has `n` nodes but `2^n` tree
+    # paths, so an unmemoized rewrite cannot finish within the timeout.
+    @tag timeout: 10_000
+    test "split over a heavily-shared (doubling-chain) DAG completes and round-trips" do
+      depth = 45
+      x = Nx.tensor([1.0, 2.0], type: :f32)
+
+      fun = fn x -> Enum.reduce(1..depth, x, fn _, acc -> Nx.add(acc, acc) end) end
+
+      expected = Nx.Defn.jit_apply(fun, [x])
+      expr = Nx.Defn.debug_expr(fun).(x)
+
+      stages = Graph.split(expr, fn _ -> :none end)
+
+      assert Graph.run(stages, [x]) == expected
+    end
+
+    test "runtime_call with tuple operands feeding a split point round-trips" do
+      a = Nx.tensor([1.0, 2.0], type: :f32)
+      b = Nx.tensor([3.0, 4.0], type: :f32)
+
+      callback = &Nx.Defn.GraphTest.RuntimeCallback.add_pair/2
+
+      fun = fn a, b ->
+        # The operands `{a, b}` are stored as a container inside the runtime_call
+        # args; splitting `:before` the downstream `add` pulls the runtime_call
+        # into a non-final stage, where its operands must be collected.
+        r = Nx.runtime_call(a, {a, b}, [], callback)
+        Nx.add(r, a)
+      end
+
+      expected = Nx.Defn.jit(fun, compiler: Nx.Defn.Evaluator).(a, b)
+      expr = Nx.Defn.debug_expr(fun).(a, b)
+
+      stages =
+        Graph.split(expr, fn
+          %T{data: %Expr{op: :add}} -> :before
+          _ -> :none
+        end)
+
+      # The stage holding the runtime_call must declare an argument for every
+      # parameter its expression references, otherwise its operands were dropped.
+      rc_stage =
+        Enum.find(stages, fn stage ->
+          stage.expr |> wrap_outputs() |> Enum.any?(&contains_op?(&1, :runtime_call))
+        end)
+
+      assert rc_stage
+
+      referenced_indices =
+        rc_stage.expr
+        |> wrap_outputs()
+        |> Enum.flat_map(&collect_param_indices(&1, []))
+        |> Enum.uniq()
+
+      assert Enum.all?(referenced_indices, &(&1 < length(rc_stage.arguments)))
+
+      assert Graph.run(stages, [a, b], compiler: Nx.Defn.Evaluator) == expected
+    end
+
+    test "run/3 returns a non-tuple (map) container as the final output" do
+      x = Nx.tensor([1, 2, 3], type: :s32)
+
+      fun = fn x ->
+        a = Nx.add(x, 1)
+        b = Nx.multiply(a, 2)
+        %{sum: Nx.sum(b), doubled: b}
+      end
+
+      expected = Nx.Defn.jit(fun, compiler: Nx.Defn.Evaluator).(x)
+      expr = Nx.Defn.debug_expr(fun).(x)
+
+      stages =
+        Graph.split(expr, fn
+          %T{data: %Expr{op: :multiply}} -> :before
+          _ -> :none
+        end)
+
+      assert Graph.run(stages, [x], compiler: Nx.Defn.Evaluator) == expected
+    end
+  end
+
   defp wrap_outputs(expr) when is_tuple(expr), do: Tuple.to_list(expr)
   defp wrap_outputs(expr), do: [expr]
+
+  # Collects every `:parameter` index referenced inside `expr`. Uses
+  # `Nx.Defn.Tree.apply_args/3`, which descends into `runtime_call` operands.
+  defp collect_param_indices(%T{data: %Expr{op: :parameter, args: [idx]}}, acc), do: [idx | acc]
+
+  defp collect_param_indices(%T{} = expr, acc) do
+    {_, acc} =
+      Nx.Defn.Tree.apply_args(expr, acc, fn arg, acc ->
+        {arg, collect_param_indices(arg, acc)}
+      end)
+
+    acc
+  end
+
+  defp collect_param_indices(_other, acc), do: acc
 
   defp contains_op?(%T{data: %Expr{op: target}}, target), do: true
 


### PR DESCRIPTION
This fixes an issue that would appear when splitting on :while and :cond
Also adds an opts passthrough argument for Nx.Defn.Graph.run