### PR TITLE
fix: do not hoist non-expr tensor arguments

### DIFF
--- a/nx/lib/nx/defn/graph.ex
+++ b/nx/lib/nx/defn/graph.ex
@@ -503,7 +503,7 @@ defmodule Nx.Defn.Graph do
 
           {arg, {tensor_args, out_position, state}}
 
-        %T{} = expr, {tensor_args, out_position, state} ->
+        %T{data: %Expr{}} = expr, {tensor_args, out_position, state} ->
           arg = Expr.parameter(expr, map_size(state.args))
 
           state = %{
@@ -514,6 +514,12 @@ defmodule Nx.Defn.Graph do
 
           {arg, {[expr | tensor_args], out_position + 1, state}}
 
+        # A bare, non-Expr-backed %Nx.Tensor{} (e.g. a `Nx.template/2` value
+        # riding in an op's args, as `:runtime_call`'s `out_template` does) is
+        # not a real graph node to hoist as a stage boundary parameter --
+        # `Expr.parameter/2` requires `data: %Expr{}` and would raise
+        # (FunctionClauseError) otherwise. Leave it untouched, like any other
+        # non-tensor arg.
         non_tensor_arg, acc ->
           {non_tensor_arg, acc}
       end)
@@ -528,10 +534,15 @@ defmodule Nx.Defn.Graph do
           {wrapped_expr, new_expr}
 
         {[], _, _} ->
-          # No intermediate computations - create a parameter for this split operation
-          # The current expression will be computed in the next stage
+          # No intermediate computations to hoist ahead of this node (e.g. its
+          # only operands are bare parameters/non-tensor values) - the stage
+          # boundary computes the node itself, not a placeholder. `param` is
+          # only the reference other stages use to consume this stage's
+          # output; embedding `param` (instead of `new_expr`) as the stage's
+          # own expression would make the stage self-referential (it would
+          # require its own not-yet-computed output as an input).
           param = Expr.parameter(new_expr, map_size(state.args))
-          {{param}, param}
+          {{new_expr}, param}
 
         _ ->
           # There are intermediate computations - only include those in the current stage
@@ -566,9 +577,10 @@ defmodule Nx.Defn.Graph do
           state
 
         {[], _, _} ->
