### PR TITLE
fix(grad): functions with tuple outputs should broadcast grads onto unused outputs

### DIFF
--- a/nx/lib/nx/defn/grad.ex
+++ b/nx/lib/nx/defn/grad.ex
@@ -421,6 +421,7 @@ defmodule Nx.Defn.Grad do
 
     {grads, []} =
       Composite.reduce(expr, {grads, gs}, fn child, {grads, [g | gs]} ->
+        g = match_block_cotangent(g, child)
         {Map.update(grads, child.data.id, [g], &[g | &1]), gs}
       end)
 
@@ -618,6 +619,18 @@ defmodule Nx.Defn.Grad do
       g = clear_axis_names(g)
       Map.update(grads, child.data.id, [g], &[g | &1])
     end)
+  end
+
+  # A block body receives one cotangent per output, each shaped like that
+  # output. An output nothing depends on accumulates no gradient, so
+  # `sum_grad/1` hands back the rank-0 zero, which block bodies cannot index
+  # or batch over. Restore the invariant here, once, rather than in each body.
+  defp match_block_cotangent(g, out) do
+    case {Nx.shape(g), Nx.shape(out)} do
+      {shape, shape} -> g
+      {{}, _} -> Nx.broadcast(Nx.as_type(g, Nx.type(out)), out)
+      {_, _} -> g
+    end
   end
 
   defp select_composite(pred, left, right) do

--- a/nx/lib/nx/defn/grad.ex
+++ b/nx/lib/nx/defn/grad.ex
@@ -401,6 +401,7 @@ defmodule Nx.Defn.Grad do
 
           _ ->
             g = gs |> Tuple.to_list() |> Enum.map(&sum_grad/1)
+            g = broadcast_tuple_grads(op, args, g)
             {nodes, update_grads(op, args, ans, g, to_grad_ids, grads)}
         end
 
@@ -421,7 +422,6 @@ defmodule Nx.Defn.Grad do
 
     {grads, []} =
       Composite.reduce(expr, {grads, gs}, fn child, {grads, [g | gs]} ->
-        g = match_block_cotangent(g, child)
         {Map.update(grads, child.data.id, [g], &[g | &1]), gs}
       end)
 
@@ -621,17 +621,25 @@ defmodule Nx.Defn.Grad do
     end)
   end
 
-  # A block body receives one cotangent per output, each shaped like that
-  # output. An output nothing depends on accumulates no gradient, so
-  # `sum_grad/1` hands back the rank-0 zero, which block bodies cannot index
-  # or batch over. Restore the invariant here, once, rather than in each body.
-  defp match_block_cotangent(g, out) do
-    case {Nx.shape(g), Nx.shape(out)} do
-      {shape, shape} -> g
-      {{}, _} -> Nx.broadcast(Nx.as_type(g, Nx.type(out)), out)
-      {_, _} -> g
+  # Unused tuple outputs get a rank-0 zero from `sum_grad([])`. Broadcast
+  # each slot onto the primal leaf, as `update_grads(:while, ...)` does.
+  defp broadcast_tuple_grads(op, args, gs) do
+    case tuple_primal(op, args) do
+      nil ->
+        gs
+
+      primal ->
+        Enum.zip_with(gs, Composite.flatten_list([primal]), fn g, out ->
+          Nx.broadcast(g, Nx.devectorize(out, keep_names: false))
+        end)
     end
   end
+
+  defp tuple_primal(:block, [_, _, expr | _]), do: expr
+  defp tuple_primal(:metadata, [expr | _]), do: expr
+  defp tuple_primal(:cond, [_, last]), do: last
+  defp tuple_primal(:io_call, [tensor_expr | _]), do: tensor_expr
+  defp tuple_primal(_, _), do: nil
 
   defp select_composite(pred, left, right) do
     {selected, []} =

--- a/nx/test/nx/defn/grad_test.exs
+++ b/nx/test/nx/defn/grad_test.exs
@@ -2334,6 +2334,25 @@ defmodule Nx.Defn.GradTest do
         Nx.stack([eigh_evals_grad(t[0]), eigh_evals_grad(t[1])])
       )
     end
