### PR TITLE
Fix inspect crash on sub-byte integer tensors

### DIFF
--- a/nx/lib/nx/backend.ex
+++ b/nx/lib/nx/backend.ex
@@ -172,11 +172,11 @@ defmodule Nx.Backend do
     {doc, tail} =
       case type do
         {:s, size} ->
-          <<seg::size(^size)-signed-integer-native, tail::binary>> = data
+          <<seg::size(^size)-signed-integer-native, tail::bitstring>> = data
           {Integer.to_string(seg), tail}
 
         {:u, size} ->
-          <<seg::size(^size)-unsigned-integer-native, tail::binary>> = data
+          <<seg::size(^size)-unsigned-integer-native, tail::bitstring>> = data
           {Integer.to_string(seg), tail}
 
         {:c, size} ->

--- a/nx/test/nx_test.exs
+++ b/nx/test/nx_test.exs
@@ -623,6 +623,22 @@ defmodule NxTest do
   end
 
   describe "inspect" do
+    test "sub-byte integer tensors" do
+      assert inspect(Nx.tensor([1, 2, 3], type: {:u, 2})) == """
+             #Nx.Tensor<
+               u2[3]
+               [1, 2, 3]
+             >\
+             """
+
+      assert inspect(Nx.tensor([-1, 0, 1], type: {:s, 2})) == """
+             #Nx.Tensor<
+               s2[3]
+               [-1, 0, 1]
+             >\
+             """
+    end
+
     test "scalar" do
       assert inspect(Nx.tensor(123)) == """
              #Nx.Tensor<


### PR DESCRIPTION
`Nx.Backend`'s inspect chunking used `tail::binary` in the `:s`/`:u` branches while the float branch already correctly used `tail::bitstring` — so `IO.inspect` on any u2/u4/s2/s4 tensor raised `MatchError` once the remaining data was not byte-aligned:

```elixir
IO.inspect(Nx.tensor([1, 2, 3], type: {:u, 2}))
# ** (MatchError) no match of right hand side value ...
```

Two-character fix per branch. Since `Nx.Backend.inspect` is the shared implementation, this also fixes Torchx sub-byte tensors.

Regression test: exact inspect renderings for u2 and s2 tensors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
