### PR TITLE
fix(exla): install libexla.so atomically

### DIFF
--- a/exla/mix.exs
+++ b/exla/mix.exs
@@ -207,7 +207,7 @@ defmodule EXLA.MixProject do
 
     if cached? do
       Mix.shell().info("Using libexla.so from #{cached_so}")
-      File.cp!(cached_so, "cache/libexla.so")
+      atomic_cp!(cached_so, "cache/libexla.so")
     end
 
     result = Mix.Tasks.Compile.ElixirMake.run(args)
@@ -215,10 +215,19 @@ defmodule EXLA.MixProject do
     if not cached? and match?({:ok, _}, result) do
       Mix.shell().info("Caching libexla.so at #{cached_so}")
       File.mkdir_p!(Path.dirname(cached_so))
-      File.cp!("cache/libexla.so", cached_so)
+      atomic_cp!("cache/libexla.so", cached_so)
     end
 
     result
+  end
+
+  # File.cp!/2 rewrites the destination in place (O_TRUNC, same inode), which
+  # corrupts any OS process that currently has the .so mmap'd. Renaming
+  # installs a new inode instead.
+  defp atomic_cp!(source, destination) do
+    tmp = "#{destination}.tmp.#{System.pid()}"
+    File.cp!(source, tmp)
+    File.rename!(tmp, destination)
   end
 
   defp xla_cache_dir() do


### PR DESCRIPTION
`cached_make/1` installs `libexla.so` with `File.cp!/2`, which opens the destination
`O_TRUNC` and rewrites it in place, keeping its inode. Truncating a shared object another
process has `mmap`'d drops that mapping's pages, including dirty copy-on-write ones, so
the `.got.plt` entries the loader relocated at load time revert to their unrelocated
on-disk values. The next call through one jumps to an unmapped link-time address and the
VM dies with `SIGSEGV`, without an `erl_crash.dump` since it never gets that far.

One `libexla.so` can back several BEAMs: the Makefile `ln -sf`s both `dev` and `test` at
`cache/libexla.so`, so a `MIX_ENV=test` compile can kill a `mix phx.server`. Sharing a
`deps/` between checkouts widens it to every BEAM on the machine.

Faulting frame, from one of five crashes I collected:

```
#0  0x000000000001a9d6 in ?? ()
#1  run_resource_dtor (vbin=0x7f81a748f368) at beam/erl_nif.c:3017
#2  handle_misc_aux_work (aux_work=2049)   at beam/erl_process.c:1879
```

`0x1a9d6` is `llvm::StdThreadPool::~StdThreadPool@plt+6` — the lazy-binding `push`, which
is the file's own initial `.got.plt` content. The core confirms the slot, with
`libexla.so` mapped at `0x7f81fa574000`:

```
0x7f81fa5fdcd0 <_ZN4llvm13StdThreadPoolD1Ev@got.plt>:  0x000000000001a9d6
```

To reproduce: run the loop below, then compile exla against the same `libexla.so` from
another `MIX_ENV` or checkout. It dies mid-run with no Elixir-level error.

```elixir
Application.ensure_all_started(:exla)
EXLA.Client.fetch!(:host)
Nx.global_default_backend(EXLA.Backend)

for _ <- 1..100_000 do
  Nx.iota({64, 64}) |> Nx.sum() |> Nx.to_number()
  :erlang.garbage_collect()
  Process.sleep(5)
end
```

Copying through a temp file and renaming installs a new inode, so existing mappings keep
the file they loaded. `File.cp!/2` already preserves the source mode on a fresh
destination.

exla 0.12.0 / xla 0.10.0, OTP 29.0.3, Elixir 1.20.2, Linux x86-64.
