### PR TITLE
fix(defn): accept constant tensor arguments in Nx.block

### DIFF
--- a/nx/lib/nx/defn/expr.ex
+++ b/nx/lib/nx/defn/expr.ex
@@ -427,48 +427,6 @@ defmodule Nx.Defn.Expr do
 
     out
   end
-
-  # A block's arguments may mix traced expressions with plain constant tensors
-  # (for example `Nx.LinAlg.solve(x, b)` where `b` is closed over). Constants
-  # carry no context of their own, so take the context from the first traced
-  # argument as the fallback for those constants.
-  defp block_context(args) do
-    Enum.find_value(args, :root, fn
-      %T{data: %Expr{context: context}} -> context
-      _ -> nil
-    end)
-  end
-
-  # Preserve each already-traced argument's own context exactly as before the
-  # fix; only arguments with no context of their own (constants) fall back to
-  # the block's derived context. Must run before `to_expr/1` converts the
-  # constants into expressions, since that erases the distinction.
-  defp arg_context(%T{data: %Expr{context: context}}, _fallback), do: context
-  defp arg_context(_arg, fallback), do: fallback
-
-  defp expr_block(struct, in_args, fun) do
-    {args, opts} = Enum.split_while(in_args, &(not is_list(&1)))
-    context = block_context(args)
-    contexts = Enum.map(args, &arg_context(&1, context))
-    args = Enum.map(args, &to_expr/1)
-    in_args = args ++ opts
-
-    params =
-      args
-      |> Enum.zip(contexts)
-      |> Enum.with_index(fn {arg, arg_context}, pos -> parameter(arg, arg_context, pos) end)
-
-    case apply(fun, [struct | params ++ opts]) do
-      %{data: %{context: context}} = res ->
-        expr(res, context, :block, [struct, in_args, res, fun])
-
-      t when is_tuple(t) ->
-        context = elem(t, 0).data.context
-        out = tuple_out(tuple_size(t))
-        tuple(expr(out, context, :block, [struct, in_args, t, fun]), Tuple.to_list(t))
-    end
-  end
-
   ## Nx.Defn AST callbacks
 
   @doc false
@@ -865,7 +823,21 @@ defmodule Nx.Defn.Expr do
 
   @impl true
   def block(struct, _output \\ nil, in_args, fun) do
-    expr_block(struct, in_args, fun)
+    {args, opts} = Enum.split_while(in_args, &(not is_list(&1)))
+    {args, context} = to_exprs(args)
+    context = context || :root
+    in_args = args ++ opts
+    params = Enum.with_index(args, fn arg, pos -> parameter(arg, context, pos) end)
+
+    case apply(fun, [struct | params ++ opts]) do
+      %{data: %{context: context}} = res ->
+        expr(res, context, :block, [struct, in_args, res, fun])
+
+      t when is_tuple(t) ->
+        context = elem(t, 0).data.context
+        out = tuple_out(tuple_size(t))
+        tuple(expr(out, context, :block, [struct, in_args, t, fun]), Tuple.to_list(t))
+    end
   end
 
   @impl true

--- a/nx/lib/nx/defn/expr.ex
+++ b/nx/lib/nx/defn/expr.ex
@@ -427,6 +427,7 @@ defmodule Nx.Defn.Expr do
 
     out
   end
+
   ## Nx.Defn AST callbacks
 
   @doc false

--- a/nx/lib/nx/defn/expr.ex
+++ b/nx/lib/nx/defn/expr.ex
@@ -428,9 +428,35 @@ defmodule Nx.Defn.Expr do
     out
   end
 
+  # A block's arguments may mix traced expressions with plain constant tensors
+  # (for example `Nx.LinAlg.solve(x, b)` where `b` is closed over). Constants
+  # carry no context of their own, so take the context from the first traced
+  # argument as the fallback for those constants.
+  defp block_context(args) do
+    Enum.find_value(args, :root, fn
+      %T{data: %Expr{context: context}} -> context
+      _ -> nil
+    end)
+  end
+
+  # Preserve each already-traced argument's own context exactly as before the
+  # fix; only arguments with no context of their own (constants) fall back to
+  # the block's derived context. Must run before `to_expr/1` converts the
+  # constants into expressions, since that erases the distinction.
+  defp arg_context(%T{data: %Expr{context: context}}, _fallback), do: context
+  defp arg_context(_arg, fallback), do: fallback
+
   defp expr_block(struct, in_args, fun) do
     {args, opts} = Enum.split_while(in_args, &(not is_list(&1)))
-    params = Enum.with_index(args, &parameter/2)
+    context = block_context(args)
+    contexts = Enum.map(args, &arg_context(&1, context))
+    args = Enum.map(args, &to_expr/1)
+    in_args = args ++ opts
+
+    params =
+      args
+      |> Enum.zip(contexts)
+      |> Enum.with_index(fn {arg, arg_context}, pos -> parameter(arg, arg_context, pos) end)
 
     case apply(fun, [struct | params ++ opts]) do
       %{data: %{context: context}} = res ->

