### PR TITLE
fix(grad): seed the backward pass from the expression's own type

### DIFF
--- a/nx/lib/nx/defn/grad.ex
+++ b/nx/lib/nx/defn/grad.ex
@@ -111,7 +111,7 @@ defmodule Nx.Defn.Grad do
 
   defp constant(float, %T{shape: shape} = t) do
     names = List.duplicate(nil, tuple_size(shape))
-    Expr.constant(%{t | names: names, type: Nx.Type.to_real(t.type)}, float, [])
+    Expr.constant(%{t | names: names, type: Nx.Type.to_floating(t.type)}, float, [])
   end
 
   # Align heterogenous vectorized inputs to the union of vec axes — matching

--- a/nx/lib/nx/defn/grad.ex
+++ b/nx/lib/nx/defn/grad.ex
@@ -111,7 +111,7 @@ defmodule Nx.Defn.Grad do
 
   defp constant(float, %T{shape: shape} = t) do
     names = List.duplicate(nil, tuple_size(shape))
-    Expr.constant(%{t | names: names, type: {:f, 32}}, float, [])
+    Expr.constant(%{t | names: names, type: Nx.Type.to_real(t.type)}, float, [])
   end
 
   # Align heterogenous vectorized inputs to the union of vec axes — matching

--- a/nx/test/nx/defn/grad_test.exs
+++ b/nx/test/nx/defn/grad_test.exs
@@ -3678,6 +3678,26 @@ defmodule Nx.Defn.GradTest do
       assert grad_while_constant(tensor) == Nx.tensor([1.0, 1.0, 1.0, 1.0, 1.0])
     end
 
