### PR TITLE
Add :pjrt_plugin platform for loading external PJRT plugins

### DIFF
--- a/exla/lib/exla.ex
+++ b/exla/lib/exla.ex
@@ -126,7 +126,15 @@ defmodule EXLA do
   Each client configuration accepts the following options:
 
     * `:platform` - the platform the client runs on. It can be
-      `:host` (CPU), `:cuda`, `:rocm`, or `:tpu`. Defaults to `:host`.
+      `:host` (CPU), `:cuda`, `:rocm`, `:tpu`, or `:c_api` (an
+      externally loaded PJRT plugin, see below). Defaults to `:host`.
+
+    * `:device_type` - required for the `:c_api` platform. The device
+      type string the PJRT plugin registers under (for example `"tt"`).
+
+    * `:plugin_path` - required for the `:c_api` platform. The path to
+      the PJRT plugin shared library to load (for example the tt-xla
+      `pjrt_plugin_tt.so`).
 
     * `:default_device_id` - the default device ID to run on.
       For example, if you have two GPUs, you can choose a different
@@ -137,6 +145,20 @@ defmodule EXLA do
 
     * `:memory_fraction` - how much memory of a GPU device to
       allocate. Defaults to `0.9`.
+
+  ### External PJRT plugins (`:c_api`)
+
+  Besides the built-in platforms, EXLA can target any hardware that ships
+  a PJRT C-API plugin (a shared library) by loading it at runtime. Use the
+  `:c_api` platform together with `:device_type` and `:plugin_path`:
+
+      config :exla, :clients,
+        tt: [platform: :c_api, device_type: "tt", plugin_path: "/path/to/pjrt_plugin_tt.so"]
+
+  The plugin is loaded via its `GetPjrtApi` entrypoint and registered under
+  `:device_type`. Any environment the plugin itself requires (for example a
+  vendor runtime root directory) must be set in the OS environment before the
+  VM starts; EXLA does not manage it.
 
   ### Memory preallocation
 

--- a/exla/lib/exla.ex
+++ b/exla/lib/exla.ex
@@ -126,13 +126,13 @@ defmodule EXLA do
   Each client configuration accepts the following options:
 
     * `:platform` - the platform the client runs on. It can be