+
+    defn eigh_evecs_grad(t) do
+      grad(t, fn x ->
+        {_evals, evecs} = Nx.LinAlg.eigh(x)
+        Nx.sum(evecs)
+      end)
+    end
+
+    test "computes the grad when only one output is consumed" do
+      t = Nx.tensor([[4.0, 1.0, 0.5], [1.0, 3.0, 0.2], [0.5, 0.2, 2.0]])
+
+      assert_all_close(Nx.add(eigh_evals_grad(t), eigh_evecs_grad(t)), eigh_sum_grad(t))
+    end
+
+    test "grad of the eigenvalue sum is the identity" do
+      t = Nx.tensor([[4.0, 1.0, 0.5], [1.0, 3.0, 0.2], [0.5, 0.2, 2.0]])
+
+      assert_all_close(eigh_evals_grad(t), Nx.eye(3, type: :f32))
+    end
   end
 
   describe "cholesky" do
@@ -2456,6 +2475,33 @@ defmodule Nx.Defn.GradTest do
 
       assert_equal(qr_grad(t), Nx.stack([qr_grad(t[0]), qr_grad(t[1])]))
     end
+
+    defn qr_q_only_grad(t) do
+      grad(t, fn x ->
+        {q, _r} = Nx.LinAlg.qr(x)
+        Nx.sum(q)
+      end)
+    end
+
+    defn qr_r_only_grad(t) do
+      grad(t, fn x ->
+        {_q, r} = Nx.LinAlg.qr(x)
+        Nx.sum(r)
+      end)
+    end
+
+    defn qr_both_grad(t) do
+      grad(t, fn x ->
+        {q, r} = Nx.LinAlg.qr(x)
+        Nx.sum(q) + Nx.sum(r)
+      end)
+    end
+
+    test "computes the grad when only one output is consumed" do
+      t = Nx.tensor([[4.0, 1.0, 0.5], [1.0, 3.0, 0.2], [0.5, 0.2, 2.0]])
+
+      assert_all_close(Nx.add(qr_q_only_grad(t), qr_r_only_grad(t)), qr_both_grad(t))
+    end
   end
 
   describe "lu" do
@@ -2523,6 +2569,43 @@ defmodule Nx.Defn.GradTest do
         ])
 
       assert_equal(lu_grad(t), Nx.stack([lu_grad(t[0]), lu_grad(t[1])]))
+    end
+
+    defn lu_p_only_grad(t) do
+      grad(t, fn x ->
+        {p, _l, _u} = Nx.LinAlg.lu(x)
+        Nx.sum(p)
+      end)
+    end
+
+    defn lu_l_only_grad(t) do
+      grad(t, fn x ->
+        {_p, l, _u} = Nx.LinAlg.lu(x)
+        Nx.sum(l)
+      end)
+    end
+
+    defn lu_u_only_grad(t) do
+      grad(t, fn x ->
+        {_p, _l, u} = Nx.LinAlg.lu(x)
+        Nx.sum(u)
+      end)
+    end
+
+    defn lu_all_grad(t) do
+      grad(t, fn x ->
+        {p, l, u} = Nx.LinAlg.lu(x)
+        Nx.sum(p) + Nx.sum(l) + Nx.sum(u)
+      end)
+    end
+
+    test "computes the grad when only one output is consumed" do
+      t = Nx.tensor([[4.0, 1.0, 0.5], [1.0, 3.0, 0.2], [0.5, 0.2, 2.0]])
+
+      assert_all_close(
+        lu_p_only_grad(t) |> Nx.add(lu_l_only_grad(t)) |> Nx.add(lu_u_only_grad(t)),
+        lu_all_grad(t)
+      )
     end
   end
 
@@ -2598,6 +2681,71 @@ defmodule Nx.Defn.GradTest do
         ])
 
       assert_equal(svd_sum_grad(t), Nx.stack([svd_sum_grad(t[0]), svd_sum_grad(t[1])]))