+    defn grad_while_f64(t) do
+      grad(t, fn t ->
+        {_, t} =
+          while {i = 0, t}, i < 3 do
+            {i + 1, t * 2.0}
+          end
+
+        Nx.sum(t)
+      end)
+    end
+
+    test "preserves the input type across the loop carry" do
+      # Three doublings, so Σ(8t) and ∂/∂t = 8 everywhere.
+      tensor = Nx.tensor([1.0, 2.0, 3.0], type: :f64)
+      result = grad_while_f64(tensor)
+
+      assert Nx.type(result) == {:f, 64}
+      assert result == Nx.tensor([8.0, 8.0, 8.0], type: :f64)
+    end
+
     defn grad_while_param(t, x) do
       value_and_grad(x, fn x ->
         {_, t} =

--- a/nx/test/nx/defn/grad_test.exs
+++ b/nx/test/nx/defn/grad_test.exs
@@ -3678,7 +3678,7 @@ defmodule Nx.Defn.GradTest do
       assert grad_while_constant(tensor) == Nx.tensor([1.0, 1.0, 1.0, 1.0, 1.0])
     end
 
-    defn grad_while_f64(t) do
+    defn grad_while_doubling(t) do
       grad(t, fn t ->
         {_, t} =
           while {i = 0, t}, i < 3 do
@@ -3691,11 +3691,18 @@ defmodule Nx.Defn.GradTest do
 
     test "preserves the input type across the loop carry" do
       # Three doublings, so Σ(8t) and ∂/∂t = 8 everywhere.
-      tensor = Nx.tensor([1.0, 2.0, 3.0], type: :f64)
-      result = grad_while_f64(tensor)
+      tensor = Nx.tensor([1.0, 2.0, 3.0], type: {:f, 64})
+      result = grad_while_doubling(tensor)
 
       assert Nx.type(result) == {:f, 64}
-      assert result == Nx.tensor([8.0, 8.0, 8.0], type: :f64)
+      assert result == Nx.tensor([8.0, 8.0, 8.0], type: {:f, 64})
+    end
+
+    test "preserves complex types across the loop carry" do
+      result = grad_while_doubling(~VEC[1+1i 2-2i 3])
+
+      assert Nx.type(result) == {:c, 64}
+      assert result == ~VEC[8 8 8]c64
     end
 
     defn grad_while_param(t, x) do

--- a/nx/test/nx/defn/grad_test.exs
+++ b/nx/test/nx/defn/grad_test.exs
@@ -2246,39 +2246,39 @@ defmodule Nx.Defn.GradTest do
     defn grad_sum_broadcast(t), do: grad(t, &Nx.sum(Nx.broadcast(&1, {3, 2, 2})))
 
     test "computes gradient" do
-      for multiplier <- [1, Complex.new(0, 1)] do
+      for {multiplier, type} <- [{1, {:f, 32}}, {Complex.new(0, 1), {:c, 64}}] do
         assert grad_sum_broadcast({3, 2, 2} |> Nx.iota() |> Nx.multiply(multiplier)) ==
-                 Nx.broadcast(1.0, {3, 2, 2})
+                 Nx.broadcast(Nx.tensor(1.0, type: type), {3, 2, 2})
 
         assert grad_sum_broadcast({1, 2, 2} |> Nx.iota() |> Nx.multiply(multiplier)) ==
-                 Nx.broadcast(3.0, {1, 2, 2})
+                 Nx.broadcast(Nx.tensor(3.0, type: type), {1, 2, 2})
 
         assert grad_sum_broadcast({3, 1, 2} |> Nx.iota() |> Nx.multiply(multiplier)) ==
-                 Nx.broadcast(2.0, {3, 1, 2})
+                 Nx.broadcast(Nx.tensor(2.0, type: type), {3, 1, 2})
 
         assert grad_sum_broadcast({3, 2, 1} |> Nx.iota() |> Nx.multiply(multiplier)) ==
-                 Nx.broadcast(2.0, {3, 2, 1})
+                 Nx.broadcast(Nx.tensor(2.0, type: type), {3, 2, 1})
 
         assert grad_sum_broadcast({3, 1, 1} |> Nx.iota() |> Nx.multiply(multiplier)) ==
-                 Nx.broadcast(4.0, {3, 1, 1})
+                 Nx.broadcast(Nx.tensor(4.0, type: type), {3, 1, 1})
 
         assert grad_sum_broadcast({1, 1, 1} |> Nx.iota() |> Nx.multiply(multiplier)) ==
-                 Nx.broadcast(12.0, {1, 1, 1})
+                 Nx.broadcast(Nx.tensor(12.0, type: type), {1, 1, 1})
 
         assert grad_sum_broadcast({2, 2} |> Nx.iota() |> Nx.multiply(multiplier)) ==
-                 Nx.broadcast(3.0, {2, 2})
+                 Nx.broadcast(Nx.tensor(3.0, type: type), {2, 2})
 
         assert grad_sum_broadcast({1, 2} |> Nx.iota() |> Nx.multiply(multiplier)) ==
-                 Nx.broadcast(6.0, {1, 2})
+                 Nx.broadcast(Nx.tensor(6.0, type: type), {1, 2})
 
         assert grad_sum_broadcast({2, 1} |> Nx.iota() |> Nx.multiply(multiplier)) ==
-                 Nx.broadcast(6.0, {2, 1})
+                 Nx.broadcast(Nx.tensor(6.0, type: type), {2, 1})
 
         assert grad_sum_broadcast({2} |> Nx.iota() |> Nx.multiply(multiplier)) ==
-                 Nx.broadcast(6.0, {2})
+                 Nx.broadcast(Nx.tensor(6.0, type: type), {2})
 
         assert grad_sum_broadcast({} |> Nx.iota() |> Nx.multiply(multiplier)) ==
-                 Nx.broadcast(12.0, {})
+                 Nx.broadcast(Nx.tensor(12.0, type: type), {})
       end
     end
   end
@@ -3116,34 +3116,34 @@ defmodule Nx.Defn.GradTest do
 
     test "computes gradient for complex" do
       assert grad_sum_squeeze_broadcast(Nx.multiply(Nx.Constants.i(), Nx.iota({3, 2, 2}))) ==
-               Nx.broadcast(1.0, {3, 2, 2})
+               Nx.broadcast(Complex.new(1.0), {3, 2, 2})
 
       assert grad_sum_squeeze_broadcast(Nx.multiply(Nx.Constants.i(), Nx.iota({1, 2, 2}))) ==
-               Nx.broadcast(3.0, {1, 2, 2})
+               Nx.broadcast(Complex.new(3.0), {1, 2, 2})
 
       assert grad_sum_squeeze_broadcast(Nx.multiply(Nx.Constants.i(), Nx.iota({1, 1, 2}))) ==
-               Nx.broadcast(6.0, {1, 1, 2})
+               Nx.broadcast(Complex.new(6.0), {1, 1, 2})
 
       assert grad_sum_squeeze_broadcast(Nx.multiply(Nx.Constants.i(), Nx.iota({1, 1, 1}))) ==
-               Nx.broadcast(12.0, {1, 1, 1})
+               Nx.broadcast(Complex.new(12.0), {1, 1, 1})
 
       assert grad_sum_squeeze_broadcast(Nx.multiply(Nx.Constants.i(), Nx.iota({2, 2}))) ==
-               Nx.broadcast(3.0, {2, 2})
+               Nx.broadcast(Complex.new(3.0), {2, 2})
 
       assert grad_sum_squeeze_broadcast(Nx.multiply(Nx.Constants.i(), Nx.iota({1, 2}))) ==
-               Nx.broadcast(6.0, {1, 2})
+               Nx.broadcast(Complex.new(6.0), {1, 2})
 
       assert grad_sum_squeeze_broadcast(Nx.multiply(Nx.Constants.i(), Nx.iota({1, 1}))) ==
-               Nx.broadcast(12.0, {1, 1})
+               Nx.broadcast(Complex.new(12.0), {1, 1})
 
       assert grad_sum_squeeze_broadcast(Nx.multiply(Nx.Constants.i(), Nx.iota({2}))) ==
-               Nx.broadcast(6.0, {2})
+               Nx.broadcast(Complex.new(6.0), {2})
 
       assert grad_sum_squeeze_broadcast(Nx.multiply(Nx.Constants.i(), Nx.iota({1}))) ==
-               Nx.broadcast(12.0, {1})
+               Nx.broadcast(Complex.new(12.0), {1})
 
       assert grad_sum_squeeze_broadcast(Nx.multiply(Nx.Constants.i(), Nx.iota({}))) ==
-               Nx.broadcast(12.0, {})
+               Nx.broadcast(Complex.new(12.0), {})
     end
   end
 
@@ -3185,7 +3185,7 @@ defmodule Nx.Defn.GradTest do
         |> Nx.multiply(Nx.Constants.i())
         |> grad_sum_pad
 
-      rhs = Nx.tensor([[0.0, 0.0], [1.0, 1.0]])
+      rhs = Nx.tensor([[0.0, 0.0], [1.0, 1.0]], type: {:c, 64})
 
       assert lhs == rhs
     end
@@ -3238,7 +3238,7 @@ defmodule Nx.Defn.GradTest do
                Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
                |> Nx.multiply(Nx.Constants.i())
              ) ==
-               Nx.tensor([[0.0, 0.0, 0.0], [1.0, 1.0, 0.0]])
+               Nx.tensor([[0.0, 0.0, 0.0], [1.0, 1.0, 0.0]], type: {:c, 64})
 
       assert grad_sum_dynamic_slice(Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])) ==
                Nx.tensor([[0.0, 0.0, 0.0], [1.0, 1.0, 0.0]])
