### PR TITLE
Fix Nx.LinAlg.eigh dropping the batch for 1x1 matrices

### DIFF
--- a/nx/lib/nx/lin_alg/block_eigh.ex
+++ b/nx/lib/nx/lin_alg/block_eigh.ex
@@ -71,7 +71,9 @@ defmodule Nx.LinAlg.BlockEigh do
     if n > 1 do
       m_decompose(matrix, opts)
     else
-      {Nx.take_diagonal(Nx.real(matrix)), Nx.tensor([1], type: matrix.type)}
+      # derive the 1x1 eigenvector matrix from the input so it inherits
+      # the collapsed vectorized (batch) axes
+      {Nx.take_diagonal(Nx.real(matrix)), Nx.multiply(matrix, 0) |> Nx.add(1)}
     end
   end
 

--- a/nx/lib/nx/lin_alg/block_eigh.ex
+++ b/nx/lib/nx/lin_alg/block_eigh.ex
@@ -73,7 +73,7 @@ defmodule Nx.LinAlg.BlockEigh do
     else
       # derive the 1x1 eigenvector matrix from the input so it inherits
       # the collapsed vectorized (batch) axes
-      {Nx.take_diagonal(Nx.real(matrix)), Nx.multiply(matrix, 0) |> Nx.add(1)}
+      {Nx.take_diagonal(Nx.real(matrix)), Nx.fill(matrix, 1)}
     end
   end
 

--- a/nx/test/nx/lin_alg_test.exs
+++ b/nx/test/nx/lin_alg_test.exs
@@ -587,6 +587,33 @@ defmodule Nx.LinAlgTest do
   end
 
   describe "eigh" do
+    test "supports batched 1x1 matrices" do
+      t = Nx.tensor([[[2.0]], [[5.0]]], type: :f64)
+
+      {eigenvals, eigenvecs} = Nx.LinAlg.eigh(t)
+
+      assert eigenvals == Nx.tensor([[2.0], [5.0]], type: :f64)
+      assert eigenvecs == Nx.tensor([[[1.0]], [[1.0]]], type: :f64)
+
+      # double batch
+      t2 = Nx.iota({3, 2, 1, 1}, type: :f64) |> Nx.add(1.0)
+      {vals2, vecs2} = Nx.LinAlg.eigh(t2)
+      assert Nx.shape(vals2) == {3, 2, 1}
+      assert Nx.shape(vecs2) == {3, 2, 1, 1}
+      assert_all_close(vals2, Nx.reshape(t2, {3, 2, 1}))
+    end
+
+    test "batched size-1 dimensions work through svd and pinv" do
+      {_u, s, _vt} = Nx.LinAlg.svd(Nx.tensor([[[3.0, 4.0]], [[6.0, 8.0]]], type: :f64))
+      assert_all_close(s, Nx.tensor([[5.0], [10.0]], type: :f64))
+
+      {_u2, s2, _vt2} = Nx.LinAlg.svd(Nx.tensor([[[3.0], [4.0]], [[6.0], [8.0]]], type: :f64))
+      assert_all_close(s2, Nx.tensor([[5.0], [10.0]], type: :f64))
+
+      pinv = Nx.LinAlg.pinv(Nx.tensor([[[2.0]], [[4.0]]], type: :f64))
+      assert_all_close(pinv, Nx.tensor([[[0.5]], [[0.25]]], type: :f64))
+    end
+
     test "computes eigenvalues and eigenvectors" do
       t =
         Nx.tensor([


### PR DESCRIPTION
## Problem

`Nx.LinAlg.eigh` crashes on any batched input whose matrices are 1×1 — and since `svd` delegates to `eigh` and `pinv` to `svd`, all three fail for batched inputs with a size-1 matrix dimension:

```elixir
Nx.LinAlg.eigh(Nx.iota({2, 1, 1}, type: :f64) |> Nx.add(1.0))
# ** (ArgumentError) cannot reshape, current shape {1} is not compatible with new shape {2, 1}

Nx.LinAlg.svd(Nx.iota({2, 1, 2}, type: :f64))   # same crash
Nx.LinAlg.pinv(Nx.iota({2, 1, 1}, type: :f64))  # same crash
```

Unbatched `{1, 1}` works; batched n ≥ 2 works.

## Cause

`BlockEigh.eigh` collapses leading batch dims into vectorized axes, decomposes the inner matrix, and re-expands via `revectorize`. The degenerate `n == 1` branch of `decompose` returns:

```elixir
{Nx.take_diagonal(Nx.real(matrix)), Nx.tensor([1], type: matrix.type)}
```

The eigenvalues side respects vectorization; the eigenvectors side is a **fresh constant with no vectorized axes** — the batch is silently dropped, and `revectorize_result` can't reshape one element into the batched target. Unbatched 1×1 only survives because a single element happens to reshape into `{1, 1}`.

## Fix

Derive the 1×1 eigenvector matrix from the input so it inherits the vectorized axes:

```elixir
{Nx.take_diagonal(Nx.real(matrix)), Nx.multiply(matrix, 0) |> Nx.add(1)}
```

## Tests

In the eigh describe: batched 1×1 with exact value assertions (eigenvalue of `[a]` is `a`, eigenvector `[1]`), double-batch `{3,2,1,1}` shape + value check, and the downstream svd (both non-square orientations, singular values 5/10 from 3-4-5 rows) and pinv (`1/a`) paths. Full nx suite green: 1384 doctests + 1382 tests.

## Known remaining corner (separate, not addressed here)

With this fix, `pinv` on a *double* batch of 1×1 (`{3,2,1,1}`) still fails with transposed batch axes in the error (`cannot broadcast {3, 2, 1, 1} to {2, 3, 1, 1}`) — batch-axis ordering somewhere in the svd composition, independent of this degenerate branch.

Found via property fuzzing while extending batched-pinv coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

