### PR TITLE
Add test coverage for revectorize's multiple-:auto guard

### DIFF
--- a/nx/test/nx/vectorize_test.exs
+++ b/nx/test/nx/vectorize_test.exs
@@ -824,4 +824,25 @@ defmodule Nx.VectorizeTest do
       assert result == Nx.vectorize(expected, a: 2, b: 3)
     end
   end
+
+  describe "revectorize" do
+    test "raises ArgumentError for more than one :auto across target_axes and :target_shape" do
+      t = Nx.iota({24}) |> Nx.vectorize(:x)
+
+      message =
+        "cannot have more than one `:auto` occurrence between target_axes and the :target_shape option"
+
+      assert_raise ArgumentError, message, fn ->
+        Nx.revectorize(t, a: :auto, b: :auto)
+      end
+
+      assert_raise ArgumentError, message, fn ->
+        Nx.revectorize(t, [a: :auto], target_shape: {:auto, 2})
+      end
+
+      assert_raise ArgumentError, message, fn ->
+        Nx.revectorize(t, [a: 2], target_shape: {:auto, :auto})
+      end
+    end
+  end
 end


### PR DESCRIPTION
Follow-up to the review note on #1819 about giving `Nx.revectorize`'s `:target_shape` a pass for the same multiple-`:auto` class.

Verified: `revectorize` already validates this — it raises a descriptive `ArgumentError` ("cannot have more than one `:auto` occurrence between target_axes and the :target_shape option") for all three combinations (two `:auto`s in `target_axes`, one in each, two in `:target_shape`), and the single-`:auto` cases resolve correctly. The vectorized `reshape` path also picks up #1819's guard.

That existing guard had no test coverage, though — this adds a test pinning all three raise cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)