### PR TITLE
EXLA: support custom call MLIR attributes

### DIFF
--- a/exla/c_src/exla/exla.cc
+++ b/exla/c_src/exla/exla.cc
@@ -141,7 +141,7 @@ mlir_op(ErlNifEnv *env, fine::ResourcePtr<MLIRFunction> function,
         std::string op_name,
         std::vector<fine::ResourcePtr<mlir::Value>> operands,
         std::vector<std::string> result_type_strings,
-        std::vector<std::tuple<fine::Atom, std::string>> attributes_kwlist,
+        std::vector<std::tuple<std::string, std::string>> attributes_kwlist,
         std::vector<fine::ResourcePtr<mlir::Region>> regions) {
   auto result_types = std::vector<mlir::Type>{};
 
@@ -154,7 +154,7 @@ mlir_op(ErlNifEnv *env, fine::ResourcePtr<MLIRFunction> function,
 
   for (auto const &[key, value] : attributes_kwlist) {
     auto attribute_value = function->module()->ParseAttribute(value);
-    attributes.push_back(std::make_tuple(key.to_string(), attribute_value));
+    attributes.push_back(std::make_tuple(key, attribute_value));
   }
 
   return function->Op(op_name, operands, result_types, attributes, regions);

--- a/exla/lib/exla/custom_call.ex
+++ b/exla/lib/exla/custom_call.ex
@@ -39,10 +39,11 @@ defprotocol EXLA.CustomCall do
       is used instead.
 
     * **`{:ok, %EXLA.CustomCall.Spec{}}`** — emit a StableHLO custom call; see
-      `EXLA.CustomCall.Spec` for `call_target_name`, optional `attributes`
-      (`[{name, attr}]` string pairs for the `stablehlo.custom_call` `backend_config` dictionary), and optional
-      `operand_element_types` (operand converts when they differ
-      from the lowered inputs).
+      `EXLA.CustomCall.Spec` for `call_target_name`; optional `attributes`
+      (`[{name, attr}]` string pairs for the `stablehlo.custom_call` `backend_config`
+      dictionary); optional `mlir_attributes` (string pairs emitted directly on
+      `stablehlo.custom_call`); and optional `operand_element_types` (operand converts
+      when they differ from the lowered inputs).
 
   ## Dispatch
 

--- a/exla/lib/exla/custom_call/spec.ex
+++ b/exla/lib/exla/custom_call/spec.ex
@@ -12,6 +12,12 @@ defmodule EXLA.CustomCall.Spec do
       `name = ` (for example `{"k", "42 : i64"}`). An empty list omits the dictionary
       from the op.
 
+    * **`mlir_attributes`** — Optional `{name, attr}` pairs, default `[]`, emitted
+      directly on `stablehlo.custom_call`. Use these for compiler-visible metadata such
+      as layouts and sharding rules. Names and attributes use the same binary format as
+      `attributes`. Names must be unique and cannot be `call_target_name`, `api_version`,
+      or `backend_config`.
+
     * **`operand_element_types`** — How operand SSA values are presented to the handler:
 
       * **`:default`** — use each lowered operand’s element type as produced from the
@@ -27,11 +33,17 @@ defmodule EXLA.CustomCall.Spec do
 
   @enforce_keys [:call_target_name]
 
-  defstruct [:call_target_name, attributes: [], operand_element_types: :default]
+  defstruct [
+    :call_target_name,
+    attributes: [],
+    mlir_attributes: [],
+    operand_element_types: :default
+  ]
 
   @type t :: %__MODULE__{
           call_target_name: String.t(),
           attributes: [{String.t(), String.t()}],
+          mlir_attributes: [{String.t(), String.t()}],
           operand_element_types: :default | [Nx.Type.t()]
         }
 end

--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -880,6 +880,14 @@ defmodule EXLA.Defn do
                     "EXLA.CustomCall.Spec attributes must be a list of {binary_key, binary_attr} pairs, got: #{inspect(other)}"
           end
 
+        mlir_attributes =
+          if is_list(spec.mlir_attributes) do
+            spec.mlir_attributes
+          else
+            raise ArgumentError,
+                  "EXLA.CustomCall.Spec mlir_attributes must be a list of {binary_key, binary_attr} pairs, got: #{inspect(spec.mlir_attributes)}"
+          end
+
         call_args = cast_custom_call_operands(call_args, spec.operand_element_types)
 
         out_typespecs =
@@ -888,7 +896,13 @@ defmodule EXLA.Defn do
           |> Enum.map(&expr_to_typespec/1)
 
         lowered =
-          Value.custom_call(call_args, out_typespecs, spec.call_target_name, dictionary_entries)
+          Value.custom_call(
+            call_args,
+            out_typespecs,
+            spec.call_target_name,
+            dictionary_entries,
+            mlir_attributes
+          )
           |> wrap_tuple_result(out)
 
         {lowered, cache}

--- a/exla/lib/exla/mlir/value.ex
+++ b/exla/lib/exla/mlir/value.ex
@@ -780,9 +780,11 @@ defmodule EXLA.MLIR.Value do
         [%Value{function: func} | _] = operands,
         typespecs,
         call_target_name,
-        dictionary_entries \\ []
+        dictionary_entries \\ [],
+        mlir_attributes \\ []
       )
-      when is_binary(call_target_name) and is_list(typespecs) and is_list(dictionary_entries) do
+      when is_binary(call_target_name) and is_list(typespecs) and is_list(dictionary_entries) and
+             is_list(mlir_attributes) do
     result_types = typespecs_to_mlir_types(typespecs)
 
     attributes = [
@@ -796,6 +798,8 @@ defmodule EXLA.MLIR.Value do
       else
         attributes
       end
+
+    attributes = attributes ++ custom_call_mlir_attrs(mlir_attributes)
 
     op(func, "stablehlo.custom_call", operands, result_types, attributes: attributes)
   end
@@ -927,13 +931,15 @@ defmodule EXLA.MLIR.Value do
         %Value{ref: ref, function: %Function{ref: ^function_ref}} -> ref
       end)
 
+    attributes = Enum.map(opts[:attributes], fn {name, value} -> {to_string(name), value} end)
+
     refs =
       EXLA.NIF.mlir_op(
         function.ref,
         op_name,
         refs,
         result_types,
-        opts[:attributes],
+        attributes,
         opts[:regions]
       )
 
@@ -1102,6 +1108,30 @@ defmodule EXLA.MLIR.Value do
               "custom_call backend_config dictionary must be a list of {binary_key, binary_attr} pairs, got entry: #{inspect(other)}"
     end)
     |> attr_dict()