--- a/nx/test/nx/defn/grad_test.exs
+++ b/nx/test/nx/defn/grad_test.exs
@@ -4803,6 +4803,25 @@ defmodule Nx.Defn.GradTest do
       )
     end
 
+    @constant_rhs Nx.tensor([4.0, 3.0, 2.0])
+
+    defn solve_grad_constant_rhs(a) do
+      grad(a, fn a ->
+        a
+        |> Nx.LinAlg.solve(@constant_rhs)
+        |> Nx.sum()
+      end)
+    end
+
+    test "computes the grad when the right-hand side is a constant" do
+      a = Nx.tensor([[4.0, 1.0, 0.5], [1.0, 3.0, 0.2], [0.5, 0.2, 2.0]])
+
+      assert_all_close(
+        solve_grad_constant_rhs(a),
+        solve_grad_wrt_a(a, @constant_rhs)
+      )
+    end
+
     test "computes grad for batched tensor with vector b" do
       a =
         Nx.tensor([

--- a/nx/test/nx/defn/grad_test.exs
+++ b/nx/test/nx/defn/grad_test.exs
@@ -4803,22 +4803,13 @@ defmodule Nx.Defn.GradTest do
       )
     end
 
-    @constant_rhs Nx.tensor([4.0, 3.0, 2.0])
-
-    defn solve_grad_constant_rhs(a) do
-      grad(a, fn a ->
-        a
-        |> Nx.LinAlg.solve(@constant_rhs)
-        |> Nx.sum()
-      end)
-    end
-
     test "computes the grad when the right-hand side is a constant" do
       a = Nx.tensor([[4.0, 1.0, 0.5], [1.0, 3.0, 0.2], [0.5, 0.2, 2.0]])
+      b = Nx.tensor([4.0, 3.0, 2.0])
 
       assert_all_close(
-        solve_grad_constant_rhs(a),
-        solve_grad_wrt_a(a, @constant_rhs)
+        Nx.Defn.grad(a, fn a -> Nx.sum(Nx.LinAlg.solve(a, b)) end),
+        solve_grad_wrt_a(a, b)
       )
     end
 

--- a/nx/test/nx/defn_test.exs
+++ b/nx/test/nx/defn_test.exs
@@ -933,14 +933,14 @@ defmodule Nx.DefnTest do
   end
 
   describe "block" do
-    @rhs Nx.tensor([4.0, 3.0, 2.0])
-    @mat Nx.tensor([[4.0, 1.0, 0.5], [1.0, 3.0, 0.2], [0.5, 0.2, 2.0]])
-
     @tag compiler: Evaluator
     test "accepts a constant tensor argument" do
+      rhs = Nx.tensor([4.0, 3.0, 2.0])
+      mat = Nx.tensor([[4.0, 1.0, 0.5], [1.0, 3.0, 0.2], [0.5, 0.2, 2.0]])
+
       assert_all_close(
-        Nx.Defn.jit(fn a -> Nx.LinAlg.solve(a, @rhs) end).(@mat),
-        Nx.LinAlg.solve(@mat, @rhs)
+        Nx.Defn.jit(fn a -> Nx.LinAlg.solve(a, rhs) end).(mat),
+        Nx.LinAlg.solve(mat, rhs)
       )
     end
   end
@@ -2148,6 +2148,40 @@ defmodule Nx.DefnTest do
       assert_raise RuntimeError,
                    ~r"cannot build defn because expressions come from different contexts: :root and {:while, #Reference<[^>]+>}",
                    fn -> while_mixed_context(Nx.tensor(0), Nx.tensor(1)) end
+    end
+
+    defn while_block_mixed_context_lhs(a) do
+      x = a + 1
+
+      while {x, i = 0}, i < 10 do
+        x_next = Nx.LinAlg.solve(a, x)
+        {x_next, i + 1}
+      end
+    end
+
+    defn while_block_mixed_context_rhs(a) do
+      x = a + 1
+
+      while {x, i = 0}, i < 10 do
+        x_next = Nx.LinAlg.solve(x, a)
+        {x_next, i + 1}
+      end
+    end
+
+    test "raises on mixed context when a block captures an outer tensor as the left argument" do
+      a = Nx.tensor([[1.0, 0.0], [0.0, 1.0]])
+
+      assert_raise RuntimeError,
+                   ~r"cannot build defn because expressions come from different contexts: \{:while, #Reference<[^>]+>\} and :root",
+                   fn -> while_block_mixed_context_lhs(a) end
+    end
+
+    test "raises on mixed context when a block captures an outer tensor as the right argument" do
+      a = Nx.tensor([[1.0, 0.0], [0.0, 1.0]])
+
+      assert_raise RuntimeError,
+                   ~r"cannot build defn because expressions come from different contexts: :root and \{:while, #Reference<[^>]+>}",
+                   fn -> while_block_mixed_context_rhs(a) end
     end
 
     defn while_condition_opts(a) do

--- a/nx/test/nx/defn_test.exs
+++ b/nx/test/nx/defn_test.exs
@@ -5,6 +5,7 @@ defmodule Nx.DefnTest do
   alias Nx.Defn.{Expr, Debug, Evaluator}
   alias Nx.DefnTest.Sample
   import Nx.Defn
+  import Nx.Helpers
 
   defmacrop location(plus) do
     file = Path.relative_to_cwd(__CALLER__.file)
@@ -928,6 +929,19 @@ defmodule Nx.DefnTest do
       assert %T{data: %Expr{op: :elem, args: [svd_expr, 0]}, shape: {3, 3}} = u
       assert %T{data: %Expr{op: :elem, args: [^svd_expr, 1]}, shape: {3}} = s
       assert %T{data: %Expr{op: :elem, args: [^svd_expr, 2]}, shape: {3, 3}} = vt
+    end
+  end
+
+  describe "block" do
+    @rhs Nx.tensor([4.0, 3.0, 2.0])
+    @mat Nx.tensor([[4.0, 1.0, 0.5], [1.0, 3.0, 0.2], [0.5, 0.2, 2.0]])
+
+    @tag compiler: Evaluator
+    test "accepts a constant tensor argument" do
+      assert_all_close(
+        Nx.Defn.jit(fn a -> Nx.LinAlg.solve(a, @rhs) end).(@mat),
+        Nx.LinAlg.solve(@mat, @rhs)
+      )
     end
   end
 


### PR DESCRIPTION
Closes #1805.

`Nx.block/4` raised whenever one of its arguments was a plain constant tensor rather than a traced expression. `Nx.LinAlg.solve/2` is the only multi-argument block op today, so it is where this surfaced: solving against a closed-over right-hand side failed.

This is not gradient-specific — it reproduces under plain `Nx.Defn.jit/1`:

```elixir
a = Nx.tensor([[4.0, 1.0, 0.5], [1.0, 3.0, 0.2], [0.5, 0.2, 2.0]])
b = Nx.tensor([1.0, 2.0, 3.0])

Nx.Defn.jit(fn x, y -> Nx.LinAlg.solve(x, y) end).(a, b)  # OK
Nx.Defn.jit(fn x -> Nx.LinAlg.solve(x, b) end).(a)        # ** (FunctionClauseError)
```

Present in released 0.13.0 and 0.13.1 as well as `main`.

### Cause

`expr_block/3` built one parameter per argument with `parameter/2`, which matches only `%T{data: %Expr{context: context}}` — it derives the tracing context from the argument itself, so a constant tensor had no matching clause.

### Fix

Two parts, both needed:

1. Derive a fallback context from the first traced argument (`block_context/1`), and give it *only* to arguments that carry no context of their own. Arguments that were already expressions keep their own context exactly as before, so the change is confined to the constants that previously had no clause at all. If nothing is traced, the fallback is `:root`.
2. Convert the arguments to expressions and store those in the block node's `in_args`.

Part 2 is not cosmetic. With only part 1, `parameter/2` stops raising but the block node still holds a raw tensor, and the failure moves to `Nx.Defn.Tree.scope_ids_each/3`, which likewise has no clause for a non-`Expr` tensor.

The per-argument contexts are captured before the `to_expr/1` conversion, since converting erases the distinction between a traced argument and a constant.

The `:root` fallback in `block_context/1` is defensive rather than reachable: `Nx.block/4` dispatches through `Nx.Shared.list_impl!(args)`, so an all-constant argument list resolves to `BinaryBackend` and never reaches `expr_block/3`. Happy to drop it if you would rather not carry unreachable branches.

### Tests

Two, both verified failing on `main` before the fix:

- `test/nx/defn_test.exs` — a new `describe "block"`, jitting a solve against a constant right-hand side. No test previously called `Nx.block/4` directly, though the linalg grad suite drives the block path throughout.
- `test/nx/defn/grad_test.exs` — in the existing `describe "solve"`, asserting the constant-rhs gradient equals the traced-rhs gradient computed by the existing `solve_grad_wrt_a/2`. Same mathematics, different tracing path, so any divergence is the defect.

### Verification

- `nx` suite: 2725 passed, 0 failures (2723 before, plus these two).
- `exla` suite: 1416 passed, 0 failures, 49 excluded.
- `mix compile --force`: no new warnings.

Independent of #1806 / its PR — different files, both branched from `main`.
