### PR TITLE
Raise ArgumentError for multiple :auto dimensions in reshape

### DIFF
--- a/nx/lib/nx/shape.ex
+++ b/nx/lib/nx/shape.ex
@@ -162,6 +162,11 @@ defmodule Nx.Shape do
   def reshape(old_shape, new_shape) do
     old_size = Tuple.product(old_shape)
 
+    if Enum.count(Tuple.to_list(new_shape), &(&1 == :auto)) > 1 do
+      raise ArgumentError,
+            "only a single :auto dimension is allowed in reshape, got: #{inspect(new_shape)}"
+    end
+
     new_shape =
       case Enum.find_index(Tuple.to_list(new_shape), &(&1 == :auto)) do
         nil ->

--- a/nx/test/nx_test.exs
+++ b/nx/test/nx_test.exs
@@ -1411,6 +1411,12 @@ defmodule NxTest do
       assert Nx.reshape(t, {2, 2}, names: [:x, :y]) ==
                Nx.tensor([[1, 2], [3, 4]], names: [:x, :y])
     end
+
+    test "raises ArgumentError for more than one :auto dimension" do
+      assert_raise ArgumentError,
+                   "only a single :auto dimension is allowed in reshape, got: {:auto, :auto}",
+                   fn -> Nx.reshape(Nx.iota({12}), {:auto, :auto}) end
+    end
   end
 
   describe "flatten" do


### PR DESCRIPTION
`Nx.reshape` with more than one `:auto` dimension leaked a bare `ArithmeticError`: after resolving the first `:auto`, `Tuple.product` multiplied by the second `:auto` atom.

```elixir
Nx.reshape(Nx.iota({12}), {:auto, :auto})
# before: ** (ArithmeticError) bad argument in arithmetic expression
# after:  ** (ArgumentError) only a single :auto dimension is allowed in reshape, got: {:auto, :auto}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
