### PR TITLE
fix(docs): reformat codeblock

### DIFF
--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -17551,18 +17551,18 @@ defmodule Nx do
   One can also pass two higher order tensors with the same shape `{j, k, ...}`, in which case
   the output will be of shape `{j, k, ..., n}`.
 
-    iex> Nx.linspace(Nx.tensor([[[0, 10]]]), Nx.tensor([[[10, 100]]]), n: 10, name: :samples, type: {:u, 8})
-    #Nx.Tensor<
-      u8[1][1][2][samples: 10]
-      [
+      iex> Nx.linspace(Nx.tensor([[[0, 10]]]), Nx.tensor([[[10, 100]]]), n: 10, name: :samples, type: {:u, 8})
+      #Nx.Tensor<
+        u8[1][1][2][samples: 10]
         [
           [
-            [0, 1, 2, 3, 4, 5, 6, 7, 8, 10],
-            [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
+            [
+              [0, 1, 2, 3, 4, 5, 6, 7, 8, 10],
+              [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
+            ]
           ]
         ]
-      ]
-    >
+      >
 
   ## Vectorized tensors
 


### PR DESCRIPTION
## The problem

One of the codeblocks in [the documentation](https://nx.hexdocs.pm/Nx.html#linspace/3-examples) did not have enough spaces, causing it to be displayed incorrectly.

See before/after pictures of the docs.

## Before
<img width="816" height="411" alt="Screenshot 2026-08-07 at 21-41-58 Nx — Nx v0 13 0" src="https://github.com/user-attachments/assets/ed208d35-43ea-4982-bda9-d0c5d9cfc0f1" />



## After
<img width="821" height="412" alt="Screenshot 2026-08-07 at 21-41-47 Nx — Nx v0 13 0" src="https://github.com/user-attachments/assets/771c14bb-0791-4ebb-bdb3-5bdddf15e697" />
