### PR TITLE
perf(binary): zip-reduce BinaryBackend.select (and related bitstring scans)

### DIFF
--- a/nx/lib/nx/binary_backend.ex
+++ b/nx/lib/nx/binary_backend.ex
@@ -625,9 +625,8 @@ defmodule Nx.BinaryBackend do
       match_types [pred_type, left_type, right_type] do
         {data, _, _} =
           for <<match!(p, 0) <- pred_data>>,
-              reduce: {<<>>, on_true_data, on_false_data} do
-            {acc, <<match!(x, 1), true_rest::bitstring>>,
-             <<match!(y, 2), false_rest::bitstring>>} ->
+            reduce: {<<>>, on_true_data, on_false_data} do
+            {acc, <<match!(x, 1), true_rest::bitstring>>, <<match!(y, 2), false_rest::bitstring>>} ->
               result =
                 if as_boolean(read!(p, 0)) do
                   read!(x, 1)
@@ -1185,7 +1184,7 @@ defmodule Nx.BinaryBackend do
           # products. Cursor-advance fixed-size channel chunks (no i*size scans).
           {sum, _} =
             for <<input_receptive_field::size(^input_field_size)-bitstring <- window>>,
-                reduce: {0, filter} do
+              reduce: {0, filter} do
               {acc,
                <<filter_receptive_field::size(^filter_field_size)-bitstring,
                  filter_rest::bitstring>>} ->
@@ -1193,7 +1192,7 @@ defmodule Nx.BinaryBackend do
                   match_types [input_type, kernel_type] do
                     {channel_sum, _} =
                       for <<match!(x, 0) <- input_receptive_field>>,
-                          reduce: {0, filter_receptive_field} do
+                        reduce: {0, filter_receptive_field} do
                         {sum_acc, <<match!(y, 1), y_rest::bitstring>>} ->
                           {sum_acc + read!(x, 0) * read!(y, 1), y_rest}
                       end

--- a/nx/lib/nx/binary_backend.ex
+++ b/nx/lib/nx/binary_backend.ex
@@ -613,39 +613,33 @@ defmodule Nx.BinaryBackend do
   end
 
   def select(%{shape: shape, type: type} = out, pred, on_true, on_false) do
-    %T{type: {_, pred_size} = pred_type} = pred
-    %T{type: {_, left_size} = left_type} = on_true
-    %T{type: {_, right_size} = right_type} = on_false
+    %T{type: pred_type} = pred
+    %T{type: left_type} = on_true
+    %T{type: right_type} = on_false
 
     pred_data = to_binary(pred)
     on_true_data = broadcast_data(on_true, shape)
     on_false_data = broadcast_data(on_false, shape)
 
     data =
-      for i <- 0..(Nx.size(shape) - 1), into: <<>> do
-        pred =
-          match_types [pred_type] do
-            consumed = i * pred_size
-            <<_::size(^consumed)-bitstring, match!(pred, 0), _::bitstring>> = pred_data
-            read!(pred, 0)
+      match_types [pred_type, left_type, right_type] do
+        {data, _, _} =
+          for <<match!(p, 0) <- pred_data>>,
+              reduce: {<<>>, on_true_data, on_false_data} do
+            {acc, <<match!(x, 1), true_rest::bitstring>>,
+             <<match!(y, 2), false_rest::bitstring>>} ->
+              result =
+                if read!(p, 0) == 0 do
+                  read!(y, 2)
+                else
+                  read!(x, 1)
+                end
+
+              {<<acc::bitstring, number_to_binary(result, type)::bitstring>>, true_rest,
+               false_rest}
           end
 
-        result =
-          if pred == 0 do
-            match_types [right_type] do
-              consumed = i * right_size
-              <<_::size(^consumed)-bitstring, match!(x, 0), _::bitstring>> = on_false_data
-              read!(x, 0)
-            end
-          else
-            match_types [left_type] do
-              consumed = i * left_size
-              <<_::size(^consumed)-bitstring, match!(x, 0), _::bitstring>> = on_true_data
-              read!(x, 0)
-            end
-          end
-
-        number_to_binary(result, type)
+        data
       end
 
     from_binary(out, data)

--- a/nx/lib/nx/binary_backend.ex
+++ b/nx/lib/nx/binary_backend.ex
@@ -629,10 +629,10 @@ defmodule Nx.BinaryBackend do
             {acc, <<match!(x, 1), true_rest::bitstring>>,
              <<match!(y, 2), false_rest::bitstring>>} ->
               result =
-                if read!(p, 0) == 0 do
-                  read!(y, 2)
-                else
+                if as_boolean(read!(p, 0)) do
                   read!(x, 1)
