### PR TITLE
ci: run formatter and default CI on Elixir 1.20 with OTP 28

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,12 +63,12 @@ jobs:
       fail-fast: false
       matrix:
         working_directory: ["nx", "exla", "torchx"]
-        elixir: ["1.17.3", "1.18.4"]
+        elixir: ["1.17.3", "1.20.2"]
         include:
           - elixir: "1.17.3"
             otp: "27.3"
-          - elixir: "1.18.4"
-            otp: "28.3"
+          - elixir: "1.20.2"
+            otp: "28.5"
             lint: true
     defaults:
       run:
@@ -129,8 +129,8 @@ jobs:
       matrix:
         working_directory: ["nx", "torchx"]
         include:
-          - elixir: "1.18.4"
-            otp: "27.3"
+          - elixir: "1.20.2"
+            otp: "28.5"
     defaults:
       run:
         working-directory: ${{ matrix.working_directory }}


### PR DESCRIPTION

## Summary

Updates the CI matrix in `.github/workflows/ci.yml` so the formatter check and the "default" build run on Elixir 1.20 with OTP 28, instead of Elixir 1.18 with OTP 28.3.

## Changes

- **Linux `main` job**: replaced the `1.18.4` / `28.3` matrix entry (the one with `lint: true`, which runs `mix format --check-formatted`) with `1.20.2` / `28.5`. The `1.17.3` / `27.3` entry is kept for backward-compat coverage.
- **Windows `win` job**: updated the single default version from `1.18.4` / `27.3` to `1.20.2` / `28.5`.
