### PR TITLE
fix: batched LinAlg grads for svd and eigh

### DIFF
--- a/nx/lib/nx/lin_alg/block_eigh.ex
+++ b/nx/lib/nx/lin_alg/block_eigh.ex
@@ -25,8 +25,9 @@ defmodule Nx.LinAlg.BlockEigh do
 
   # Reverse-mode for A = Q diag(Λ) Qᴴ with distinct eigenvalues.
   # See https://people.maths.ox.ac.uk/gilesm/files/NA-08-01.pdf
+  # Implementation verified against Jax
   defnp eigh_grad({eigenvals, eigenvecs}, _input, {g_vals, g_vecs}) do
-    ba = batch_axes(eigenvecs)
+    batch_axes = batch_axes(eigenvecs)
     eye = eye_from_matrix(eigenvecs)
     g_vals = broadcast_grad(g_vals, eigenvals)
     g_vecs = broadcast_grad(g_vecs, eigenvecs)
@@ -36,12 +37,12 @@ defmodule Nx.LinAlg.BlockEigh do
 
     mid =
       Nx.new_axis(g_vals, -1) * eye +
-        f * Nx.dot(Nx.LinAlg.adjoint(eigenvecs), [-1], ba, g_vecs, [-2], ba)
+        f * Nx.dot(Nx.LinAlg.adjoint(eigenvecs), [-1], batch_axes, g_vecs, [-2], batch_axes)
 
     grad =
       eigenvecs
-      |> Nx.dot([-1], ba, mid, [-2], ba)
-      |> Nx.dot([-1], ba, Nx.LinAlg.adjoint(eigenvecs), [-2], ba)
+      |> Nx.dot([-1], batch_axes, mid, [-2], batch_axes)
+      |> Nx.dot([-1], batch_axes, Nx.LinAlg.adjoint(eigenvecs), [-2], batch_axes)
 
     # Symmetrize: A is Hermitian/symmetric
     [(grad + Nx.LinAlg.adjoint(grad)) / 2]

--- a/nx/lib/nx/lin_alg/block_eigh.ex
+++ b/nx/lib/nx/lin_alg/block_eigh.ex
@@ -10,12 +10,58 @@ defmodule Nx.LinAlg.BlockEigh do
   import Nx.Defn
 
   defn eigh(matrix, opts) do