+    end
+
+    defn svd_u_only_grad(t) do
+      grad(t, fn x ->
+        {u, _s, _vt} = Nx.LinAlg.svd(x)
+        Nx.sum(u)
+      end)
+    end
+
+    defn svd_s_only_grad(t) do
+      grad(t, fn x ->
+        {_u, s, _vt} = Nx.LinAlg.svd(x)
+        Nx.sum(s)
+      end)
+    end
+
+    defn svd_vt_only_grad(t) do
+      grad(t, fn x ->
+        {_u, _s, vt} = Nx.LinAlg.svd(x)
+        Nx.sum(vt)
+      end)
+    end
+
+    defn svd_all_outputs_grad(t) do
+      grad(t, fn x ->
+        {u, s, vt} = Nx.LinAlg.svd(x)
+        Nx.sum(u) + Nx.sum(s) + Nx.sum(vt)
+      end)
+    end
+
+    test "computes the grad when only one output is consumed" do
+      t = Nx.tensor([[4.0, 1.0, 0.5], [1.0, 3.0, 0.2], [0.5, 0.2, 2.0]])
+
+      assert_all_close(
+        svd_u_only_grad(t) |> Nx.add(svd_s_only_grad(t)) |> Nx.add(svd_vt_only_grad(t)),
+        svd_all_outputs_grad(t)
+      )
+    end
+
+    test "grad of the singular value sum is u . vt" do
+      t = Nx.tensor([[4.0, 1.0, 0.5], [1.0, 3.0, 0.2], [0.5, 0.2, 2.0]])
+      {u, _s, vt} = Nx.LinAlg.svd(t)
+
+      assert_all_close(svd_s_only_grad(t), Nx.dot(u, vt))
+    end
+
+    test "grad with only singular values consumed batches elementwise" do
+      t = Nx.tensor([[4.0, 1.0, 0.5], [1.0, 3.0, 0.2], [0.5, 0.2, 2.0]])
+      batched = Nx.stack([t, Nx.multiply(t, 1.5)])
+
+      assert_equal(
+        svd_s_only_grad(batched),
+        Nx.stack([svd_s_only_grad(t), svd_s_only_grad(Nx.multiply(t, 1.5))])
+      )
+    end
+
+    test "grad with only singular values consumed works over vectorized axes" do
+      t = Nx.tensor([[4.0, 1.0, 0.5], [1.0, 3.0, 0.2], [0.5, 0.2, 2.0]])
+      stacked = Nx.stack([t, Nx.multiply(t, 1.5)])
+      vectorized = Nx.vectorize(stacked, :batch)
+
+      assert_equal(
+        Nx.devectorize(svd_s_only_grad(vectorized), keep_names: false),
+        Nx.stack([svd_s_only_grad(t), svd_s_only_grad(Nx.multiply(t, 1.5))])
+      )
     end
   end
 

--- a/nx/test/nx/defn/grad_test.exs
+++ b/nx/test/nx/defn/grad_test.exs
@@ -93,6 +93,48 @@ defmodule Nx.Defn.GradTest do
       assert_receive {:io_call, tensor}
       assert tensor == Nx.tensor(6.0)
     end
+
+    defn io_call_tuple_pair(x) do
+      r = {Nx.multiply(x, 2.0), Nx.multiply(x, 3.0)}
+
+      io_call(
+        custom_grad(r, [x], fn {ga, gb} ->
+          n = Nx.axis_size(ga, -2)
+          [Nx.add(Nx.multiply(ga, n * 1.0), gb)]
+        end),
+        :tuple_grad
+      )
+    end
+
+    defn io_call_tuple_both(x) do
+      grad(x, fn x ->
+        {p, q} = io_call_tuple_pair(x)
+        Nx.sum(p) + Nx.sum(q)
+      end)
+    end
+
+    defn io_call_tuple_first(x) do
+      grad(x, fn x ->
+        {p, _} = io_call_tuple_pair(x)
+        Nx.sum(p)
+      end)
+    end
+
+    defn io_call_tuple_second(x) do
+      grad(x, fn x ->
+        {_, q} = io_call_tuple_pair(x)
+        Nx.sum(q)
+      end)
+    end
+
+    test "computes grad when only one tuple output is consumed" do
+      a = Nx.tensor([[4.0, 1.0, 0.5], [1.0, 3.0, 0.2], [0.5, 0.2, 2.0]])
+
+      assert_all_close(
+        Nx.add(io_call_tuple_first(a), io_call_tuple_second(a)),
+        io_call_tuple_both(a)
+      )
+    end
   end
 
   describe "metadata" do
