### PR TITLE
Do not propagate donatable marks onto results

### DIFF
--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -384,7 +384,15 @@ defmodule EXLA.Defn do
             inputs_and_io_calls =
               Outfeed.used_inputs_and_io_calls(expr, used_inputs, lazy_transfers)
 
-            {expr, {make_ref(), Nx.to_template(expr), inputs_and_io_calls}}
+            # A parameter returned as is keeps the donatable mark of the
+            # argument behind it. The caller owns whatever comes back and has
+            # not asked to donate it again, so results are never donatable.
+            outputs =
+              expr
+              |> Nx.to_template()
+              |> Nx.Defn.Composite.traverse(&%{&1 | donatable?: false})
+
+            {expr, {make_ref(), outputs, inputs_and_io_calls}}
           end)
         end)
 

--- a/exla/test/exla/defn/donation_test.exs
+++ b/exla/test/exla/defn/donation_test.exs
@@ -159,6 +159,34 @@ defmodule EXLA.Defn.DonationTest do
       end
     end
 
+    test "results are not donatable" do
+      x = Nx.donatable(on_device([1, 2, 3]))
+
+      result = EXLA.jit(&Nx.add(&1, 1)).(x)
+
+      refute Nx.donatable?(result)
+      # The mark must not survive into a later call either, which would donate
+      # a buffer the caller never offered.
+      assert Nx.to_flat_list(EXLA.jit(&Nx.sum/1).(result)) == [9]
+    end
+
+    test "a result which is the donated argument itself is not donatable" do
+      x = Nx.donatable(on_device([1, 2, 3]))
+      y = on_device([10, 20, 30])
+      %EXLA.Backend{buffer: %DeviceBuffer{} = xb} = x.data
+
+      {passed_through, sum} = EXLA.jit(fn a, b -> {a, Nx.add(b, 1)} end).(x, y)
+
+      refute Nx.donatable?(passed_through)
+      refute Nx.donatable?(sum)
+      assert Nx.to_flat_list(passed_through) == [1, 2, 3]
+
+      # The argument was still donated, its buffer now backs the result.
+      assert_raise RuntimeError, ~r"called on deleted or donated buffer", fn ->
+        DeviceBuffer.read(xb)
+      end
+    end
+
     test "inspect shows a clear message after donation" do
       x = Nx.donatable(on_device([1, 2, 3]))
       _ = EXLA.jit(&Nx.add(&1, 1)).(x)

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -1041,6 +1041,10 @@ defmodule Nx do
   compile time; invoking the compiled function then requires matching
   `donatable?` marks on the live arguments (mismatches raise).
 
+  The mark applies to the argument only. Whatever a function returns belongs
+  to its caller, who has not asked to donate it, so results are never
+  donatable, not even when the result is a donated argument returned as is.
+
   ## Examples
 
       iex> t = Nx.donatable(Nx.tensor([1, 2, 3]))
@@ -1050,6 +1054,10 @@ defmodule Nx do
       iex> %{a: a, b: b} = Nx.donatable(%{a: Nx.tensor(1), b: Nx.tensor(2)})
       iex> {Nx.donatable?(a), Nx.donatable?(b)}
       {true, true}
+
+      iex> fun = Nx.Defn.jit(&Nx.add(&1, 1))
+      iex> Nx.donatable?(fun.(Nx.donatable(Nx.tensor([1, 2, 3]))))
+      false
 
   """
   @doc type: :conversion

--- a/nx/lib/nx/defn/expr.ex
+++ b/nx/lib/nx/defn/expr.ex
@@ -1333,8 +1333,17 @@ defmodule Nx.Defn.Expr do
     {atom, make_ref()}
   end
 
-  defp expr(tensor, context, op, args) do
+  # Expression nodes are built by copying the shape, type and names of an
+  # existing tensor, which would also carry over its `donatable?` mark. The mark
+  # says a specific buffer may be reused, so it is only meaningful on a
+  # parameter, which stands for an argument the caller handed us. Everything
+  # else is computed and gets a buffer of its own.
+  defp expr(tensor, context, :parameter = op, args) do
     %{tensor | data: %Expr{id: id(), op: op, args: args, context: context}}
+  end
+
+  defp expr(tensor, context, op, args) do
+    %{tensor | data: %Expr{id: id(), op: op, args: args, context: context}, donatable?: false}
   end
 
   defp to_expr(%T{data: %Expr{}} = t),

--- a/nx/test/nx/defn/donation_test.exs
+++ b/nx/test/nx/defn/donation_test.exs
@@ -46,6 +46,34 @@ defmodule Nx.Defn.DonationTest do
     end
   end
 
+  describe "donatable propagation" do
+    test "expression parameters keep the mark, expressions built from them do not" do
+      template = Nx.donatable(Nx.template({3}, {:s, 32}))
+
+      {_fun, [param], _templates, _flatten} =
+        Nx.Defn.Compiler.to_lazy_params(fn t -> t end, [template])
+
+      assert param.donatable?
+      refute Nx.add(param, 1).donatable?
+      refute Nx.sum(param).donatable?
+      refute Nx.reshape(param, {3, 1}).donatable?
+    end
+
+    test "results of a jitted function are not donatable" do
+      fun = Nx.Defn.jit(&Nx.add(&1, 1))
+      refute Nx.donatable?(fun.(Nx.donatable(Nx.tensor([1, 2, 3]))))
+    end
+
+    test "results are not donatable when only part of a container is" do
+      fun = Nx.Defn.jit(fn %{a: a, b: b} -> %{a: Nx.add(a, b), b: Nx.multiply(b, 2)} end)
+
+      result = fun.(%{a: Nx.donatable(Nx.tensor([1, 2])), b: Nx.tensor([3, 4])})
+
+      refute Nx.donatable?(result.a)
+      refute Nx.donatable?(result.b)
+    end
+  end
+
   describe "to_lazy_params" do
     test "preserves donatable on templates and expression parameters" do
       # Map keys are traversed in sorted order: :b then :w


### PR DESCRIPTION
When you mark a tensor with `Nx.donatable/1`, you are saying one thing: "I am done with this buffer, feel free to write on top of it." That is a promise about that one tensor, and nothing else.

Right now the mark spreads. Every expression node is built by copying the shape, type, and names off a tensor that already exists, and the donatable flag was riding along in that copy. So if you donate `x` and then compute `Nx.add(x, 1)`, the answer comes back marked too, even though it lives in a brand new buffer that nobody offered up. The mark then follows that tensor around, and the next time you jit something it tries to donate a buffer you never meant to give away.

I ran into this while adding donation to Axon's training loops. After one donating training step, every parameter and every piece of optimizer state came back marked. Axon had to sweep the marks off by hand after each step, otherwise it would donate its own metrics on the following step, and the marks would follow you out of the loop into whatever you did with your trained model afterward.

The fix is small. The mark is about a real buffer, so it only makes sense on a parameter, which is the stand in for an argument you handed in. EXLA reads the flag off those parameter nodes to work out what it can alias, so parameters keep it and everything else clears it.

There is one leftover case. If a function just hands an argument straight back, the output is the parameter itself, so the mark was still riding out with it. EXLA now clears the marks when it builds the output template, so results are never donatable no matter how they were made. The argument is still really donated, its buffer just backs the result now.

Tests cover both, on the Nx side and the EXLA side, and I added a line to the `Nx.donatable/1` docs saying results are never donatable.

One test in `exla/test/exla/device_memory_sharing_test.exs` fails on my machine, but it fails the same way on main without this change, so it is not from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)