+  end
+
+  @reserved_custom_call_attrs ["call_target_name", "api_version", "backend_config"]
+
+  defp custom_call_mlir_attrs(pairs) do
+    attributes =
+      Enum.map(pairs, fn
+        {name, attr} when is_binary(name) and is_binary(attr) ->
+          {name, attr}
+
+        other ->
+          raise ArgumentError,
+                "custom_call MLIR attributes must be a list of {binary_name, binary_attr} pairs, got entry: #{inspect(other)}"
+      end)
+
+    names = Enum.map(attributes, &elem(&1, 0))
+
+    if Enum.any?(names, &(&1 in @reserved_custom_call_attrs)) or
+         length(Enum.uniq(names)) != length(names) do
+      raise ArgumentError,
+            "custom_call MLIR attribute names must be unique and cannot override EXLA attributes"
+    end
+
+    attributes
   end
 
   defp join_list(list) do

--- a/exla/test/exla/custom_call_alias_test.exs
+++ b/exla/test/exla/custom_call_alias_test.exs
@@ -103,7 +103,7 @@ defmodule EXLA.CustomCallAliasTest do
     refute mlir =~ "@eigh_cpu_custom_call_s32("
   end
 
-  test "QR alias plugin: MLIR uses alias name and not the builtin target string" do
+  test "QR alias plugin: MLIR uses alias name and MLIR attributes" do
     load_plugin!()
 
     arg = Nx.iota({3, 4}, type: {:f, 32})
@@ -111,6 +111,11 @@ defmodule EXLA.CustomCallAliasTest do
 
     assert mlir =~ "qr_cpu_custom_call_f32_exla_alias"
     refute mlir =~ "@qr_cpu_custom_call_f32("
+    refute mlir =~ "backend_config"
+    assert mlir =~ "operand_layouts = [dense<[1, 0]> : tensor<2xindex>]"
+
+    assert mlir =~
+             "result_layouts = [dense<[1, 0]> : tensor<2xindex>, dense<[1, 0]> : tensor<2xindex>]"
   end
 
   test "QR alias plugin: JIT result matches builtin QR" do

