### PR TITLE
fix(docs): adjust broken formatting of example code

### DIFF
--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -17562,7 +17562,7 @@ defmodule Nx do
           ]
         ]
       ]
-    >
+      >
 
   ## Vectorized tensors
 

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -17551,8 +17551,8 @@ defmodule Nx do
   One can also pass two higher order tensors with the same shape `{j, k, ...}`, in which case
   the output will be of shape `{j, k, ..., n}`.
 
-    iex> Nx.linspace(Nx.tensor([[[0, 10]]]), Nx.tensor([[[10, 100]]]), n: 10, name: :samples, type: {:u, 8})
-    #Nx.Tensor<
+      iex> Nx.linspace(Nx.tensor([[[0, 10]]]), Nx.tensor([[[10, 100]]]), n: 10, name: :samples, type: {:u, 8})
+      #Nx.Tensor<
       u8[1][1][2][samples: 10]
       [
         [


### PR DESCRIPTION
## The Problem
ExDoc wasn't properly displaying one of the code examples at https://nx.hexdocs.pm/Nx.html#linspace/3-examples

## Screenshot before
<img width="847" height="576" alt="Screenshot 2026-08-07 at 20-10-18 Nx — Nx v0 13 0" src="https://github.com/user-attachments/assets/715646b2-be91-4125-a055-c2de4ffc3526" />

## Screenshot after
<img width="847" height="550" alt="Screenshot 2026-08-07 at 20-14-14 Nx — Nx v0 13 0" src="https://github.com/user-attachments/assets/dfd807ce-78e2-454d-8e23-c6319a7f7909" />
