### PR TITLE
Accept sub-byte bitstrings in Nx.from_binary

### DIFF
--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -2020,11 +2020,6 @@ defmodule Nx do
   Creates a one-dimensional tensor from a `binary` with the given `type`.
 
   If the binary size does not match its type, an error is raised.
-
-  For sub-byte types (u2/u4/s2/s4), the input may also be a bitstring
-  whose bit count is not divisible by 8, as produced by `to_binary/2`
-  for those types.
-
   ## Examples
 
       iex> Nx.from_binary(<<1, 2, 3, 4>>, :s8)

--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -2021,6 +2021,10 @@ defmodule Nx do
 
   If the binary size does not match its type, an error is raised.
 
+  For sub-byte types (u2/u4/s2/s4), the input may also be a bitstring
+  whose bit count is not divisible by 8, as produced by `to_binary/2`
+  for those types.
+
   ## Examples
 
       iex> Nx.from_binary(<<1, 2, 3, 4>>, :s8)
@@ -2049,7 +2053,7 @@ defmodule Nx do
       is ignored inside `defn`
   """
   @doc type: :creation
-  def from_binary(binary, type, opts \\ []) when is_binary(binary) do
+  def from_binary(binary, type, opts \\ []) when is_bitstring(binary) do
     opts = keyword!(opts, [:backend])
     {_, size} = type = Nx.Type.normalize!(type)
     dim = div(Kernel.bit_size(binary), size)

--- a/nx/test/nx_test.exs
+++ b/nx/test/nx_test.exs
@@ -1489,6 +1489,20 @@ defmodule NxTest do
         Nx.from_binary("", {:u, 32})
       end)
     end
+
+    test "round-trips sub-byte tensors whose binary is not byte-aligned" do
+      for {type, values} <- [
+            {{:u, 2}, [1, 2, 3]},
+            {{:u, 4}, [5, 10, 15]},
+            {{:s, 2}, [-1, 0, 1]}
+          ] do
+        tensor = Nx.tensor(values, type: type)
+        data = Nx.to_binary(tensor)
+
+        refute is_binary(data)
+        assert Nx.from_binary(data, type) == tensor
+      end
+    end
   end
 
   describe "to_batched/3" do


### PR DESCRIPTION
`Nx.to_binary`'s docs note that sub-byte types (u2/u4/s2/s4) may yield a *bitstring* whose bit count is not divisible by 8 — but `Nx.from_binary`'s `is_binary` guard rejected exactly those values, so the documented round trip crashed:

```elixir
t = Nx.tensor([1, 2, 3], type: {:u, 2})   # 6 bits
t |> Nx.to_binary() |> Nx.from_binary({:u, 2})
# ** (FunctionClauseError) no function clause matching in Nx.from_binary/3
```

The function body already measures in bits (`bit_size` + rem check), so the fix is the guard: `is_binary` → `is_bitstring`. A doc sentence now notes the bitstring case, mirroring `to_binary`'s existing info box.

Regression test: round trip for u2/u4/s2, asserting the intermediate really is a non-binary bitstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
