### PR TITLE
perf(grad): use triangular_solve to invert A in triangular_solve grad

### DIFF
--- a/nx/lib/nx/defn/grad.ex
+++ b/nx/lib/nx/defn/grad.ex
@@ -1311,7 +1311,15 @@ defmodule Nx.Defn.Grad do
         :conjugate -> Nx.conjugate(a)
       end
 
-    a_inv_hermitian = Nx.LinAlg.invert(Nx.LinAlg.adjoint(a))
+    # a is triangular after transform_a; invert(A^H) via triangular_solve.
+    # :transpose already flipped triangle once; adjoint flips once more.
+    a_h = Nx.LinAlg.adjoint(a)
+
+    a_h_lower =
+      if opts[:transform_a] == :transpose, do: opts[:lower], else: not opts[:lower]
+
+    eye = Nx.eye(Nx.shape(a_h), type: Nx.type(a_h))
+    a_inv_hermitian = Nx.LinAlg.triangular_solve(a_h, eye, lower: a_h_lower)
     batch_axes = linalg_batch_axes(a_inv_hermitian)
 
     x = if b_rank_correction_axis, do: Nx.new_axis(x, b_rank_correction_axis), else: x


### PR DESCRIPTION
### Problem

The `triangular_solve` rule in `Nx.Defn.Grad` builds `invert(adjoint(A))` with general `Nx.LinAlg.invert/1`. After `transform_a`, `A` is triangular, so a full inverse is overkill (same class of win as #1786 / QR-grad invert).

### Solution

Invert `Aᴴ` via `triangular_solve(Aᴴ, I)`, flipping the `lower:` flag to account for adjoint (and the extra flip when `transform_a: :transpose`):

```elixir
a_h = Nx.LinAlg.adjoint(a)
a_h_lower = if opts[:transform_a] == :transpose, do: opts[:lower], else: not opts[:lower]
a_inv_hermitian = Nx.LinAlg.triangular_solve(a_h, eye, lower: a_h_lower)
```

Benefits grads through `triangular_solve`, Cholesky solves, and anything that differentiates through those.

### Test plan

- [ ] Grad tests covering `triangular_solve` (incl. `transform_a: :transpose` / `:none`)
- [ ] Smoke `grad` through `cholesky` → `triangular_solve` if present