@@ -3560,7 +3560,7 @@ defmodule Nx.Defn.GradTest do
 
     test "as_type passes through for non-downcasting calls" do
       assert grad_as_type(Nx.tensor([1, 2, 3])) == Nx.tensor([1.0, 1.0, 1.0])
-      assert grad_as_type_complex(~VEC[1+i 2+i 3+i]) == Nx.tensor([1.0, 1.0, 1.0])
+      assert grad_as_type_complex(~VEC[1+i 2+i 3+i]) == ~VEC[1 1 1]c64
     end
 
     test "bitcast passes through" do


### PR DESCRIPTION
Closes #1827.

### Problem

`grad` seeds the backward pass with a hard-coded `{:f, 32}` regardless of the
type being differentiated. Straight-line code promotes that seed away on the
first multiply; a `while` carry cannot, because its types must match exactly.

```elixir
defn looped(x) do
  {_i, r} =
    while {i = 0, r = x}, i < 3 do
      {i + 1, Nx.multiply(r, 2.0)}
    end

  Nx.sum(r)
end

x = Nx.tensor([1.0, 2.0, 3.0], type: :f64)

Nx.Defn.grad(&looped/1).(x)
#=> #Nx.Tensor<f32[3]  [0.0, 2.5, 0.0]>   expected f64[3] [8.0, 8.0, 8.0]
```

| body | grad type, f64 input |
|---|---|
| straight-line | `f64` |
| `cond` / `if` | `f64` |
| `while` | `f32` |

Under EXLA this is an MLIR error — `tensor<3xf32>` against `tensor<3xf64>` in the
loop carry. Under `Nx.Defn.Evaluator` there is no error and the values are wrong.

### Solution

Seed from the expression's own type:

```elixir
Expr.constant(%{t | names: names, type: Nx.Type.to_floating(t.type)}, float, [])
```

`constant/2` has one caller, `grad.ex:98`, so this changes the seed and nothing
else. `Nx.Type.to_floating/1` preserves whatever the input already is:

| input | `to_floating` | effect |
|---|---|---|
| `{:f, 64}` | `{:f, 64}` | fixes this |
| `{:f, 32}`, `{:bf, 16}` | unchanged | none |
| `{:s, _}`, `{:u, _}` | `{:f, 32}` | none |
| `{:c, 64}` / `{:c, 128}` | `{:c, 64}` / `{:c, 128}` | grads of complex functions are now complex, where they used to be real |

That last row is a behaviour change, settled in review. Five existing assertions
compared complex gradients against real expectations and now compare against
complex ones — `pad works on complex`, `broadcast computes gradient`, `slice
computes gradient`, `squeeze computes gradient for complex`, and `as_type/bitcast
as_type passes through for non-downcasting calls`. Their values are unchanged;
only the dtype they are compared against moved.

### Siblings checked

| site | affected | evidence |
|---|---|---|
| `grad.ex:114` `constant/2` | yes — this fix | the only hard-coded `{:f, 32}` under `lib/nx/defn/` |
| `svd.ex:254-255` `min_precision_type/1` | no | a floor, not a cap; `{:f, 64}` maps to `{:f, 64}` |
| `svd.ex:255` catch-all, complex input | unreachable | `Nx.LinAlg.svd/2` raises `not yet implemented for complex inputs` |

### Verification

Two tests are added. Against the unpatched seed both fail; against `to_real`
only the complex one fails, which is what pins `to_floating` specifically — the
f64 case is fixed by either.

- `nx`: 2766 → 2768 passed, zero warnings, `mix format --check-formatted` clean
- `exla`: 1419 passed, 49 excluded
- the EXLA error above is gone; the same jitted grad returns `f64 [8.0, 8.0, 8.0]`

Branched from `main` at `37901d74`; independent of any other open PR.