-    matrix
-    |> Nx.revectorize([collapsed_axes: :auto],
-      target_shape: {Nx.axis_size(matrix, -2), Nx.axis_size(matrix, -1)}
-    )
-    |> decompose(opts)
-    |> revectorize_result(matrix)
+    result =
+      matrix
+      |> Nx.revectorize([collapsed_axes: :auto],
+        target_shape: {Nx.axis_size(matrix, -2), Nx.axis_size(matrix, -1)}
+      )
+      |> decompose(opts)
+      |> revectorize_result(matrix)
+
+    custom_grad(result, [matrix], fn g ->
+      eigh_grad(result, matrix, g)
+    end)
+  end
+
+  # Reverse-mode for A = Q diag(Λ) Qᴴ with distinct eigenvalues.
+  # See https://people.maths.ox.ac.uk/gilesm/files/NA-08-01.pdf
+  defnp eigh_grad({eigenvals, eigenvecs}, _input, {g_vals, g_vecs}) do
+    ba = batch_axes(eigenvecs)
+    eye = eye_from_matrix(eigenvecs)
+    g_vals = broadcast_grad(g_vals, eigenvals)
+    g_vecs = broadcast_grad(g_vecs, eigenvecs)
+
+    # F_ij = 1/(λ_j - λ_i) for i ≠ j, 0 on the diagonal (JAX eigh JVP convention)
+    f = 1 / (eye + Nx.new_axis(eigenvals, -2) - Nx.new_axis(eigenvals, -1)) - eye
+
+    mid =
+      Nx.new_axis(g_vals, -1) * eye +
+        f * Nx.dot(Nx.LinAlg.adjoint(eigenvecs), [-1], ba, g_vecs, [-2], ba)
+
+    grad =
+      eigenvecs
+      |> Nx.dot([-1], ba, mid, [-2], ba)
+      |> Nx.dot([-1], ba, Nx.LinAlg.adjoint(eigenvecs), [-2], ba)
+
+    # Symmetrize: A is Hermitian/symmetric
+    [(grad + Nx.LinAlg.adjoint(grad)) / 2]
+  end
+
+  defnp broadcast_grad(g, template) do
+    if Nx.rank(g) == 0 do
+      Nx.broadcast(g, Nx.shape(template))
+    else
+      g
+    end
+  end
+
+  deftransformp batch_axes(t) do
+    rank = tuple_size(t.shape)
+    Enum.to_list(0..(rank - 3)//1)
+  end
+
+  deftransformp eye_from_matrix(t) do
+    Nx.eye(Nx.shape(t), type: Nx.type(t))
   end
 
   defnp decompose(matrix, opts) do

--- a/nx/lib/nx/lin_alg/svd.ex
+++ b/nx/lib/nx/lin_alg/svd.ex
@@ -317,8 +317,10 @@ defmodule Nx.LinAlg.SVD do
   end
 
   defnp svd_grad({u, s_input, vt}, input, {du, ds, dvt}) do
-    {k} = Nx.shape(s_input)
-    {m, n} = Nx.shape(input)
+    m = Nx.axis_size(input, -2)
+    n = Nx.axis_size(input, -1)
+    k = Nx.axis_size(s_input, -1)
+    ba = batch_axes(input)
 
     if m < n do
       raise "grad for Nx.LinAlg.svd/2 not implemented for the wide matrix case"
@@ -328,49 +330,120 @@ defmodule Nx.LinAlg.SVD do
       if m == n do
         u
       else
-        u[[0..(m - 1), 0..(k - 1)]]
+        slice_last_matrix(u, m, k)
       end
 
     du =
       if m == n do
         du
       else
-        du[[0..(m - 1), 0..(k - 1)]]
+        slice_last_matrix(du, m, k)
       end
 
     # https://j-towns.github.io/papers/svd-derivative.pdf
 
-    eye_k = Nx.eye(k)
-    eye_m = Nx.eye(m)
-    eye_n = Nx.eye(n)
+    eye_k = eye_from_vector(s_input)
+    eye_m = eye_from_matrix(input, m)
+    eye_n = eye_from_matrix(input, n)
 
     s_sq = s_input ** 2
-    sub = -(Nx.new_axis(s_sq, 1) - s_sq) + eye_k
+    sub = -(Nx.new_axis(s_sq, -1) - Nx.new_axis(s_sq, -2)) + eye_k
     f = Nx.select(eye_k, 0, 1 / sub)
 
-    s = Nx.make_diagonal(s_input)
-    s_inv = Nx.make_diagonal(1 / s_input)
+    s = Nx.new_axis(s_input, -1) * eye_k
+    s_inv = Nx.new_axis(1 / s_input, -1) * eye_k
+    ds_matrix = eye_k * Nx.new_axis(ds, -2)
 
-    ut_du = Nx.dot(Nx.LinAlg.adjoint(u), du) - Nx.dot(Nx.LinAlg.adjoint(du), u)
+    ut_du =
+      Nx.dot(Nx.LinAlg.adjoint(u), [-1], ba, du, [-2], ba) -
+        Nx.dot(Nx.LinAlg.adjoint(du), [-1], ba, u, [-2], ba)
 
-    first_component_du = u |> Nx.dot(f * ut_du) |> Nx.dot(s)
+    first_component_du =
+      u
+      |> Nx.dot([-1], ba, f * ut_du, [-2], ba)
+      |> Nx.dot([-1], ba, s, [-2], ba)
 
-    second_component_du = (eye_m - Nx.dot(u, Nx.LinAlg.adjoint(u))) |> Nx.dot(du) |> Nx.dot(s_inv)
+    second_component_du =
+      (eye_m - Nx.dot(u, [-1], ba, Nx.LinAlg.adjoint(u), [-2], ba))
+      |> Nx.dot([-1], ba, du, [-2], ba)
+      |> Nx.dot([-1], ba, s_inv, [-2], ba)
 
-    du_component = Nx.dot(first_component_du + second_component_du, vt)
+    du_component =
+      Nx.dot(first_component_du + second_component_du, [-1], ba, vt, [-2], ba)
 
-    ds_component = u |> Nx.dot(eye_k * ds) |> Nx.dot(vt)
+    ds_component =
+      u
+      |> Nx.dot([-1], ba, ds_matrix, [-2], ba)
+      |> Nx.dot([-1], ba, vt, [-2], ba)
 
     first_dvt_component =
-      (Nx.dot(vt, Nx.LinAlg.adjoint(dvt)) - Nx.dot(dvt, Nx.LinAlg.adjoint(vt))) * f
+      (Nx.dot(vt, [-1], ba, Nx.LinAlg.adjoint(dvt), [-2], ba) -
+         Nx.dot(dvt, [-1], ba, Nx.LinAlg.adjoint(vt), [-2], ba)) * f
 
-    first_dvt_component = s |> Nx.dot(first_dvt_component) |> Nx.dot(vt)
+    first_dvt_component =
+      s
+      |> Nx.dot([-1], ba, first_dvt_component, [-2], ba)
+      |> Nx.dot([-1], ba, vt, [-2], ba)
 
     second_dvt_component =
-      s_inv |> Nx.dot(dvt) |> Nx.dot(eye_n - Nx.dot(Nx.LinAlg.adjoint(vt), vt))
+      s_inv
+      |> Nx.dot([-1], ba, dvt, [-2], ba)
+      |> Nx.dot(
+        [-1],
+        ba,
+        eye_n - Nx.dot(Nx.LinAlg.adjoint(vt), [-1], ba, vt, [-2], ba),
+        [-2],
+        ba
+      )
 
-    dvt_component = Nx.dot(u, first_dvt_component + second_dvt_component)
+    dvt_component =
+      Nx.dot(u, [-1], ba, first_dvt_component + second_dvt_component, [-2], ba)
 
     [du_component + ds_component + dvt_component]
+  end
+
+  deftransformp batch_axes(t) do
+    rank = tuple_size(t.shape)
+    Enum.to_list(0..(rank - 3)//1)
+  end
+
+  deftransformp eye_from_vector(t) do
+    shape = Nx.shape(t)
+    k = elem(shape, tuple_size(shape) - 1)
+    batch = shape |> Tuple.delete_at(tuple_size(shape) - 1) |> Tuple.to_list()
+    Nx.eye(List.to_tuple(batch ++ [k, k]))
+  end
+
+  deftransformp eye_from_matrix(t, size) do
+    shape = Nx.shape(t)
+    rank = tuple_size(shape)
+
+    batch =
+      shape
+      |> Tuple.delete_at(rank - 1)
+      |> Tuple.delete_at(rank - 2)
+      |> Tuple.to_list()
+
+    Nx.eye(List.to_tuple(batch ++ [size, size]))
+  end
+
+  deftransformp slice_last_matrix(t, rows, cols) do
+    shape = Nx.shape(t)
+    rank = tuple_size(shape)
+    starts = List.duplicate(0, rank)
+
+    lengths =
+      shape
+      |> Tuple.to_list()
+      |> Enum.with_index()
+      |> Enum.map(fn {dim, i} ->
+        cond do
+          i == rank - 2 -> rows
+          i == rank - 1 -> cols
+          true -> dim
+        end
+      end)
+
+    Nx.slice(t, starts, lengths)
   end
 end

--- a/nx/lib/nx/lin_alg/svd.ex
+++ b/nx/lib/nx/lin_alg/svd.ex
@@ -320,7 +320,7 @@ defmodule Nx.LinAlg.SVD do
     m = Nx.axis_size(input, -2)
     n = Nx.axis_size(input, -1)
     k = Nx.axis_size(s_input, -1)
-    ba = batch_axes(input)
+    batch_axes = batch_axes(input)
 
     if m < n do
       raise "grad for Nx.LinAlg.svd/2 not implemented for the wide matrix case"
@@ -355,49 +355,49 @@ defmodule Nx.LinAlg.SVD do
     ds_matrix = eye_k * Nx.new_axis(ds, -2)
 
     ut_du =
-      Nx.dot(Nx.LinAlg.adjoint(u), [-1], ba, du, [-2], ba) -
-        Nx.dot(Nx.LinAlg.adjoint(du), [-1], ba, u, [-2], ba)
+      Nx.dot(Nx.LinAlg.adjoint(u), [-1], batch_axes, du, [-2], batch_axes) -
+        Nx.dot(Nx.LinAlg.adjoint(du), [-1], batch_axes, u, [-2], batch_axes)
 
     first_component_du =
       u
-      |> Nx.dot([-1], ba, f * ut_du, [-2], ba)
-      |> Nx.dot([-1], ba, s, [-2], ba)
+      |> Nx.dot([-1], batch_axes, f * ut_du, [-2], batch_axes)
+      |> Nx.dot([-1], batch_axes, s, [-2], batch_axes)
 
     second_component_du =
-      (eye_m - Nx.dot(u, [-1], ba, Nx.LinAlg.adjoint(u), [-2], ba))
-      |> Nx.dot([-1], ba, du, [-2], ba)
-      |> Nx.dot([-1], ba, s_inv, [-2], ba)
+      (eye_m - Nx.dot(u, [-1], batch_axes, Nx.LinAlg.adjoint(u), [-2], batch_axes))
+      |> Nx.dot([-1], batch_axes, du, [-2], batch_axes)
+      |> Nx.dot([-1], batch_axes, s_inv, [-2], batch_axes)
 
     du_component =
-      Nx.dot(first_component_du + second_component_du, [-1], ba, vt, [-2], ba)
+      Nx.dot(first_component_du + second_component_du, [-1], batch_axes, vt, [-2], batch_axes)
 
     ds_component =
       u
-      |> Nx.dot([-1], ba, ds_matrix, [-2], ba)
-      |> Nx.dot([-1], ba, vt, [-2], ba)
+      |> Nx.dot([-1], batch_axes, ds_matrix, [-2], batch_axes)
+      |> Nx.dot([-1], batch_axes, vt, [-2], batch_axes)
 
     first_dvt_component =
-      (Nx.dot(vt, [-1], ba, Nx.LinAlg.adjoint(dvt), [-2], ba) -
-         Nx.dot(dvt, [-1], ba, Nx.LinAlg.adjoint(vt), [-2], ba)) * f
+      (Nx.dot(vt, [-1], batch_axes, Nx.LinAlg.adjoint(dvt), [-2], batch_axes) -
+         Nx.dot(dvt, [-1], batch_axes, Nx.LinAlg.adjoint(vt), [-2], batch_axes)) * f
 
     first_dvt_component =
       s
-      |> Nx.dot([-1], ba, first_dvt_component, [-2], ba)
-      |> Nx.dot([-1], ba, vt, [-2], ba)
+      |> Nx.dot([-1], batch_axes, first_dvt_component, [-2], batch_axes)
+      |> Nx.dot([-1], batch_axes, vt, [-2], batch_axes)
 
     second_dvt_component =
       s_inv
-      |> Nx.dot([-1], ba, dvt, [-2], ba)
+      |> Nx.dot([-1], batch_axes, dvt, [-2], batch_axes)
       |> Nx.dot(
         [-1],
-        ba,
-        eye_n - Nx.dot(Nx.LinAlg.adjoint(vt), [-1], ba, vt, [-2], ba),
+        batch_axes,
+        eye_n - Nx.dot(Nx.LinAlg.adjoint(vt), [-1], batch_axes, vt, [-2], batch_axes),
         [-2],
-        ba
+        batch_axes
       )
 
     dvt_component =
-      Nx.dot(u, [-1], ba, first_dvt_component + second_dvt_component, [-2], ba)
+      Nx.dot(u, [-1], batch_axes, first_dvt_component + second_dvt_component, [-2], batch_axes)
 
     [du_component + ds_component + dvt_component]
   end
@@ -410,8 +410,14 @@ defmodule Nx.LinAlg.SVD do
   deftransformp eye_from_vector(t) do
     shape = Nx.shape(t)
     k = elem(shape, tuple_size(shape) - 1)
-    batch = shape |> Tuple.delete_at(tuple_size(shape) - 1) |> Tuple.to_list()
-    Nx.eye(List.to_tuple(batch ++ [k, k]))
+    batch = Tuple.delete_at(shape, tuple_size(shape) - 1)
+
+    eye_shape =
+      batch
+      |> Tuple.insert_at(tuple_size(batch), k)
+      |> Tuple.insert_at(tuple_size(batch) + 1, k)
+
+    Nx.eye(eye_shape)
   end
 
   deftransformp eye_from_matrix(t, size) do
@@ -422,9 +428,13 @@ defmodule Nx.LinAlg.SVD do
       shape
       |> Tuple.delete_at(rank - 1)
       |> Tuple.delete_at(rank - 2)
-      |> Tuple.to_list()
 
-    Nx.eye(List.to_tuple(batch ++ [size, size]))
+    eye_shape =
+      batch
+      |> Tuple.insert_at(tuple_size(batch), size)
+      |> Tuple.insert_at(tuple_size(batch) + 1, size)
+
+    Nx.eye(eye_shape)
   end
 
   deftransformp slice_last_matrix(t, rows, cols) do

--- a/nx/test/nx/defn/grad_test.exs
+++ b/nx/test/nx/defn/grad_test.exs
@@ -2525,6 +2525,23 @@ defmodule Nx.Defn.GradTest do
         ])
       )
     end
