### PR TITLE
perf(grad): use triangular_solve to invert R in QR grad

### DIFF
--- a/nx/lib/nx/lin_alg/qr.ex
+++ b/nx/lib/nx/lin_alg/qr.ex
@@ -153,7 +153,8 @@ defmodule Nx.LinAlg.QR do
   defn qr_grad({q, r}, {dq, dr}) do
     # Definition taken from https://arxiv.org/pdf/2009.10071.pdf
     # Equation (3)
-    r_inv = Nx.LinAlg.invert(r)
+    eye = Nx.eye(Nx.shape(r), type: Nx.type(r))
+    r_inv = Nx.LinAlg.triangular_solve(r, eye, lower: false)
     ba = batch_axes(r)
 
     m =


### PR DESCRIPTION
### Problem

`qr_grad/2` inverts the upper-triangular factor `R` with `Nx.LinAlg.invert/1`, a general inverse (det + LU solve). That is unnecessary work for a triangular matrix and matches the pattern already fixed for LU grads in #1786.

### Solution

Replace `invert(R)` with `triangular_solve(R, I, lower: false)`:

```elixir
eye = Nx.eye(Nx.shape(r), type: Nx.type(r))
r_inv = Nx.LinAlg.triangular_solve(r, eye, lower: false)
```

Same algebra, cheaper triangular path; benefits any autodiff through `Nx.LinAlg.qr/2`.

### Test plan

- [ ] Existing QR / LinAlg grad tests
- [ ] Spot-check `grad` through `qr` on a small square matrix