### PR TITLE
exla: add EXLA.load_dylib/1 for custom call libraries

### DIFF
--- a/exla/lib/exla.ex
+++ b/exla/lib/exla.ex
@@ -491,6 +491,50 @@ defmodule EXLA do
     {expr_cache_fun, comp_cache_fun}
   end
 
+  @doc """
+  Loads a native shared library into the OS process running the VM.
+
+  ## Path
+
+  `path` is a string handed to the system dynamic loader as is, extension
+  included (`.so`, also `.dylib` on macOS). Look up rules are the same as
+  for native dynamic linking loaders (for example, searching through
+  `LD_LIBRARY_PATH`). Therefore, using absolute paths is advised.
+
+  ## Loading semantics
+
+  The library must be loaded **before** EXLA compiles a computation emitting one
+  of the targets it implements. Otherwise compilation fails with an unregistered
+  custom call error. Your application `start/2` callback is a good place for it:
+
+      defmodule MyApp.Application do
+        use Application
+
+        @impl true
+        def start(_type, _args) do
+          :ok = EXLA.load_dylib(Application.app_dir(:my_app, "priv/libmy_custom_calls.so"))
+          Supervisor.start_link([], strategy: :one_for_one, name: MyApp.Supervisor)
+        end
+      end
+
+  The library is never unloaded, since XLA holds on to the registered handlers
+  for as long as the VM runs. Therefore, it is advised that the library is as
+  lightweight as possible.
+
+  ## Errors
+
+  An `ArgumentError` is raised with the message reported by the dynamic loader
+  when the library cannot be opened. The usual causes are a path that does not
+  exist, a library built for a different architecture, and symbols that cannot
+  be resolved.
+
+  This function is only supported on Unix systems (Linux and macOS).
+  """
+  @spec load_dylib(Path.t()) :: :ok
+  def load_dylib(path) when is_binary(path) do
+    EXLA.NIF.load_dylib(path)
+  end
+
   @impl true
   defdelegate __compile__(key, vars, fun, opts), to: EXLA.Defn
 

--- a/exla/lib/exla.ex
+++ b/exla/lib/exla.ex
@@ -82,6 +82,9 @@ defmodule EXLA do
   your block tag struct; see `EXLA.CustomCall` for the `call/4` contract,
   including returning `:skip` to fall back to the block's default Elixir callback.
 
+  The native library implementing the handler is loaded with `load_dylib/1`,
+  which must happen before compiling any function that emits the target name.
+
   Backend-specific behaviour, options, and limitations for Nx functions are
   documented in the [Backend documentation](backend_documentation.html) guides
   (for example [Nx](backend_documentation-nx.html) and

--- a/exla/lib/exla/custom_call.ex
+++ b/exla/lib/exla/custom_call.ex
@@ -53,11 +53,9 @@ defprotocol EXLA.CustomCall do
 
   ## Native handlers
 
-  Emitting a custom call in MLIR is only half of the story: the **target name**
-  must be registered with XLA on the relevant platform (typically via a native
-  library loaded into the process). That registration is **not** configured
-  through `config :exla, ...`; you load or link the native code by the same
-  means you would for any other NIF-backed extension.
+  For a custom call backed by an external native library, load the library that
+  registers the corresponding native handler for the active XLA platform before
+  compiling the block.
 
   ## Example
 

--- a/exla/test/exla/custom_call_alias_test.exs
+++ b/exla/test/exla/custom_call_alias_test.exs
@@ -59,13 +59,7 @@ defmodule EXLA.CustomCallAliasTest do
       """)
     end
 
-    case EXLA.NIF.load_dylib(path) do
-      :ok ->
-        :ok
-
-      other ->
-        flunk("load_dylib(#{path}) expected :ok, got: #{inspect(other)}")
-    end
+    assert EXLA.load_dylib(path) == :ok
   end
 
   test "builtin QR lowering includes qr_cpu_custom_call_f32 in MLIR" do

--- a/exla/test/exla/load_dylib_test.exs
+++ b/exla/test/exla/load_dylib_test.exs
@@ -1,0 +1,20 @@
+defmodule EXLA.LoadDylibTest do
+  use ExUnit.Case, async: false
+
+  test "loads a library and is safe to call again for the same one" do
+    # EXLA's own NIF: already loaded, so opening it again only bumps its
+    # reference count.
+    path = Application.app_dir(:exla, "priv/libexla.so")
+
+    assert EXLA.load_dylib(path) == :ok
+    assert EXLA.load_dylib(path) == :ok
+  end
+
+  test "raises with the dynamic loader message when the library cannot be opened" do
+    path = Path.join(System.tmp_dir!(), "exla_does_not_exist.so")
+
+    assert_raise ArgumentError, ~r/exla_does_not_exist\.so/, fn ->
+      EXLA.load_dylib(path)
+    end
+  end
+end


### PR DESCRIPTION
Closes #1825

It reuses EXLA.NIF.load_dylib()