--- a/exla/test/exla/mlir/custom_call_test.exs
+++ b/exla/test/exla/mlir/custom_call_test.exs
@@ -1,6 +1,10 @@
 defmodule EXLA.MLIR.CustomCallTest do
   use EXLA.Case, async: true
 
+  alias EXLA.MLIR.Function
+  alias EXLA.MLIR.Module
+  alias EXLA.MLIR.Value
+
   describe "qr" do
     for type <- [bf: 16, f: 16, f: 32, f: 64] do
       tol_opts =
@@ -35,5 +39,49 @@ defmodule EXLA.MLIR.CustomCallTest do
         assert_all_close(fun.(wide), wide, unquote(tol_opts))
       end
     end
+  end
+
+  test "MLIR attribute names cannot override or duplicate attributes" do
+    typespec = EXLA.Typespec.tensor({:f, 32}, {1})
+
+    for mlir_attributes <- [
+          [{"call_target_name", ~s("replacement")}],
+          [{"test.attribute", "1 : i64"}, {"test.attribute", "2 : i64"}]
+        ] do
+      assert_raise ArgumentError, ~r/must be unique and cannot override/, fn ->
+        Module.new([typespec], [typespec], fn function ->
+          [argument] = Function.get_arguments(function)
+          Value.custom_call([argument], [typespec], "original", [], mlir_attributes)
+        end)
+      end
+    end
+  end
+
+  test "string MLIR attribute names preserve backend config without creating atoms" do
+    typespec = EXLA.Typespec.tensor({:f, 32}, {1})
+    name = "test.attribute_#{System.unique_integer([:positive])}"
+
+    assert_raise ArgumentError, fn -> String.to_existing_atom(name) end
+
+    mlir =
+      Module.new([typespec], [typespec], fn function ->
+        [argument] = Function.get_arguments(function)
+
+        [result] =
+          Value.custom_call(
+            [argument],
+            [typespec],
+            "original",
+            [{"test_backend", "42 : i64"}],
+            [{name, "1 : i64"}]
+          )
+
+        Value.func_return(function, [result])
+        Module.as_string(function.module)
+      end)
+
+    assert mlir =~ "backend_config = {test_backend = 42 : i64}"
+    assert mlir =~ "#{name} = 1 : i64"
+    assert_raise ArgumentError, fn -> String.to_existing_atom(name) end
   end
 end

--- a/exla/test/support/exla_test_qr_alias_block.ex
+++ b/exla/test/support/exla_test_qr_alias_block.ex
@@ -9,7 +9,14 @@ end
 defimpl EXLA.CustomCall, for: EXLA.Test.QRAliasBlock do
   def call(_, {%{type: {q_kind, q_size}}, _r_expr}, [_tensor], client)
       when q_kind != :c and q_size == 32 and client.platform == :host do
-    {:ok, %EXLA.CustomCall.Spec{call_target_name: "qr_cpu_custom_call_f32_exla_alias"}}
+    {:ok,
+     %EXLA.CustomCall.Spec{
+       call_target_name: "qr_cpu_custom_call_f32_exla_alias",
+       mlir_attributes: [
+         {"operand_layouts", "[dense<[1, 0]> : tensor<2xindex>]"},
+         {"result_layouts", "[dense<[1, 0]> : tensor<2xindex>, dense<[1, 0]> : tensor<2xindex>]"}
+       ]
+     }}
   end
 
   def call(_, _, _, _), do: :skip


### PR DESCRIPTION
`EXLA.CustomCall.Spec.attributes` is serialized into `backend_config`, so external custom calls cannot attach compiler-visible metadata to `stablehlo.custom_call`.

Add `mlir_attributes` as `{name, value}` strings emitted at the operation level, while preserving `attributes` as handler-visible backend configuration. Duplicate and EXLA-owned attribute names are rejected. Tests cover validation, StableHLO emission, the existing backend configuration path, and the compiled execution path.

The external [FlashAttention-3 experiment](https://github.com/humdrum00001010/ex_flashattention3/blob/main/RESULTS.md) uses this API for layout constraints and a Shardy rule. Its performance measurements do not represent an Nx optimization: this change only makes compiler metadata expressible, and the measured throughput differences are not attributed to Nx or `mlir_attributes`.

Closes #1823