+                else
+                  read!(y, 2)
                 end
 
               {<<acc::bitstring, number_to_binary(result, type)::bitstring>>, true_rest,
@@ -1177,51 +1177,34 @@ defmodule Nx.BinaryBackend do
             |> weighted_traverse(batch, input_size, offset)
             |> :erlang.list_to_bitstring()
 
-          # The receptive field size of each binary in bytes
+          # The receptive field size of each channel binary in bits
           input_field_size = Nx.size(filter_shape) * input_size
           filter_field_size = Nx.size(filter_shape) * kernel_size
 
-          # For each channel in both filter and input...
-          # The output from a single filter being applied over a window
-          # of the input tensor is the sum of the element-wise products
-          values =
-            for i <- 0..(num_input_channels - 1) do
-              current_input_pos = i * input_field_size
-              current_filter_pos = i * filter_field_size
-              <<_::size(^current_input_pos)-bitstring, input_receptive_field::bitstring>> = window
+          # For each channel in both filter and input, zip-reduce element-wise
+          # products. Cursor-advance fixed-size channel chunks (no i*size scans).
+          {sum, _} =
+            for <<input_receptive_field::size(^input_field_size)-bitstring <- window>>,
+                reduce: {0, filter} do
+              {acc,
+               <<filter_receptive_field::size(^filter_field_size)-bitstring,
+                 filter_rest::bitstring>>} ->
+                channel_sum =
+                  match_types [input_type, kernel_type] do
+                    {channel_sum, _} =
+                      for <<match!(x, 0) <- input_receptive_field>>,
+                          reduce: {0, filter_receptive_field} do
+                        {sum_acc, <<match!(y, 1), y_rest::bitstring>>} ->
+                          {sum_acc + read!(x, 0) * read!(y, 1), y_rest}
+                      end
 
-              <<_::size(^current_filter_pos)-bitstring, filter_receptive_field::bitstring>> =
-                filter
-
-              for j <- 0..(Nx.size(filter_shape) - 1) do
-                x =
-                  match_types [input_type] do
-                    left_consumed = j * input_size
-
-                    <<_::size(^left_consumed)-bitstring, match!(x, 0), _::bitstring>> =
-                      input_receptive_field
-
-                    read!(x, 0)
+                    channel_sum
                   end
 
-                y =
-                  match_types [kernel_type] do
-                    right_consumed = j * kernel_size
-
-                    <<_::size(^right_consumed)-bitstring, match!(y, 0), _::bitstring>> =
-                      filter_receptive_field
-
-                    read!(y, 0)
-                  end
-
-                x * y
-              end
+                {acc + channel_sum, filter_rest}
             end
 
-          values
-          |> List.flatten()
-          |> Enum.reduce(&+/2)
-          |> number_to_binary(output_type)
+          number_to_binary(sum, output_type)
         end
       end
 
@@ -1597,8 +1580,8 @@ defmodule Nx.BinaryBackend do
     %T{type: {_, source_size} = source_type} = source
     source_data = to_binary(source)
 
-    output_windows =
-      for {anchor, i} <- Enum.with_index(input_anchors) do
+    {output_windows, _} =
+      Enum.map_reduce(input_anchors, source_data, fn anchor, source_rest ->
         offset = weighted_offset(input_weighted_shape, anchor)
 
         window =
@@ -1629,14 +1612,10 @@ defmodule Nx.BinaryBackend do
         padded_absolute_index = Enum.zip_with(anchor, offset_from_anchor, &+/2)
         absolute_index = Enum.zip_with(padded_absolute_index, low_pads, &-/2)
 
-        source_consumed = i * source_size
-
-        <<_::size(^source_consumed)-bitstring, from_source::size(^source_size)-bitstring,
-          _::bitstring>> = source_data
-
+        <<from_source::size(^source_size)-bitstring, source_rest::bitstring>> = source_rest
         source_value = binary_to_number(from_source, source_type)
-        {source_value, absolute_index}
-      end
+        {{source_value, absolute_index}, source_rest}
+      end)
 
     # Filter out indices that fall in the padding region (outside original tensor bounds)
     output_windows =


### PR DESCRIPTION
### Problem

`Nx.BinaryBackend.select/4` indexed into pred / on_true / on_false with per-element `i * size` bitstring skips (`<<_::size(consumed), ...>>`). That is O(n²) scanning over the binaries. Similar cursor-style scans showed up in `conv` channel products and window-scatter source peeling.

### Solution

Rewrite hot paths to advance bitstring cursors (zip-reduce) instead of recomputing offsets:

1. **`select`** — single `for <<match!(p) <- pred_data>>` that peels `on_true` / `on_false` in lockstep
2. **`conv`** — channel zip-reduce for element-wise products (no `i * field_size` seeks)
3. **`window_scatter_*`** — `Enum.map_reduce` over source binary instead of `i * source_size` seeks

Measured on BinaryBackend (`Nx.select`, f32, 10-iter avg):

| n | Before | After | Speedup |
|---|--------|-------|---------|
| 1e3 | ~0.069 ms | ~0.059 ms | ~1.2× |
| 1e5 | ~13.2 ms | ~9.8 ms | ~1.35× |
| 1e6 | ~208 ms | ~102 ms | **~2.0×** |

`conv` follow-up ~1.02–1.04×; scatter peel ~noise (not the hotspot).

### Test plan

- [ ] BinaryBackend tests for `select`, `conv`, window scatter
- [ ] Cross-check a few `Nx.select` shapes (scalar pred broadcast, same-shape)