### PR TITLE
perf(linalg): use thin SVD when only singular values are needed

### DIFF
--- a/nx/lib/nx/lin_alg.ex
+++ b/nx/lib/nx/lin_alg.ex
@@ -328,7 +328,7 @@ defmodule Nx.LinAlg do
   defp norm_frobenius(%{shape: {_, _}} = t, opts), do: norm_integer(t, 2, opts)
 
   defp norm_nuclear(%{shape: {_, _}} = t) do
-    {_u, s, _v} = svd(t)
+    {_u, s, _v} = svd(t, full_matrices?: false)
     Nx.sum(s)
   end
 
@@ -373,7 +373,7 @@ defmodule Nx.LinAlg do
   end
 
   defp norm_integer(%{shape: {_, _}} = t, -2, opts) do
-    {_u, s, _v} = Nx.LinAlg.svd(t)
+    {_u, s, _v} = svd(t, full_matrices?: false)
     Nx.reduce_min(s, opts)
   end
 
@@ -2182,7 +2182,7 @@ defmodule Nx.LinAlg do
     max_dim = if row_dim > col_dim, do: row_dim, else: col_dim
 
     # Calculate max singular value
-    {_u, s, _v} = Nx.LinAlg.svd(a)
+    {_u, s, _v} = Nx.LinAlg.svd(a, full_matrices?: false)
 
     s_max = Nx.reduce_max(s)
 


### PR DESCRIPTION
### Problem

Default `Nx.LinAlg.svd/2` uses `full_matrices?: true` (QDWH path). Several callers only need `S` but still paid for full `U`/`V`:

- `norm(..., ord: :nuclear)`
- `norm(..., ord: -2)`
- `matrix_rank/2`

`pinv` already passes `full_matrices?: false` (#1081). Thin SVD uses Gram → `eigh` and avoids large QDWH intermediates (especially tall matrices).

### Solution

Pass `full_matrices?: false` at those three call sites. Public `svd/2` default is unchanged.

Trade-off (already documented on `svd_non_full`): Gram squares the condition number; fine for these S-only uses under existing eps conventions.

### Test plan

- [ ] Doctests / tests for `matrix_rank`, nuclear norm, `ord: -2`
- [ ] Confirm no API change to `svd/2` defaults