@@ -122,6 +164,45 @@ defmodule Nx.Defn.GradTest do
 
     test "computes custom grad" do
       assert {x, x} = custom_grad_meta(Nx.tensor(1))
+    end
+
+    defn custom_grad_tuple_pair(x) do
+      r = {Nx.multiply(x, 2.0), Nx.multiply(x, 3.0)}
+
+      custom_grad(r, [x], fn {ga, gb} ->
+        n = Nx.axis_size(ga, -2)
+        [Nx.add(Nx.multiply(ga, n * 1.0), gb)]
+      end)
+    end
+
+    defn custom_grad_tuple_both(x) do
+      grad(x, fn x ->
+        {p, q} = custom_grad_tuple_pair(x)
+        Nx.sum(p) + Nx.sum(q)
+      end)
+    end
+
+    defn custom_grad_tuple_first(x) do
+      grad(x, fn x ->
+        {p, _} = custom_grad_tuple_pair(x)
+        Nx.sum(p)
+      end)
+    end
+
+    defn custom_grad_tuple_second(x) do
+      grad(x, fn x ->
+        {_, q} = custom_grad_tuple_pair(x)
+        Nx.sum(q)
+      end)
+    end
+
+    test "computes custom grad when only one tuple output is consumed" do
+      a = Nx.tensor([[4.0, 1.0, 0.5], [1.0, 3.0, 0.2], [0.5, 0.2, 2.0]])
+
+      assert_all_close(
+        Nx.add(custom_grad_tuple_first(a), custom_grad_tuple_second(a)),
+        custom_grad_tuple_both(a)
+      )
     end
 
     defn random_meta(t), do: grad(t, fn t -> t |> Nx.exp() |> random_meta_transform() end)
@@ -3375,6 +3456,52 @@ defmodule Nx.Defn.GradTest do
       assert grad_if_tuple(Nx.tensor(2)) == Nx.tensor(112.0)
       assert grad_if_tuple(Nx.tensor(-1)) == Nx.tensor(5.0)
       assert grad_if_tuple(Nx.tensor(-2)) == Nx.tensor(444.0)
+    end
+
+    defn if_tuple_pair(x) do
+      r = {Nx.multiply(x, 2.0), Nx.multiply(x, 3.0)}
+
+      pair =
+        custom_grad(r, [x], fn {ga, gb} ->
+          n = Nx.axis_size(ga, -2)
+          [Nx.add(Nx.multiply(ga, n * 1.0), gb)]
+        end)
+
+      if Nx.sum(x) > 0 do
+        pair
+      else
+        pair
+      end
+    end
+
+    defn if_tuple_both(x) do
+      grad(x, fn x ->
+        {p, q} = if_tuple_pair(x)
+        Nx.sum(p) + Nx.sum(q)
+      end)
+    end
+
+    defn if_tuple_first(x) do
+      grad(x, fn x ->
+        {p, _} = if_tuple_pair(x)
+        Nx.sum(p)
+      end)
+    end
+
+    defn if_tuple_second(x) do
+      grad(x, fn x ->
+        {_, q} = if_tuple_pair(x)
+        Nx.sum(q)
+      end)
+    end
+
+    test "computes grad when only one tuple output is consumed" do
+      a = Nx.tensor([[4.0, 1.0, 0.5], [1.0, 3.0, 0.2], [0.5, 0.2, 2.0]])
+
+      assert_all_close(
+        Nx.add(if_tuple_first(a), if_tuple_second(a)),
+        if_tuple_both(a)
+      )
     end
   end
 


### PR DESCRIPTION
closes #1806
closes #1809

Gradients through `Nx.LinAlg` decompositions only worked when every output was consumed:

```elixir
a = Nx.tensor([[4.0, 1.0, 0.5], [1.0, 3.0, 0.2], [0.5, 0.2, 2.0]])

Nx.Defn.grad(fn x -> {_q, r} = Nx.LinAlg.qr(x); Nx.sum(r) end).(a)
# ** (ArgumentError) given axis (-1) invalid for shape with rank 0

Nx.Defn.grad(fn x -> {q, r} = Nx.LinAlg.qr(x); Nx.sum(q) + Nx.sum(r) end).(a)
# fine
```