-      `:host` (CPU), `:cuda`, `:rocm`, `:tpu`, or `:c_api` (an
+      `:host` (CPU), `:cuda`, `:rocm`, `:tpu`, or `:pjrt_plugin` (an
       externally loaded PJRT plugin, see below). Defaults to `:host`.
 
-    * `:device_type` - required for the `:c_api` platform. The device
+    * `:device_type` - required for the `:pjrt_plugin` platform. The device
       type string the PJRT plugin registers under (for example `"tt"`).
 
-    * `:plugin_path` - required for the `:c_api` platform. The path to
+    * `:plugin_path` - required for the `:pjrt_plugin` platform. The path to
       the PJRT plugin shared library to load (for example the tt-xla
       `pjrt_plugin_tt.so`).
 
@@ -146,14 +146,14 @@ defmodule EXLA do
     * `:memory_fraction` - how much memory of a GPU device to
       allocate. Defaults to `0.9`.
 
-  ### External PJRT plugins (`:c_api`)
+  ### External PJRT plugins (`:pjrt_plugin`)
 
   Besides the built-in platforms, EXLA can target any hardware that ships
   a PJRT C-API plugin (a shared library) by loading it at runtime. Use the
-  `:c_api` platform together with `:device_type` and `:plugin_path`:
+  `:pjrt_plugin` platform together with `:device_type` and `:plugin_path`:
 
       config :exla, :clients,
-        tt: [platform: :c_api, device_type: "tt", plugin_path: "/path/to/pjrt_plugin_tt.so"]
+        tt: [platform: :pjrt_plugin, device_type: "tt", plugin_path: "/path/to/pjrt_plugin_tt.so"]
 
   The plugin is loaded via its `GetPjrtApi` entrypoint and registered under
   `:device_type`. Any environment the plugin itself requires (for example a

--- a/exla/lib/exla/client.ex
+++ b/exla/lib/exla/client.ex
@@ -185,6 +185,27 @@ defmodule EXLA.Client do
         :tpu ->
           EXLA.NIF.get_tpu_client()
 
+        :c_api ->
+          device_type =
+            case Keyword.get(options, :device_type) do
+              nil ->
+                raise ArgumentError,
+                      "the :c_api platform requires a :device_type, the PJRT plugin device " <>
+                        "type to register and look up (for example \"tt\")"
+
+              device_type ->
+                to_string(device_type)
+            end
+
+          plugin_path =
+            Keyword.get(options, :plugin_path) ||
+              raise ArgumentError,
+                    "the :c_api platform requires a :plugin_path pointing at the PJRT plugin " <>
+                      "shared library (for example the tt-xla pjrt_plugin_tt.so)"
+
+          :ok = EXLA.NIF.load_pjrt_plugin(device_type, plugin_path)
+          EXLA.NIF.get_c_api_client(device_type)
+
         _ ->
           raise ArgumentError, "unknown EXLA platform: #{inspect(platform)}"
       end

--- a/exla/lib/exla/client.ex
+++ b/exla/lib/exla/client.ex
@@ -185,12 +185,12 @@ defmodule EXLA.Client do
         :tpu ->
           EXLA.NIF.get_tpu_client()
 
-        :c_api ->
+        :pjrt_plugin ->
           device_type =
             case Keyword.get(options, :device_type) do
               nil ->
                 raise ArgumentError,
-                      "the :c_api platform requires a :device_type, the PJRT plugin device " <>
+                      "the :pjrt_plugin platform requires a :device_type, the PJRT plugin device " <>
                         "type to register and look up (for example \"tt\")"
 
               device_type ->
@@ -200,7 +200,7 @@ defmodule EXLA.Client do
           plugin_path =
             Keyword.get(options, :plugin_path) ||
               raise ArgumentError,
-                    "the :c_api platform requires a :plugin_path pointing at the PJRT plugin " <>
+                    "the :pjrt_plugin platform requires a :plugin_path pointing at the PJRT plugin " <>
                       "shared library (for example the tt-xla pjrt_plugin_tt.so)"
 
           :ok = EXLA.NIF.load_pjrt_plugin(device_type, plugin_path)


### PR DESCRIPTION
## What

Adds a `:pjrt_plugin` client platform to EXLA that loads an external PJRT C-API plugin (a shared library) at runtime and builds a client from it. The plugin is selected per-client via two new options:

- `:device_type` — the device type string the plugin registers under (e.g. `"tt"`)
- `:plugin_path` — path to the plugin shared library (e.g. `pjrt_plugin_tt.so`)

```elixir
config :exla, :clients,
  tt: [platform: :pjrt_plugin , device_type: "tt", plugin_path: "/path/to/pjrt_plugin_tt.so"]
```
Implementation is a single new branch in EXLA.Client.build_client/2 that calls the existing EXLA.NIF.load_pjrt_plugin/2 and EXLA.NIF.get_c_api_client/1 NIFs, plus docs in the EXLA "Clients" section.

## Why

Today each accelerator needs a dedicated platform branch (:cuda, :rocm, :tpu). PJRT already defines a stable C-API for out-of-tree plugins, and the loader NIFs are already in the tree — this just exposes them through client config. It lets EXLA target any hardware shipping a PJRT plugin without a bespoke backend. My motivating case is running Nx on Tenstorrent hardware via tt-xla's pjrt_plugin_tt.so, but nothing here is TT-specific.

## Scope

- No C++ / no NIF changes. Elixir-only
- Missing :device_type or :plugin_path raises a clear ArgumentError.
- Any environment a plugin itself requires (e.g. a vendor runtime root dir) must be set in the OS environment before the VM starts; EXLA does not manage it. This is documented.

## Testing

- Existing EXLA host suite is unchanged and passes (957 doctests, 445 tests; the one Nx.rsqrt/1 f64 last-ULP doctest diff is pre-existing and reproduces on a clean tree — a precompiled xla_extension CPU machine-feature mismatch, unrelated to this change).
- End-to-end validated on real hardware: with tt-xla's pjrt_plugin_tt.so, Nx.add/2 and a full linear-regression training run execute on TT hardware and PCC-match :host.