+
+    defn svd_sum_grad(t) do
+      grad(t, fn tensor ->
+        {u, s, vt} = Nx.LinAlg.svd(tensor)
+        Nx.sum(u) + Nx.sum(s) + Nx.sum(vt)
+      end)
+    end
+
+    test "computes grad for batched tensor" do
+      t =
+        Nx.tensor([
+          [[3.0, 0.0], [1.0, 2.0]],
+          [[4.0, 1.0], [2.0, 3.0]]
+        ])
+
+      assert_equal(svd_sum_grad(t), Nx.stack([svd_sum_grad(t[0]), svd_sum_grad(t[1])]))
+    end
   end
 
   describe "invert" do

--- a/nx/test/nx/defn/grad_test.exs
+++ b/nx/test/nx/defn/grad_test.exs
@@ -2323,6 +2323,16 @@ defmodule Nx.Defn.GradTest do
       assert exp_cholesky_grad(t) ==
                Nx.tensor([[-0.5299541, -0.88652998], [3.59515929, 6.550619]])
     end
+
+    test "computes grad for batched tensor" do
+      t =
+        Nx.tensor([
+          [[4.0, 2.0], [2.0, 5.0]],
+          [[9.0, 3.0], [3.0, 10.0]]
+        ])
+
+      assert_equal(cholesky_grad(t), Nx.stack([cholesky_grad(t[0]), cholesky_grad(t[1])]))
+    end
   end
 
   describe "qr" do
