### PR TITLE
fix: batched gradients for lu, invert, triangular_solve and determinant

### DIFF
--- a/nx/lib/nx/defn/grad.ex
+++ b/nx/lib/nx/defn/grad.ex
@@ -1112,7 +1112,7 @@ defmodule Nx.Defn.Grad do
       end
 
     a_inv_hermitian = Nx.LinAlg.invert(Nx.LinAlg.adjoint(a))
-    ba = linalg_batch_axes(a_inv_hermitian)
+    batch_axes = linalg_batch_axes(a_inv_hermitian)
 
     x =
       case {Nx.shape(x_input), opts[:left_side]} do
@@ -1140,18 +1140,31 @@ defmodule Nx.Defn.Grad do
         # which means that:
         # A_bar = inv(A^H).X_bar.X^H
         # B_bar = inv(A^H).X_bar
-        gx = Nx.dot(g, [-1], ba, Nx.LinAlg.adjoint(x), [-2], ba)
-        da = a_inv_hermitian |> Nx.dot([-1], ba, gx, [-2], ba) |> Nx.negate()
-        db = Nx.dot(a_inv_hermitian, [-1], ba, g, [-2], ba)
+        da =
+          a_inv_hermitian
+          |> Nx.dot(
+            [-1],
+            batch_axes,
+            Nx.dot(g, [-1], batch_axes, Nx.LinAlg.adjoint(x), [-2], batch_axes),
+            [-2],
+            batch_axes
+          )
+          |> Nx.negate()
+
+        db = Nx.dot(a_inv_hermitian, [-1], batch_axes, g, [-2], batch_axes)
         {da, db}
       else
         # X.A = B -> X = B.inv(A)
         # taking a similar approach to the branch above, we get
         # A_bar = -X^H.X_bar.inv(A^H)
         # B_bar = X_bar.inv(A^H)
-        xg = Nx.dot(Nx.LinAlg.adjoint(x), [-1], ba, g, [-2], ba)
-        da = xg |> Nx.dot([-1], ba, a_inv_hermitian, [-2], ba) |> Nx.negate()
-        db = Nx.dot(g, [-1], ba, a_inv_hermitian, [-2], ba)
+        da =
+          Nx.LinAlg.adjoint(x)
+          |> Nx.dot([-1], batch_axes, g, [-2], batch_axes)
+          |> Nx.dot([-1], batch_axes, a_inv_hermitian, [-2], batch_axes)
+          |> Nx.negate()
+
+        db = Nx.dot(g, [-1], batch_axes, a_inv_hermitian, [-2], batch_axes)
         {da, db}
       end
 

--- a/nx/lib/nx/defn/grad.ex
+++ b/nx/lib/nx/defn/grad.ex
@@ -1107,11 +1107,12 @@ defmodule Nx.Defn.Grad do
     a =
       case opts[:transform_a] do
         :none -> a_input
-        :transpose -> Nx.transpose(a_input)
+        :transpose -> transpose_matrix(a_input)
         :conjugate -> Nx.conjugate(a_input)
       end
 
     a_inv_hermitian = Nx.LinAlg.invert(Nx.LinAlg.adjoint(a))
+    ba = linalg_batch_axes(a_inv_hermitian)
 
     x =
       case {Nx.shape(x_input), opts[:left_side]} do
@@ -1139,23 +1140,25 @@ defmodule Nx.Defn.Grad do
         # which means that:
         # A_bar = inv(A^H).X_bar.X^H
         # B_bar = inv(A^H).X_bar
-        da = a_inv_hermitian |> Nx.dot(g |> Nx.dot(Nx.LinAlg.adjoint(x))) |> Nx.negate()
-        db = Nx.dot(a_inv_hermitian, g)
+        gx = Nx.dot(g, [-1], ba, Nx.LinAlg.adjoint(x), [-2], ba)
+        da = a_inv_hermitian |> Nx.dot([-1], ba, gx, [-2], ba) |> Nx.negate()
+        db = Nx.dot(a_inv_hermitian, [-1], ba, g, [-2], ba)
         {da, db}
       else
         # X.A = B -> X = B.inv(A)
         # taking a similar approach to the branch above, we get
         # A_bar = -X^H.X_bar.inv(A^H)
         # B_bar = X_bar.inv(A^H)
