### PR TITLE
Fix multi-tensor op dispatch to consider all tensor arguments

### DIFF
--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -12480,7 +12480,7 @@ defmodule Nx do
         tensor
       else
         out = %{tensor | type: type, shape: shape, names: names}
-        impl!(tensor).reduce(out, tensor, acc, [axes: axes, keep_axes: keep_axes], fun)
+        impl!(tensor, acc).reduce(out, tensor, acc, [axes: axes, keep_axes: keep_axes], fun)
       end
 
     vectorize(output, vectorized_axes)
@@ -12617,7 +12617,7 @@ defmodule Nx do
 
       out = %{tensor | shape: output_shape}
       opts = [padding: padding_config, strides: strides, window_dilations: dilations]
-      impl!(tensor).window_reduce(out, tensor, acc, window_dimensions, opts, fun)
+      impl!(tensor, acc).window_reduce(out, tensor, acc, window_dimensions, opts, fun)
     end)
   end
 
@@ -13995,7 +13995,7 @@ defmodule Nx do
 
       Nx.Shared.raise_complex_not_supported(output_type, :clip, 2)
 
-      impl!(tensor).clip(%{tensor | type: output_type}, tensor, min, max)
+      impl!(tensor, min, max).clip(%{tensor | type: output_type}, tensor, min, max)
     end)
   end
 
@@ -14521,7 +14521,7 @@ defmodule Nx do
     output_names = List.duplicate(nil, offset) ++ output_names
 
     result =