@@ -2378,6 +2388,16 @@ defmodule Nx.Defn.GradTest do
           4.98145 5.87086i
         ]
       )
+    end
+
+    test "computes grad for batched tensor" do
+      t =
+        Nx.tensor([
+          [[1.0, 2.0], [1.0, -1.0]],
+          [[3.0, 1.0], [2.0, 4.0]]
+        ])
+
+      assert_equal(qr_grad(t), Nx.stack([qr_grad(t[0]), qr_grad(t[1])]))
     end
   end
 
@@ -4614,6 +4634,21 @@ defmodule Nx.Defn.GradTest do
           [-1.0, -3.0, -3.0],
           [0.0, 0.0, 0.0]
         ])
+      )
+    end
+
+    test "computes grad for batched tensor with vector b" do
+      a =
+        Nx.tensor([
+          [[4.0, 1.0, 0.0], [1.0, 5.0, 0.0], [0.0, 0.0, 6.0]],
+          [[9.0, 1.0, 0.0], [1.0, 10.0, 0.0], [0.0, 0.0, 11.0]]
+        ])
+
+      b = Nx.tensor([[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]])
+
+      assert_equal(
+        solve_grad_wrt_a(a, b),
+        Nx.stack([solve_grad_wrt_a(a[0], b[0]), solve_grad_wrt_a(a[1], b[1])])
       )
     end
   end

