### PR TITLE
Pass through non-Expr tensors in stop_grad/custom_grad/metadata

### DIFF
--- a/nx/lib/nx/defn/expr.ex
+++ b/nx/lib/nx/defn/expr.ex
@@ -99,18 +99,31 @@ defmodule Nx.Defn.Expr do
   inspection.
   """
   def metadata(expr, metadata) when is_map(metadata) do
-    case to_container_expr(expr) do
-      %{data: %{context: context}} = res ->
-        expr(res, context, :metadata, [Nx.devectorize(expr), metadata])
+    if expr_container?(expr) do
+      case to_container_expr(expr) do
+        %{data: %{context: context}} = res ->
+          expr(res, context, :metadata, [Nx.devectorize(expr), metadata])
 
-      t when is_tuple(t) ->
-        context = elem(t, 0).data.context
+        t when is_tuple(t) ->
+          context = elem(t, 0).data.context
 
-        tuple(
-          expr(tuple_out(tuple_size(t)), context, :metadata, [Nx.devectorize(expr), metadata]),
-          Tuple.to_list(t)
-        )
+          tuple(
+            expr(tuple_out(tuple_size(t)), context, :metadata, [Nx.devectorize(expr), metadata]),
+            Tuple.to_list(t)
+          )
+      end
+    else
+      # BinaryBackend.block/4 (and similar) may re-run callbacks that call
+      # stop_grad/custom_grad/metadata; concrete tensors must pass through.
+      expr
     end
+  end
+
+  defp expr_container?(container) do
+    Composite.reduce(container, true, fn
+      %T{data: %Expr{}}, true -> true
+      _, _ -> false
+    end)
   end
 
   @doc """

--- a/nx/lib/nx/defn/kernel.ex
+++ b/nx/lib/nx/defn/kernel.ex
@@ -244,9 +244,13 @@ defmodule Nx.Defn.Kernel do
       expr = stop_grad(expr)
 
   """
-  def stop_grad(expr) do
+  def stop_grad(%Nx.Tensor{data: %Nx.Defn.Expr{}} = expr) do
     Nx.Defn.Expr.metadata(expr, %{stop_grad: true, inspect: :stop_grad})
   end
+
+  # Concrete backends (e.g. BinaryBackend.block/4 re-applying a default callback)
+  # must not wrap results in Expr.metadata.
+  def stop_grad(expr), do: expr
 
   @doc """
   Defines a custom gradient for the given expression.
@@ -268,9 +272,15 @@ defmodule Nx.Defn.Kernel do
       end
 
   """
-  def custom_grad(expr, inputs, fun) when Kernel.and(is_list(inputs), is_function(fun, 1)) do
+  def custom_grad(%Nx.Tensor{data: %Nx.Defn.Expr{}} = expr, inputs, fun)
+      when Kernel.and(is_list(inputs), is_function(fun, 1)) do
     Nx.Defn.Expr.metadata(expr, %{custom_grad: {inputs, fun}, inspect: :custom_grad})
   end
+
+  # See stop_grad/1 — pass through when re-applied outside an expression.
+  def custom_grad(expr, inputs, fun)
+      when Kernel.and(is_list(inputs), is_function(fun, 1)),
+      do: expr
 
   @doc """
   Element-wise unary plus operator.

--- a/nx/lib/nx/defn/kernel.ex
+++ b/nx/lib/nx/defn/kernel.ex
@@ -244,13 +244,9 @@ defmodule Nx.Defn.Kernel do
       expr = stop_grad(expr)
 
   """
-  def stop_grad(%Nx.Tensor{data: %Nx.Defn.Expr{}} = expr) do
+  def stop_grad(expr) do
     Nx.Defn.Expr.metadata(expr, %{stop_grad: true, inspect: :stop_grad})
   end
-
-  # Concrete backends (e.g. BinaryBackend.block/4 re-applying a default callback)
-  # must not wrap results in Expr.metadata.
-  def stop_grad(expr), do: expr
 
   @doc """
   Defines a custom gradient for the given expression.
@@ -272,15 +268,9 @@ defmodule Nx.Defn.Kernel do
       end
 
   """
-  def custom_grad(%Nx.Tensor{data: %Nx.Defn.Expr{}} = expr, inputs, fun)
-      when Kernel.and(is_list(inputs), is_function(fun, 1)) do
+  def custom_grad(expr, inputs, fun) when Kernel.and(is_list(inputs), is_function(fun, 1)) do
     Nx.Defn.Expr.metadata(expr, %{custom_grad: {inputs, fun}, inspect: :custom_grad})
   end
-
-  # See stop_grad/1 — pass through when re-applied outside an expression.
-  def custom_grad(expr, inputs, fun)
-      when Kernel.and(is_list(inputs), is_function(fun, 1)),
-      do: expr
 
   @doc """
   Element-wise unary plus operator.


### PR DESCRIPTION
Ties to Axon https://github.com/elixir-nx/axon/pull/639
Real results were getting tagged as traced tensors when `BinaryBackend.block/4` re-ran callbacks that used `custom_grad`/`stop_grad`/`metadata`
This PR makes `Expr.metadata` pass through non-Expr tensors so those callbacks stay safe on forward.