-          # Add parameter mapping and node replacement for the split operation
-          # Extract the parameter from the tuple
-          param = elem(stage_expr, 0)
+          # Add parameter mapping and node replacement for the split operation.
+          # `result_expr` (not `stage_expr`, which now holds the node itself)
+          # is the synthetic parameter representing this stage's output.
+          param = result_expr
 
           %{
             state
@@ -690,7 +702,10 @@ defmodule Nx.Defn.Graph do
     tensor_args =
       Enum.reduce(args, [], fn
         %T{data: %Expr{op: :parameter}}, acc -> acc
-        %T{} = tensor_expr, acc -> [tensor_expr | acc]
+        # Mirrors split_before/3's `%T{data: %Expr{}}` guard: a bare,
+        # non-Expr-backed %Nx.Tensor{} (e.g. :runtime_call's out_template)
+        # is not a real intermediate computation.
+        %T{data: %Expr{}} = tensor_expr, acc -> [tensor_expr | acc]
         _, acc -> acc
       end)
 
@@ -919,6 +934,32 @@ defmodule Nx.Defn.Graph do
         # `Nx.Defn.Tree.apply_args/4`'s `:runtime_call` clause).
         {tensor_expr, acc} = composite_rewrite_subtree(tensor_expr, state, acc)
         {put_in(expr.data.args, [tensor_expr, callback, out, opts]), acc}
+    end
+  end
+
+  defp do_rewrite_subtree(
+         %T{data: %Expr{op: :token, id: id, args: [token]}} = expr,
+         state,
+         acc
+       ) do
+    case state.nodes_to_replace do
+      %{^id => res} ->
+        {res, put_in(acc.used_args[id], res)}
+
+      _ ->
+        # Each hook's payload lives in `token.hooks[].expr`, inside a
+        # `%Nx.Defn.Token{}` struct (not a `%T{}`/list) -- the generic
+        # clause's list handling silently skips it, so a hook payload that
+        # depends on a stage-boundary-hoisted value would keep its stale,
+        # pre-remap parameter reference. Traverse hook exprs here (mirrors
+        # `Nx.Defn.Tree.apply_args/4`'s `:token` clause).
+        {hooks, acc} =
+          Enum.map_reduce(token.hooks, acc, fn %{expr: hook_expr} = hook, acc ->
+            {hook_expr, acc} = composite_rewrite_subtree(hook_expr, state, acc)
+            {%{hook | expr: hook_expr}, acc}
+          end)
+
+        {put_in(expr.data.args, [%{token | hooks: hooks}]), acc}
     end
   end
 

--- a/nx/test/nx/defn/graph_test.exs
+++ b/nx/test/nx/defn/graph_test.exs
@@ -1,6 +1,7 @@
 defmodule Nx.Defn.GraphTest.RuntimeCallback do
   @moduledoc false
   def add_pair({a, b}, _opts), do: Nx.add(a, b)
+  def cast_f32(t, _opts), do: Nx.as_type(t, :f32)
 end
 
 defmodule Nx.Defn.GraphTest do
@@ -1050,6 +1051,72 @@ defmodule Nx.Defn.GraphTest do
       assert Enum.all?(referenced_indices, &(&1 < length(rc_stage.arguments)))
 
       assert Graph.run(stages, [a, b], compiler: Nx.Defn.Evaluator) == expected
+    end
+
+    test "split :before does not hoist a runtime_call's out_template as a stage parameter" do
+      callback = &Nx.Defn.GraphTest.RuntimeCallback.cast_f32/2
+
+      fun = fn qw ->
+        # `qw` is the sole tensor operand and a bare parameter, so the
+        # `out_template` built by `Nx.template/3` is the only other
+        # `%Nx.Tensor{}` in the runtime_call's args -- it must not be
+        # mistaken for a real graph node to hoist.
+        r = Nx.runtime_call(Nx.template({4}, :f32), qw, [], callback)
+        Nx.add(r, 1)
+      end
+
+      qw = Nx.tensor([1, 2, 3, 4], type: :u8)
+
+      expected = Nx.Defn.jit(fun, compiler: Nx.Defn.Evaluator).(qw)
+      expr = Nx.Defn.debug_expr(fun).(qw)
+
+      stages =
+        Graph.split(expr, fn
+          %T{data: %Expr{op: :runtime_call}} -> :before
+          _ -> :none
+        end)
+
+      rc_stage =
+        Enum.find(stages, fn stage ->
+          stage.expr |> wrap_outputs() |> Enum.any?(&contains_op?(&1, :runtime_call))
+        end)
+
+      assert rc_stage
+
+      # The stage's parameter count must match what its expression actually
+      # references -- out_template must not have been hoisted as a spurious
+      # extra parameter.
+      referenced_indices =
+        rc_stage.expr
+        |> wrap_outputs()
+        |> Enum.flat_map(&collect_param_indices(&1, []))
+        |> Enum.uniq()
+
+      assert Enum.all?(referenced_indices, &(&1 < length(rc_stage.arguments)))
+
+      assert Graph.run(stages, [qw], compiler: Nx.Defn.Evaluator) == expected
+    end
+
+    test "split :both does not hoist a runtime_call's out_template as an intermediate computation" do
+      callback = &Nx.Defn.GraphTest.RuntimeCallback.cast_f32/2
+
+      fun = fn qw ->
+        r = Nx.runtime_call(Nx.template({4}, :f32), qw, [], callback)
+        Nx.add(r, 1)
+      end
+
+      qw = Nx.tensor([1, 2, 3, 4], type: :u8)
+
+      expected = Nx.Defn.jit(fun, compiler: Nx.Defn.Evaluator).(qw)
+      expr = Nx.Defn.debug_expr(fun).(qw)
+
+      stages =
+        Graph.split(expr, fn
+          %T{data: %Expr{op: :runtime_call}} -> :both
+          _ -> :none
+        end)
+
+      assert Graph.run(stages, [qw], compiler: Nx.Defn.Evaluator) == expected
     end
 
     test "run/3 returns a non-tuple (map) container as the final output" do


### PR DESCRIPTION
Don't hoist a runtime_call's Nx.TemplateBackend out_template as a Graph.split stage parameter, and fix a self-referential stage bug in split_before when a split node has no intermediate computations to hoist.