--- a/nx/test/nx/defn/grad_test.exs
+++ b/nx/test/nx/defn/grad_test.exs
@@ -2279,6 +2279,63 @@ defmodule Nx.Defn.GradTest do
     end
   end
 
+  describe "eigh" do
+    defn eigh_evals_grad(t) do
+      grad(t, fn x ->
+        {evals, _} = Nx.LinAlg.eigh(x)
+        Nx.sum(evals)
+      end)
+    end
+
+    defn eigh_sum_grad(t) do
+      grad(t, fn x ->
+        {evals, evecs} = Nx.LinAlg.eigh(x)
+        Nx.sum(evals) + Nx.sum(evecs)
+      end)
+    end
+
+    test "computes grad of eigenvalue sum as identity" do
+      t = Nx.tensor([[4.0, 2.0], [2.0, 5.0]], type: :f32)
+      assert_all_close(eigh_evals_grad(t), Nx.eye(2, type: :f32))
+    end
+
+    test "computes grad of eigenvalue sum as identity for f64" do
+      t = Nx.tensor([[4.0, 2.0], [2.0, 5.0]], type: :f64)
+      assert_all_close(eigh_evals_grad(t), Nx.eye(2, type: :f64))
+    end
+
+    test "computes grad for batched tensor" do
+      t =
+        Nx.tensor([
+          [[4.0, 2.0], [2.0, 5.0]],
+          [[9.0, 3.0], [3.0, 10.0]]
+        ])
+
+      assert_equal(
+        eigh_evals_grad(t),
+        Nx.stack([eigh_evals_grad(t[0]), eigh_evals_grad(t[1])])
+      )
+
+      assert_equal(eigh_sum_grad(t), Nx.stack([eigh_sum_grad(t[0]), eigh_sum_grad(t[1])]))
+    end
+
+    test "computes grad for batched f64 tensor" do
+      t =
+        Nx.tensor(
+          [
+            [[4.0, 2.0], [2.0, 5.0]],
+            [[9.0, 3.0], [3.0, 10.0]]
+          ],
+          type: :f64
+        )
+
+      assert_equal(
+        eigh_evals_grad(t),
+        Nx.stack([eigh_evals_grad(t[0]), eigh_evals_grad(t[1])])
+      )
+    end
+  end
+
   describe "cholesky" do
     defn cholesky_grad(t) do
       grad(t, fn x -> x |> Nx.LinAlg.cholesky() |> Nx.sum() end)
@@ -5603,7 +5660,7 @@ defmodule Nx.Defn.GradTest do
       end)
     end
 
-    test "vectorized grad through Nx.LinAlg.eigh (autograd via defn)" do
+    test "vectorized grad through Nx.LinAlg.eigh (custom grad)" do
       x =
         Nx.tensor([
           [[2.0, 1.0], [1.0, 3.0]],


### PR DESCRIPTION
## Summary
- Add batched grad tests for qr, cholesky, and solve (already-fixed paths)
- Make svd_grad batch-aware (batch_axes + last-two-dim dots/eye/diag)
- Add custom_grad for eigh (F-matrix VJP) fixing 2D and f64 failures

## Issues
Closes #1740
Closes #1748

Note: #1743 (svd batched grad) was previously closed as a duplicate of #1748; this PR contains that fix.