| grad, one output consumed | 0.13.1 | `main` before this PR |
|---|---|---|
| `eigh` | FAIL | OK |
| `svd` | OK | **FAIL** |
| `qr` | FAIL | FAIL |
| `lu` | FAIL | FAIL |

`svd` is a regression on `main`, bisected to 2eabb4f (#1783):

```
bdea65e (parent)   svd s-only OK    eigh w-only FAIL
2eabb4f  #1783      svd s-only FAIL  eigh w-only OK
```

#1783 made `svd_grad` batch-aware — replacing concrete shapes with `Nx.axis_size(t, -2)` and batched `Nx.dot` — and separately gave `eigh` an analytic VJP plus a `broadcast_grad/2` guard. The guard made `eigh` tolerate the malformed cotangent; `svd` got the batch-aware code without it. So the commit fixed one op's partial-output gradient and broke another's.

### Cause

`sum_grad([])` returns a rank-0 `Expr.tensor(0.0)` for any node that accumulated no gradient. For an unconsumed tuple output of a block, that scalar reaches the grad body, which then indexes axes on it.

### Fix

Restore the invariant once, at the block boundary, rather than in each grad body:

> A block body receives one cotangent per output, each shaped like that output.

`update_grads(:block, …)` already zips cotangents against the block's outputs, and each output expression carries its own shape and type, so the shaping happens there. `qr`, `lu` and `svd` need no per-op guards, and `eigh`'s `broadcast_grad` becomes dead code rather than load-bearing.

This mirrors what `update_grads(:while, …)` already does a few clauses up — `gs = Enum.zip_with(gs, flatten_initial, &Nx.broadcast/2)` — so the block clause is now normalizing its cotangents the same way the `while` clause always has.

**Why not fix `sum_grad/1` itself?** Because the shapes are not available there. The obvious deeper fix is to make the tuple branch of `recur_to_grad` hand `sum_grad/1` a per-position template, but for a `:metadata`/`custom_grad` node `ans` is a `tuple_out/1` template that carries no per-element shapes — the only place the output shapes exist is `args`, which is exactly what the block clause has and `sum_grad/1` does not. Hence the boundary.

That does leave a sibling hole, which I would rather name than hide: the same rank-0 cotangent reaches a bare tuple-output `custom_grad` outside any block, and fails identically. `Nx.Block.LinAlg.Eigh` uses that pattern and is only shielded today because its `custom_grad` sits inside a block. I have not touched it here — it is a distinct entry point and deserves its own change. Happy to file it separately, or fold it in if you would prefer one PR.

I confirmed that: deleting the two `broadcast_grad` calls from `eigh_grad/3` leaves the grad suite green and the compiler reports `broadcast_grad/2 unused`. I have **not** removed it in this PR — that is your call, and it would also mean dropping the now-unused `defnp`.

I considered guarding each grad body instead, mirroring `broadcast_grad`. #1783 is the argument against it: per-op guards are exactly what got missed, and every future block op reintroduces the bug.

One thing worth your opinion: the helper's final clause passes a cotangent through unchanged when its shape differs from the output's and it is not rank 0. That branch should be unreachable — `sum_grad([])` is the only producer of a rank-0 cotangent, and every other path preserves the accumulated shape, which already matches the primal output. I left it as a permissive no-op rather than raising, but if you would rather it raise so a future violation surfaces loudly instead of silently, say so and I will change it.

### Tests

Seven, in the existing `describe` blocks. Five fail on `main` before the fix; the two `eigh` ones already pass and are guard-rails against this change regressing what `broadcast_grad` currently covers.

The main oracle is linearity of the cotangent — partial-output gradients must sum to the all-outputs gradient, which the existing tests already cover. That is precisely the invariant the defect breaks, and it covers every output position. Where a closed form exists it is asserted directly: `∇sum(σ) = UVᵀ` and `∇sum(λ) = I`. Plus a batching check.

Every existing `qr`/`lu`/`svd` grad test destructures all outputs, which is why this shipped — `eigh` had the suite's only partial-output test, added by #1783 itself.

### Verification

- `nx` suite: 2730 passed, 0 failures (2723 before, plus these seven).
- `exla` suite: 1416 passed, 0 failures, 49 excluded.
- `mix compile --force`: no new warnings.

Independent of #1807 — different files, both branched from `main`.