-        da = x |> Nx.LinAlg.adjoint() |> Nx.dot(g) |> Nx.dot(a_inv_hermitian) |> Nx.negate()
-        db = Nx.dot(g, a_inv_hermitian)
+        xg = Nx.dot(Nx.LinAlg.adjoint(x), [-1], ba, g, [-2], ba)
+        da = xg |> Nx.dot([-1], ba, a_inv_hermitian, [-2], ba) |> Nx.negate()
+        db = Nx.dot(g, [-1], ba, a_inv_hermitian, [-2], ba)
         {da, db}
       end
 
     da =
       case opts[:transform_a] do
         :none -> da
-        :transpose -> Nx.transpose(da)
+        :transpose -> transpose_matrix(da)
         :conjugate -> Nx.conjugate(da)
       end
 
@@ -1543,6 +1546,13 @@ defmodule Nx.Defn.Grad do
 
   defp up_to(i, n) when i < n, do: [i | up_to(i + 1, n)]
   defp up_to(_, _), do: []
+
+  defp linalg_batch_axes(t), do: Enum.to_list(0..(Nx.rank(t) - 3)//1)
+
+  defp transpose_matrix(t) do
+    rank = Nx.rank(t)
+    Nx.transpose(t, axes: Enum.to_list(0..(rank - 3)//1) ++ [rank - 1, rank - 2])
+  end
 
   defp argsort(list), do: list |> Enum.with_index() |> Enum.sort() |> Enum.map(&elem(&1, 1))
 

--- a/nx/lib/nx/defn/grad.ex
+++ b/nx/lib/nx/defn/grad.ex
@@ -1117,15 +1117,15 @@ defmodule Nx.Defn.Grad do
     # When b is a (possibly batched) vector, its rank is one less than a's.
     # Add a unit axis so the backward math below can treat it as a matrix;
     # the axis is removed from db at the end.
-    vector_axis =
+    b_rank_correction_axis =
       cond do
         Nx.rank(x_input) != Nx.rank(a_input) - 1 -> nil
         opts[:left_side] -> -1
         true -> -2
       end
 
-    x = if vector_axis, do: Nx.new_axis(x_input, vector_axis), else: x_input
-    g = if vector_axis, do: Nx.new_axis(g, vector_axis), else: g
+    x = if b_rank_correction_axis, do: Nx.new_axis(x_input, b_rank_correction_axis), else: x_input
+    g = if b_rank_correction_axis, do: Nx.new_axis(g, b_rank_correction_axis), else: g
 
     {da, db} =
       if opts[:left_side] do
@@ -1181,7 +1181,7 @@ defmodule Nx.Defn.Grad do
         Nx.triu(da)
       end
 
-    db = if vector_axis, do: Nx.squeeze(db, axes: [vector_axis]), else: db
+    db = if b_rank_correction_axis, do: Nx.squeeze(db, axes: [b_rank_correction_axis]), else: db
 
     [{a_input, da}, {b, db}]
   end

--- a/nx/lib/nx/defn/grad.ex
+++ b/nx/lib/nx/defn/grad.ex
@@ -1107,12 +1107,11 @@ defmodule Nx.Defn.Grad do
     a =
       case opts[:transform_a] do
         :none -> a_input
-        :transpose -> transpose_matrix(a_input)
+        :transpose -> Nx.transpose(a_input)
         :conjugate -> Nx.conjugate(a_input)
       end
 
     a_inv_hermitian = Nx.LinAlg.invert(Nx.LinAlg.adjoint(a))
-    batch_axes = linalg_batch_axes(a_inv_hermitian)
 
     x =
       case {Nx.shape(x_input), opts[:left_side]} do
@@ -1140,38 +1139,23 @@ defmodule Nx.Defn.Grad do
         # which means that:
         # A_bar = inv(A^H).X_bar.X^H
         # B_bar = inv(A^H).X_bar
-        da =
-          a_inv_hermitian
-          |> Nx.dot(
-            [-1],
-            batch_axes,
-            Nx.dot(g, [-1], batch_axes, Nx.LinAlg.adjoint(x), [-2], batch_axes),
-            [-2],
-            batch_axes
-          )
-          |> Nx.negate()
-
-        db = Nx.dot(a_inv_hermitian, [-1], batch_axes, g, [-2], batch_axes)
+        da = a_inv_hermitian |> Nx.dot(g |> Nx.dot(Nx.LinAlg.adjoint(x))) |> Nx.negate()
+        db = Nx.dot(a_inv_hermitian, g)
         {da, db}
       else
         # X.A = B -> X = B.inv(A)
         # taking a similar approach to the branch above, we get
         # A_bar = -X^H.X_bar.inv(A^H)
         # B_bar = X_bar.inv(A^H)
-        da =
-          Nx.LinAlg.adjoint(x)
-          |> Nx.dot([-1], batch_axes, g, [-2], batch_axes)
-          |> Nx.dot([-1], batch_axes, a_inv_hermitian, [-2], batch_axes)
-          |> Nx.negate()
-
-        db = Nx.dot(g, [-1], batch_axes, a_inv_hermitian, [-2], batch_axes)
+        da = x |> Nx.LinAlg.adjoint() |> Nx.dot(g) |> Nx.dot(a_inv_hermitian) |> Nx.negate()
+        db = Nx.dot(g, a_inv_hermitian)
         {da, db}
       end
 
     da =
       case opts[:transform_a] do
         :none -> da
-        :transpose -> transpose_matrix(da)
+        :transpose -> Nx.transpose(da)
         :conjugate -> Nx.conjugate(da)
       end
 
@@ -1559,13 +1543,6 @@ defmodule Nx.Defn.Grad do
 
   defp up_to(i, n) when i < n, do: [i | up_to(i + 1, n)]
   defp up_to(_, _), do: []
-
-  defp linalg_batch_axes(t), do: Enum.to_list(0..(Nx.rank(t) - 3)//1)
-
-  defp transpose_matrix(t) do
-    rank = Nx.rank(t)
-    Nx.transpose(t, axes: Enum.to_list(0..(rank - 3)//1) ++ [rank - 1, rank - 2])
-  end
 
   defp argsort(list), do: list |> Enum.with_index() |> Enum.sort() |> Enum.map(&elem(&1, 1))
 

--- a/nx/lib/nx/defn/grad.ex
+++ b/nx/lib/nx/defn/grad.ex
@@ -1107,25 +1107,25 @@ defmodule Nx.Defn.Grad do
     a =
       case opts[:transform_a] do
         :none -> a_input
-        :transpose -> Nx.transpose(a_input)
+        :transpose -> transpose_matrix(a_input)
         :conjugate -> Nx.conjugate(a_input)
       end
 
     a_inv_hermitian = Nx.LinAlg.invert(Nx.LinAlg.adjoint(a))
+    batch_axes = linalg_batch_axes(a_inv_hermitian)
 
-    x =
-      case {Nx.shape(x_input), opts[:left_side]} do
-        {{n}, true} -> Nx.reshape(x_input, {n, 1})
-        {{n}, false} -> Nx.reshape(x_input, {1, n})
-        _ -> x_input
+    # When b is a (possibly batched) vector, its rank is one less than a's.
+    # Add a unit axis so the backward math below can treat it as a matrix;
+    # the axis is removed from db at the end.
+    vector_axis =
+      cond do
+        Nx.rank(x_input) != Nx.rank(a_input) - 1 -> nil
+        opts[:left_side] -> -1
+        true -> -2
       end
 
-    g =
-      case {Nx.shape(g), opts[:left_side]} do
-        {{n}, true} -> Nx.reshape(g, {n, 1})
-        {{n}, false} -> Nx.reshape(g, {1, n})
-        _ -> g
-      end
+    x = if vector_axis, do: Nx.new_axis(x_input, vector_axis), else: x_input
+    g = if vector_axis, do: Nx.new_axis(g, vector_axis), else: g
 
     {da, db} =
       if opts[:left_side] do
@@ -1139,23 +1139,38 @@ defmodule Nx.Defn.Grad do
         # which means that:
         # A_bar = inv(A^H).X_bar.X^H
         # B_bar = inv(A^H).X_bar
-        da = a_inv_hermitian |> Nx.dot(g |> Nx.dot(Nx.LinAlg.adjoint(x))) |> Nx.negate()
-        db = Nx.dot(a_inv_hermitian, g)
+        da =
+          a_inv_hermitian
+          |> Nx.dot(
+            [-1],
+            batch_axes,
+            Nx.dot(g, [-1], batch_axes, Nx.LinAlg.adjoint(x), [-2], batch_axes),
+            [-2],
+            batch_axes
+          )
+          |> Nx.negate()
+
+        db = Nx.dot(a_inv_hermitian, [-1], batch_axes, g, [-2], batch_axes)
         {da, db}
       else
         # X.A = B -> X = B.inv(A)
         # taking a similar approach to the branch above, we get
         # A_bar = -X^H.X_bar.inv(A^H)
         # B_bar = X_bar.inv(A^H)
-        da = x |> Nx.LinAlg.adjoint() |> Nx.dot(g) |> Nx.dot(a_inv_hermitian) |> Nx.negate()
-        db = Nx.dot(g, a_inv_hermitian)
+        da =
+          Nx.LinAlg.adjoint(x)
+          |> Nx.dot([-1], batch_axes, g, [-2], batch_axes)
+          |> Nx.dot([-1], batch_axes, a_inv_hermitian, [-2], batch_axes)
+          |> Nx.negate()
+
+        db = Nx.dot(g, [-1], batch_axes, a_inv_hermitian, [-2], batch_axes)
         {da, db}
       end
 
     da =
       case opts[:transform_a] do
         :none -> da
-        :transpose -> Nx.transpose(da)
+        :transpose -> transpose_matrix(da)
         :conjugate -> Nx.conjugate(da)
       end
 
@@ -1166,11 +1181,7 @@ defmodule Nx.Defn.Grad do
         Nx.triu(da)
       end
 
-    db =
-      case Nx.shape(x_input) do
-        {n} -> Nx.reshape(db, {n})
-        _ -> db
-      end
+    db = if vector_axis, do: Nx.squeeze(db, axes: [vector_axis]), else: db
 
     [{a_input, da}, {b, db}]
   end
@@ -1543,6 +1554,13 @@ defmodule Nx.Defn.Grad do
 
   defp up_to(i, n) when i < n, do: [i | up_to(i + 1, n)]
   defp up_to(_, _), do: []
+
+  defp linalg_batch_axes(t), do: Enum.to_list(0..(Nx.rank(t) - 3)//1)
+
+  defp transpose_matrix(t) do
+    rank = Nx.rank(t)
+    Nx.transpose(t, axes: Enum.to_list(0..(rank - 3)//1) ++ [rank - 1, rank - 2])
+  end
 
   defp argsort(list), do: list |> Enum.with_index() |> Enum.sort() |> Enum.map(&elem(&1, 1))
 

--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -866,8 +866,20 @@ defmodule Nx.LinAlg do
     custom_grad(ans, [tensor], fn g ->
       # As defined in https://juliadiff.org/ChainRulesCore.jl/stable/maths/arrays.html#Matrix-inversion-2
       ans_h = adjoint(ans)
-      [ans_h |> Nx.negate() |> Nx.dot(g) |> Nx.dot(ans_h)]
+      ba = batch_axes(ans_h)
+
+      [
+        ans_h
+        |> Nx.negate()
+        |> Nx.dot([-1], ba, g, [-2], ba)
+        |> Nx.dot([-1], ba, ans_h, [-2], ba)
+      ]
     end)
+  end
+
+  deftransformp batch_axes(t) do
+    rank = tuple_size(t.shape)
+    Enum.to_list(0..(rank - 3)//1)
   end
 
   defnp invert_tensor(tensor) do

--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -866,13 +866,13 @@ defmodule Nx.LinAlg do
     custom_grad(ans, [tensor], fn g ->
       # As defined in https://juliadiff.org/ChainRulesCore.jl/stable/maths/arrays.html#Matrix-inversion-2
       ans_h = adjoint(ans)
-      ba = batch_axes(ans_h)
+      batch_axes = batch_axes(ans_h)
 
       [
         ans_h
         |> Nx.negate()
-        |> Nx.dot([-1], ba, g, [-2], ba)
-        |> Nx.dot([-1], ba, ans_h, [-2], ba)
+        |> Nx.dot([-1], batch_axes, g, [-2], batch_axes)
+        |> Nx.dot([-1], batch_axes, ans_h, [-2], batch_axes)
       ]
     end)
   end

--- a/nx/lib/nx/lin_alg/lu.ex
+++ b/nx/lib/nx/lin_alg/lu.ex
@@ -159,10 +159,10 @@ defmodule Nx.LinAlg.LU do
     u_h = Nx.LinAlg.adjoint(u)
     l_h = Nx.LinAlg.adjoint(l)
     p_t = Nx.LinAlg.adjoint(p)
-    ba = batch_axes(u)
+    batch_axes = batch_axes(u)
 
-    lh_dl = Nx.dot(l_h, [-1], ba, dl, [-2], ba)
-    du_uh = Nx.dot(du, [-1], ba, u_h, [-2], ba)
+    lh_dl = Nx.dot(l_h, [-1], batch_axes, dl, [-2], batch_axes)
+    du_uh = Nx.dot(du, [-1], batch_axes, u_h, [-2], batch_axes)
 
     lt_inv = Nx.LinAlg.invert(l_h)
     ut_inv = Nx.LinAlg.invert(u_h)
@@ -171,9 +171,9 @@ defmodule Nx.LinAlg.LU do
 
     da =
       p_t
-      |> Nx.dot([-1], ba, lt_inv, [-2], ba)
-      |> Nx.dot([-1], ba, df, [-2], ba)
-      |> Nx.dot([-1], ba, ut_inv, [-2], ba)
+      |> Nx.dot([-1], batch_axes, lt_inv, [-2], batch_axes)
+      |> Nx.dot([-1], batch_axes, df, [-2], batch_axes)
+      |> Nx.dot([-1], batch_axes, ut_inv, [-2], batch_axes)
 
     [da]
   end

--- a/nx/lib/nx/lin_alg/lu.ex
+++ b/nx/lib/nx/lin_alg/lu.ex
@@ -159,16 +159,27 @@ defmodule Nx.LinAlg.LU do
     u_h = Nx.LinAlg.adjoint(u)
     l_h = Nx.LinAlg.adjoint(l)
     p_t = Nx.LinAlg.adjoint(p)
+    ba = batch_axes(u)
 
-    lh_dl = Nx.dot(l_h, dl)
-    du_uh = Nx.dot(du, u_h)
+    lh_dl = Nx.dot(l_h, [-1], ba, dl, [-2], ba)
+    du_uh = Nx.dot(du, [-1], ba, u_h, [-2], ba)
 
     lt_inv = Nx.LinAlg.invert(l_h)
     ut_inv = Nx.LinAlg.invert(u_h)
 
     df = lh_dl |> Nx.tril(k: -1) |> Nx.add(Nx.triu(du_uh))
-    da = p_t |> Nx.dot(lt_inv) |> Nx.dot(df) |> Nx.dot(ut_inv)
+
+    da =
+      p_t
+      |> Nx.dot([-1], ba, lt_inv, [-2], ba)
+      |> Nx.dot([-1], ba, df, [-2], ba)
+      |> Nx.dot([-1], ba, ut_inv, [-2], ba)
 
     [da]
+  end
+
+  deftransformp batch_axes(t) do
+    rank = tuple_size(t.shape)
+    Enum.to_list(0..(rank - 3)//1)
   end
 end

--- a/nx/test/nx/defn/grad_test.exs
+++ b/nx/test/nx/defn/grad_test.exs
@@ -4769,32 +4769,6 @@ defmodule Nx.Defn.GradTest do
         triangular_solve_grad_wrt_b(a, b, transform_a: :none, left_side: false, lower: false)
       )
     end
-
-    test "computes grad for batched tensor wrt a and b" do
-      a =
-        Nx.tensor([
-          [[1.0, 1.0, 1.0], [0.0, 1.0, 1.0], [0.0, 0.0, 1.0]],
-          [[2.0, 1.0, 0.0], [0.0, 1.0, 1.0], [0.0, 0.0, 3.0]]
-        ])
-
-      b = Nx.tensor([[[4.0], [3.0], [2.0]], [[1.0], [2.0], [6.0]]])
-
-      assert_all_close(
-        triangular_solve_grad_wrt_a(a, b, lower: false),
-        Nx.stack([
-          triangular_solve_grad_wrt_a(a[0], b[0], lower: false),
-          triangular_solve_grad_wrt_a(a[1], b[1], lower: false)
-        ])
-      )
-
-      assert_all_close(
-        triangular_solve_grad_wrt_b(a, b, lower: false),
-        Nx.stack([
-          triangular_solve_grad_wrt_b(a[0], b[0], lower: false),
-          triangular_solve_grad_wrt_b(a[1], b[1], lower: false)
-        ])
-      )
-    end
   end
 
   describe "not implemented" do

--- a/nx/test/nx/defn/grad_test.exs
+++ b/nx/test/nx/defn/grad_test.exs
@@ -4769,6 +4769,102 @@ defmodule Nx.Defn.GradTest do
         triangular_solve_grad_wrt_b(a, b, transform_a: :none, left_side: false, lower: false)
       )
     end
+
+    test "computes grad for batched tensor with matrix b" do
+      a =
+        Nx.tensor([
+          [[1.0, 1.0, 1.0], [0.0, 1.0, 1.0], [0.0, 0.0, 1.0]],
+          [[2.0, 1.0, 0.0], [0.0, 1.0, 1.0], [0.0, 0.0, 3.0]]
+        ])
+
+      b = Nx.tensor([[[4.0], [3.0], [2.0]], [[1.0], [2.0], [6.0]]])
+
+      assert_all_close(
+        triangular_solve_grad_wrt_a(a, b, lower: false),
+        Nx.stack([
+          triangular_solve_grad_wrt_a(a[0], b[0], lower: false),
+          triangular_solve_grad_wrt_a(a[1], b[1], lower: false)
+        ])
+      )
+
+      assert_all_close(
+        triangular_solve_grad_wrt_b(a, b, lower: false),
+        Nx.stack([
+          triangular_solve_grad_wrt_b(a[0], b[0], lower: false),
+          triangular_solve_grad_wrt_b(a[1], b[1], lower: false)
+        ])
+      )
+    end
+
+    test "computes grad for batched tensor with vector b" do
+      a =
+        Nx.tensor([
+          [[4.0, 0.0], [2.0, 5.0]],
+          [[9.0, 0.0], [3.0, 10.0]]
+        ])
+
+      b = Nx.tensor([[1.0, 1.0], [1.0, 1.0]])
+
+      assert_all_close(
+        triangular_solve_grad_wrt_a(a, b),
+        Nx.stack([
+          triangular_solve_grad_wrt_a(a[0], b[0]),
+          triangular_solve_grad_wrt_a(a[1], b[1])
+        ])
+      )
+
+      assert_all_close(
+        triangular_solve_grad_wrt_b(a, b),
+        Nx.stack([
+          triangular_solve_grad_wrt_b(a[0], b[0]),
+          triangular_solve_grad_wrt_b(a[1], b[1])
+        ])
+      )
+    end
+
+    test "computes grad for batched tensor with vector b, left_side: false" do
+      a =
+        Nx.tensor([
+          [[2.0, 1.0], [0.0, 4.0]],
+          [[3.0, 2.0], [0.0, 1.0]]
+        ])
+
+      b = Nx.tensor([[1.0, 2.0], [3.0, 1.0]])
+
+      assert_all_close(
+        triangular_solve_grad_wrt_a(a, b, left_side: false, lower: false),
+        Nx.stack([
+          triangular_solve_grad_wrt_a(a[0], b[0], left_side: false, lower: false),
+          triangular_solve_grad_wrt_a(a[1], b[1], left_side: false, lower: false)
+        ])
+      )
+
+      assert_all_close(
+        triangular_solve_grad_wrt_b(a, b, left_side: false, lower: false),
+        Nx.stack([
+          triangular_solve_grad_wrt_b(a[0], b[0], left_side: false, lower: false),
+          triangular_solve_grad_wrt_b(a[1], b[1], left_side: false, lower: false)
+        ])
+      )
+    end
+
+    test "computes grad for batched tensor with transform_a: :transpose" do
+      a =
+        Nx.tensor([
+          [[4.0, 0.0], [2.0, 5.0]],
+          [[9.0, 0.0], [3.0, 10.0]]
+        ])
+
+      b = Nx.tensor([[1.0, 1.0], [1.0, 1.0]])
+
+      assert_all_close(
+        triangular_solve_grad_wrt_a(a, b, transform_a: :transpose),
+        Nx.stack([
+          triangular_solve_grad_wrt_a(a[0], b[0], transform_a: :transpose),
+          triangular_solve_grad_wrt_a(a[1], b[1], transform_a: :transpose)
+        ])
+      )
+    end
   end
 
   describe "not implemented" do

--- a/nx/test/nx/defn/grad_test.exs
+++ b/nx/test/nx/defn/grad_test.exs
@@ -3,6 +3,7 @@ defmodule Nx.Defn.GradTest do
 
   import Nx.Defn
   import Nx.Helpers
+  import Nx.Testing, only: [assert_equal: 2]
   import Nx, only: :sigils
 
   @iters 1..25
@@ -2444,7 +2445,7 @@ defmodule Nx.Defn.GradTest do
           [[3.0, 1.0], [2.0, 4.0]]
         ])
 
-      assert_all_close(lu_grad(t), Nx.stack([lu_grad(t[0]), lu_grad(t[1])]))
+      assert_equal(lu_grad(t), Nx.stack([lu_grad(t[0]), lu_grad(t[1])]))
     end
   end
 
@@ -2578,7 +2579,7 @@ defmodule Nx.Defn.GradTest do
           [[2.0, 0.0, 1.0], [1.0, 3.0, 0.0], [0.0, 1.0, 4.0]]
         ])
 
-      assert_all_close(invert_grad(t), Nx.stack([invert_grad(t[0]), invert_grad(t[1])]))
+      assert_equal(invert_grad(t), Nx.stack([invert_grad(t[0]), invert_grad(t[1])]))
     end
   end
 
@@ -2608,7 +2609,7 @@ defmodule Nx.Defn.GradTest do
           ]
         ])
 
-      assert_all_close(
+      assert_equal(
         determinant_grad(t),
         Nx.stack([determinant_grad(t[0]), determinant_grad(t[1])])
       )
@@ -4779,7 +4780,7 @@ defmodule Nx.Defn.GradTest do
 
       b = Nx.tensor([[[4.0], [3.0], [2.0]], [[1.0], [2.0], [6.0]]])
 
-      assert_all_close(
+      assert_equal(
         triangular_solve_grad_wrt_a(a, b, lower: false),
         Nx.stack([
           triangular_solve_grad_wrt_a(a[0], b[0], lower: false),
@@ -4787,7 +4788,7 @@ defmodule Nx.Defn.GradTest do
         ])
       )
 
-      assert_all_close(
+      assert_equal(
         triangular_solve_grad_wrt_b(a, b, lower: false),
         Nx.stack([
           triangular_solve_grad_wrt_b(a[0], b[0], lower: false),
@@ -4805,7 +4806,7 @@ defmodule Nx.Defn.GradTest do
 
       b = Nx.tensor([[1.0, 1.0], [1.0, 1.0]])
 
-      assert_all_close(
+      assert_equal(
         triangular_solve_grad_wrt_a(a, b),
         Nx.stack([
           triangular_solve_grad_wrt_a(a[0], b[0]),
@@ -4813,7 +4814,7 @@ defmodule Nx.Defn.GradTest do
         ])
       )
 
-      assert_all_close(
+      assert_equal(
         triangular_solve_grad_wrt_b(a, b),
         Nx.stack([
           triangular_solve_grad_wrt_b(a[0], b[0]),
@@ -4831,7 +4832,7 @@ defmodule Nx.Defn.GradTest do
 
       b = Nx.tensor([[1.0, 2.0], [3.0, 1.0]])
 
-      assert_all_close(
+      assert_equal(
         triangular_solve_grad_wrt_a(a, b, left_side: false, lower: false),
         Nx.stack([
           triangular_solve_grad_wrt_a(a[0], b[0], left_side: false, lower: false),
@@ -4839,7 +4840,7 @@ defmodule Nx.Defn.GradTest do
         ])
       )
 
-      assert_all_close(
+      assert_equal(
         triangular_solve_grad_wrt_b(a, b, left_side: false, lower: false),
         Nx.stack([
           triangular_solve_grad_wrt_b(a[0], b[0], left_side: false, lower: false),
@@ -4857,7 +4858,7 @@ defmodule Nx.Defn.GradTest do
 
       b = Nx.tensor([[1.0, 1.0], [1.0, 1.0]])
 
-      assert_all_close(
+      assert_equal(
         triangular_solve_grad_wrt_a(a, b, transform_a: :transpose),
         Nx.stack([
           triangular_solve_grad_wrt_a(a[0], b[0], transform_a: :transpose),

--- a/nx/test/nx/defn/grad_test.exs
+++ b/nx/test/nx/defn/grad_test.exs
@@ -2436,6 +2436,16 @@ defmodule Nx.Defn.GradTest do
         ]
       )
     end
+
+    test "computes grad for batched tensor" do
+      t =
+        Nx.tensor([
+          [[1.0, 2.0], [1.0, -1.0]],
+          [[3.0, 1.0], [2.0, 4.0]]
+        ])
+
+      assert_all_close(lu_grad(t), Nx.stack([lu_grad(t[0]), lu_grad(t[1])]))
+    end
   end
 
   describe "svd" do
@@ -2558,6 +2568,49 @@ defmodule Nx.Defn.GradTest do
           [0.9508, 69.7985, -524.3346],
           [-1.2254, 3.1769, -0.0230]
         ])
+      )
+    end
+
+    test "computes grad for batched tensor" do
+      t =
+        Nx.tensor([
+          [[1.0, 2.0, 3.0], [0.0, 4.0, 5.0], [0.0, 0.0, -6.0]],
+          [[2.0, 0.0, 1.0], [1.0, 3.0, 0.0], [0.0, 1.0, 4.0]]
+        ])
+
+      assert_all_close(invert_grad(t), Nx.stack([invert_grad(t[0]), invert_grad(t[1])]))
+    end
+  end
+
+  describe "determinant" do
+    defn determinant_grad(t) do
+      grad(t, fn tensor ->
+        tensor
+        |> Nx.LinAlg.determinant()
+        |> Nx.sum()
+      end)
+    end
+
+    test "computes grad for batched tensor" do
+      t =
+        Nx.tensor([
+          [
+            [5.0, 1.0, 2.0, 3.0],
+            [4.0, 10.0, 6.0, 7.0],
+            [8.0, 9.0, 15.0, 11.0],
+            [12.0, 13.0, 14.0, 20.0]
+          ],
+          [
+            [2.0, 0.0, 1.0, 0.0],
+            [1.0, 3.0, 0.0, 1.0],
+            [0.0, 1.0, 4.0, 0.0],
+            [1.0, 0.0, 0.0, 5.0]
+          ]
+        ])
+
+      assert_all_close(
+        determinant_grad(t),
+        Nx.stack([determinant_grad(t[0]), determinant_grad(t[1])])
       )
     end
   end
@@ -4714,6 +4767,32 @@ defmodule Nx.Defn.GradTest do
           lower: false
         ),
         triangular_solve_grad_wrt_b(a, b, transform_a: :none, left_side: false, lower: false)
+      )
+    end
+
+    test "computes grad for batched tensor wrt a and b" do
+      a =
+        Nx.tensor([
+          [[1.0, 1.0, 1.0], [0.0, 1.0, 1.0], [0.0, 0.0, 1.0]],
+          [[2.0, 1.0, 0.0], [0.0, 1.0, 1.0], [0.0, 0.0, 3.0]]
+        ])
+
+      b = Nx.tensor([[[4.0], [3.0], [2.0]], [[1.0], [2.0], [6.0]]])
+
+      assert_all_close(
+        triangular_solve_grad_wrt_a(a, b, lower: false),
+        Nx.stack([
+          triangular_solve_grad_wrt_a(a[0], b[0], lower: false),
+          triangular_solve_grad_wrt_a(a[1], b[1], lower: false)
+        ])
+      )
+
+      assert_all_close(
+        triangular_solve_grad_wrt_b(a, b, lower: false),
+        Nx.stack([
+          triangular_solve_grad_wrt_b(a[0], b[0], lower: false),
+          triangular_solve_grad_wrt_b(a[1], b[1], lower: false)
+        ])
       )
     end
   end


### PR DESCRIPTION
The gradient formulas for these linalg ops used Nx.dot/2, which assumes 2D inputs. On batched (3D+) tensors the contraction axes were wrong and the backward pass either raised or produced bad shapes. Forward passes were fine.

Added a batch_axes helper (same approach already used by qr_grad) and switched the dot calls to contract only the last two axes, keeping the leading batch axes. triangular_solve also had two Nx.transpose/1 calls that reversed every axis; they now transpose only the last two, and the vector RHS reshape is rank based so it covers both a plain {n} vector and a batched {batch, n} one (the shape used by [#1741](https://github.com/RicardoSantos-99/dominex/issues/1741)'s own reproducer).

determinant goes through lu, so its batched grad is fixed too. Tests compare batched grads against the stack of per-slice 2D grads, plus finite differences for triangular_solve.

Same batched-grad class and fix pattern as #1731 (qr, cholesky).

Closes [#1741](https://github.com/RicardoSantos-99/dominex/issues/1741)
Closes [#1742](https://github.com/RicardoSantos-99/dominex/issues/1742)
Closes [#1744](https://github.com/RicardoSantos-99/dominex/issues/1744)
Closes [#1746](https://github.com/RicardoSantos-99/dominex/issues/1746)