-      impl!(tensor).put_slice(
+      impl!(tensor, slice).put_slice(
         %{tensor | shape: output_shape_devec, names: output_names, type: output_type},
         tensor,
         start_indices,
@@ -15199,7 +15199,7 @@ defmodule Nx do
 
     {shape, names} = Nx.Shape.gather(tensor.shape, indices.shape, axes)
     out = %{tensor | shape: shape, names: names}
-    result = impl!(tensor).gather(out, tensor, indices, axes: axes)
+    result = impl!(tensor, indices).gather(out, tensor, indices, axes: axes)
     vectorize(result, vectorized_axes)
   end
 

--- a/nx/test/nx/defn/grad_test.exs
+++ b/nx/test/nx/defn/grad_test.exs
@@ -6536,4 +6536,37 @@ defmodule Nx.Defn.GradTest do
                    end
     end
   end
+
+  describe "multi-tensor ops with captured closure tensors" do
+    test "put_slice grad wrt the update with a captured target" do
+      t = Nx.tensor([1.0, 2.0, 3.0, 4.0, 5.0])
+
+      grad = Nx.Defn.grad(Nx.tensor([10.0, 20.0]), fn p -> Nx.sum(Nx.put_slice(t, [1], p)) end)
+      assert grad == Nx.tensor([1.0, 1.0])
+    end
+
+    test "clip grad wrt min and max with a captured target" do
+      t = Nx.tensor([1.0, 2.0, 3.0, 4.0, 5.0])
+
+      grad_min = Nx.Defn.grad(Nx.tensor(1.5), fn lo -> Nx.sum(Nx.clip(t, lo, Nx.tensor(4.5))) end)
+      assert grad_min == Nx.tensor(1.0)
+
+      grad_max = Nx.Defn.grad(Nx.tensor(4.5), fn hi -> Nx.sum(Nx.clip(t, Nx.tensor(1.5), hi)) end)
+      assert grad_max == Nx.tensor(1.0)
+    end
+
+    test "reduce and window_reduce raise their documented no-grad error, not a dispatch crash" do
+      t = Nx.tensor([1.0, 2.0, 3.0, 4.0, 5.0])
+
+      assert_raise ArgumentError, ~r"cannot compute gradient for Nx.reduce/4", fn ->
+        Nx.Defn.grad(Nx.tensor(0.0), fn a -> Nx.reduce(t, a, fn x, acc -> Nx.add(x, acc) end) end)
+      end
+
+      assert_raise ArgumentError, ~r"cannot compute gradient for Nx.window_reduce/5", fn ->
+        Nx.Defn.grad(Nx.tensor(0.0), fn a ->
+          Nx.sum(Nx.window_reduce(t, a, {2}, fn x, acc -> Nx.max(x, acc) end))
+        end)
+      end
+    end
+  end
 end

--- a/nx/test/nx/defn_test.exs
+++ b/nx/test/nx/defn_test.exs
@@ -2994,4 +2994,29 @@ defmodule Nx.DefnTest do
       assert vectorized_metadata_tuple(x, z) == vec_nonvec_result
     end
   end
+
+  describe "multi-tensor ops with captured closure tensors" do
+    @describetag compiler: Evaluator
+
+    test "put_slice in a jit closure over a concrete target" do
+      t = Nx.tensor([1.0, 2.0, 3.0, 4.0, 5.0])
+      jitted = Nx.Defn.jit(fn p -> Nx.put_slice(t, [1], p) end)
+
+      assert jitted.(Nx.tensor([10.0, 20.0])) == Nx.tensor([1.0, 10.0, 20.0, 4.0, 5.0])
+    end
+
+    test "clip in a jit closure over a concrete target" do
+      t = Nx.tensor([1.0, 2.0, 3.0, 4.0, 5.0])
+      jitted = Nx.Defn.jit(fn lo -> Nx.clip(t, lo, 10.0) end)
+
+      assert jitted.(Nx.tensor(1.5)) == Nx.tensor([1.5, 2.0, 3.0, 4.0, 5.0])
+    end
+
+    test "gather in a jit closure over a concrete source" do
+      t = Nx.tensor([1.0, 2.0, 3.0, 4.0, 5.0])
+      jitted = Nx.Defn.jit(fn idx -> Nx.gather(t, Nx.reshape(idx, {3, 1})) end)
+
+      assert jitted.(Nx.tensor([0, 2, 4], type: :s32)) == Nx.tensor([1.0, 3.0, 5.0])
+    end
+  end
 end


### PR DESCRIPTION
## Problem

`Nx.put_slice`, `Nx.clip`, `Nx.gather`, `Nx.reduce`, and `Nx.window_reduce` dispatch on the first tensor's backend only (`impl!(tensor)`). Whenever a concrete tensor is combined with an `Expr` argument — a `Nx.Defn.jit` closure over a captured tensor, or a grad re-trace of a captured value — `Nx.BinaryBackend` gets picked and crashes:

```elixir
t = Nx.tensor([1.0, 2.0, 3.0, 4.0, 5.0])
Nx.Defn.jit(fn p -> Nx.put_slice(t, [1], p) end).(Nx.tensor([10.0, 20.0]))
# ** (FunctionClauseError) no function clause matching in Nx.BinaryBackend.to_binary/1
```

Found by fuzzing grad/jit with captured closure tensors; the same crash fires for all five ops in both jit and grad contexts.

## Fix

Dispatch through the existing `impl!/2,3` (whose `pick_struct` already prefers any backend over `Nx.BinaryBackend`), considering the tensor arguments that can independently be Exprs:

| Op | Dispatch |
|---|---|
| `put_slice` | `impl!(tensor, slice)` |
| `clip` | `impl!(tensor, min, max)` |
| `gather` | `impl!(tensor, indices)` |
| `reduce`, `window_reduce` | `impl!(tensor, acc)` |

One line per site in `nx/lib/nx.ex`.

A side effect worth noting: for `reduce`/`window_reduce` under grad, the dispatch crash was *masking* the intended "cannot compute gradient for Nx.reduce/4" ArgumentError — with correct dispatch, the documented error surfaces.

## Tests

- grad-side regressions (put_slice/clip values, reduce/window_reduce documented-error assertions) appended to the captured-closure area of `test/nx/defn/grad_test.exs`
- jit-closure regressions (put_slice/clip/gather values) in `test/nx/defn_test.exs` under `compiler: Evaluator`
- full nx suite green: 1384 doctests + 1375 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
