### PR TITLE
fix(grad): take while gradient carry types from the carry

### DIFF
--- a/exla/test/exla/defn/expr_test.exs
+++ b/exla/test/exla/defn/expr_test.exs
@@ -1515,6 +1515,49 @@ defmodule EXLA.Defn.ExprTest do
                      cond_inside_while_vectorized(Nx.vectorize(Nx.tensor([1, 2, 3]), :a), 3)
                    end
     end
+
+    defn grad_while_accumulator(a) do
+      grad(a, fn a ->
+        {_i, _a, acc} =
+          while {i = 0, a = a, acc = a}, i < 3 do
+            {i + 1, a, acc + a}
+          end
+
+        acc
+      end)
+    end
+
+    test "computes the gradient of a multi-element carry" do
+      for type <- [bf: 16, f: 16, f: 32, f: 64] do
+        # acc = a + 3a, so the gradient is 4 and keeps the input's type.
+        result = grad_while_accumulator(Nx.tensor(1.0, type: type))
+
+        assert Nx.type(result) == type
+        assert_equal(result, Nx.tensor(4.0, type: type))
+      end
+    end
+
+    defn grad_while_carried_series(a, s) do
+      grad(a, fn a ->
+        {_i, acc, _s} =
+          while {i = 0, acc = a, s = s}, i < 3 do
+            {i + 1, acc + Nx.sum(s), s}
+          end
+
+        acc
+      end)
+    end
+
+    test "computes the gradient when a carry has a different type to the input" do
+      for type <- [bf: 16, f: 16, f: 32, f: 64, s: 64] do
+        # acc = a + 3 * sum(s), so the gradient is 1 whatever s holds.
+        s = Nx.broadcast(Nx.tensor(2, type: type), {4})
+        result = grad_while_carried_series(Nx.tensor(1.0, type: {:f, 64}), s)
+
+        assert Nx.type(result) == {:f, 64}
+        assert_equal(result, Nx.tensor(1.0, type: {:f, 64}))
+      end
+    end
   end
 
   defn while_inside_if(pred, x) do

--- a/exla/test/exla/defn/expr_test.exs
+++ b/exla/test/exla/defn/expr_test.exs
@@ -1515,49 +1515,6 @@ defmodule EXLA.Defn.ExprTest do
                      cond_inside_while_vectorized(Nx.vectorize(Nx.tensor([1, 2, 3]), :a), 3)
                    end
     end
-
-    defn grad_while_accumulator(a) do
-      grad(a, fn a ->
-        {_i, _a, acc} =
-          while {i = 0, a = a, acc = a}, i < 3 do
-            {i + 1, a, acc + a}
-          end
-
-        acc
-      end)
-    end
-
-    test "computes the gradient of a multi-element carry" do
-      for type <- [bf: 16, f: 16, f: 32, f: 64] do
-        # acc = a + 3a, so the gradient is 4 and keeps the input's type.
-        result = grad_while_accumulator(Nx.tensor(1.0, type: type))
-
-        assert Nx.type(result) == type
-        assert_equal(result, Nx.tensor(4.0, type: type))
-      end
-    end
-
-    defn grad_while_carried_series(a, s) do
-      grad(a, fn a ->
-        {_i, acc, _s} =
-          while {i = 0, acc = a, s = s}, i < 3 do
-            {i + 1, acc + Nx.sum(s), s}
-          end
-
-        acc
-      end)
-    end
-
-    test "computes the gradient when a carry has a different type to the input" do
-      for type <- [bf: 16, f: 16, f: 32, f: 64, s: 64] do
-        # acc = a + 3 * sum(s), so the gradient is 1 whatever s holds.
-        s = Nx.broadcast(Nx.tensor(2, type: type), {4})
-        result = grad_while_carried_series(Nx.tensor(1.0, type: {:f, 64}), s)
-
-        assert Nx.type(result) == {:f, 64}
-        assert_equal(result, Nx.tensor(1.0, type: {:f, 64}))
-      end
-    end
   end
 
   defn while_inside_if(pred, x) do

--- a/nx/lib/nx/defn/grad.ex
+++ b/nx/lib/nx/defn/grad.ex
@@ -433,30 +433,56 @@ defmodule Nx.Defn.Grad do
     flatten_initial = Composite.flatten_list([initial])
     context = hd(flatten_initial).data.context
     arg_context = condition.data.context
-    gs = Enum.zip_with(gs, flatten_initial, &Nx.broadcast/2)
-    n_args = length(flatten_initial)
 
-    # Convert all gradients into while parameters.
-    # Positions: arg is 0..n_args-1; grad_args continue from n_args.
-    {grad_args, pos_after_grads} =
-      Enum.map_reduce(gs, n_args, fn g, pos ->
-        {Expr.parameter(g, arg_context, pos), pos + 1}
+    gs =
+      Enum.zip_with(gs, flatten_initial, fn g, init ->
+        g |> Nx.broadcast(init) |> Nx.as_type(Nx.Type.to_floating(init.type))
       end)
+
+    n_args = length(flatten_initial)
 
     # Now compute the gradient of the body, first we build the tree as usual.
     {parents, nodes} = parents_tree(body, %{})
 
-    # The bodies have the grad_arg as their gradient, recursively.
-    {while_grads, []} =
-      Composite.reduce(body, {%{}, grad_args}, fn arg, {grads, [g | gs]} ->
-        {Map.put(grads, arg.data.id, [g]), gs}
-      end)
+    # Convert all gradients into while parameters and differentiate the body
+    # through them. Positions: arg is 0..n_args-1; grad_args continue from n_args.
+    build_grad_body = fn gs ->
+      {grad_args, pos_after_grads} =
+        Enum.map_reduce(gs, n_args, fn g, pos ->
+          {Expr.parameter(g, arg_context, pos), pos + 1}
+        end)
 
-    # Now grad over each input.
-    {grad_body, _} =
-      [arg]
-      |> Composite.flatten_list()
-      |> Enum.map_reduce({nodes, while_grads}, &to_grad(&1, {arg, %{}, 0}, parents, &2, []))
+      # The bodies have the grad_arg as their gradient, recursively.
+      {while_grads, []} =
+        Composite.reduce(body, {%{}, grad_args}, fn arg, {grads, [g | gs]} ->
+          {Map.put(grads, arg.data.id, [g]), gs}
+        end)
+
+      # Now grad over each input.
+      {grad_body, _} =
+        [arg]
+        |> Composite.flatten_list()
+        |> Enum.map_reduce({nodes, while_grads}, &to_grad(&1, {arg, %{}, 0}, parents, &2, []))
+
+      {grad_args, pos_after_grads, grad_body}
+    end
+
+    {grad_args, pos_after_grads, grad_body} = build_grad_body.(gs)
+
+    # The body may compute a carry's gradient in a wider type than the carry it
+    # flows into: an f32 carry combined with an f64 one comes back f64. The loop
+    # requires the carry and the body to agree, so widen the carries to whatever
+    # the body produced and differentiate again.
+    promoted = Enum.zip_with(gs, grad_body, fn g, gb -> Nx.Type.merge(g.type, gb.type) end)
+
+    {gs, grad_args, pos_after_grads, grad_body} =
+      if promoted == Enum.map(gs, & &1.type) do
+        {gs, grad_args, pos_after_grads, grad_body}
+      else
+        gs = Enum.zip_with(gs, promoted, &Nx.as_type/2)
+        {grad_args, pos_after_grads, grad_body} = build_grad_body.(gs)
+        {gs, grad_args, pos_after_grads, grad_body}
+      end
 
     # Reverse-mode through while must apply body VJPs from last iteration to first.
     # We rematerialize each intermediate state from `initial` (O(n²) time, O(1)

--- a/nx/test/nx/defn/grad_test.exs
+++ b/nx/test/nx/defn/grad_test.exs
@@ -3889,7 +3889,7 @@ defmodule Nx.Defn.GradTest do
     end
 
     test "computes the gradient of a multi-element carry" do
-      for type <- [f: 8, bf: 16, f: 16, f: 32, f: 64] do
+      for type <- [f: 8, bf: 16, f: 16, f: 32, f: 64, c: 64, c: 128] do
         # acc = a + 3a, so the gradient is 4 and keeps the input's type.
         result = grad_while_accumulator(Nx.tensor(1.0, type: type))
 
@@ -3910,12 +3910,16 @@ defmodule Nx.Defn.GradTest do
     end
 
     test "computes the gradient when a carry has a different type to the input" do
-      for type <- [f: 8, bf: 16, f: 16, f: 32, f: 64] do
-        # acc = a + 3 * sum(s), so the gradient is 1 whatever s holds.
+      for type <- [f: 8, bf: 16, f: 16, f: 32, f: 64, c: 64, c: 128] do
+        # acc = a + 3 * sum(s), so the gradient is 1 whatever s holds. a's
+        # type must absorb whatever the body computes, so widen it to
+        # whatever merges with the series' type: f64 for reals, complex for
+        # complex s (f64 alone doesn't absorb complex; merge always favors it).
+        sink_type = Nx.Type.merge({:f, 64}, type)
         s = Nx.broadcast(Nx.tensor(2, type: type), {4})
-        result = grad_while_carried_series(Nx.tensor(1.0, type: {:f, 64}), s)
+        result = grad_while_carried_series(Nx.tensor(1, type: sink_type), s)
 
-        assert Nx.type(result) == {:f, 64}
+        assert Nx.type(result) == sink_type
         assert_equal(result, 1)
 
         result = grad_while_carried_series(Nx.tensor(1, type: type), Nx.broadcast(2, {4}))

--- a/nx/test/nx/defn/grad_test.exs
+++ b/nx/test/nx/defn/grad_test.exs
@@ -3876,6 +3876,56 @@ defmodule Nx.Defn.GradTest do
       assert_all_close(power_via_generator(x), power_via_generator_unroll(x))
       assert_all_close(grad_power_via_generator(x), grad_power_via_generator_unroll(x))
     end
+
+    defn grad_while_accumulator(a) do
+      grad(a, fn a ->
+        {_i, _a, acc} =
+          while {i = 0, a = a, acc = a}, i < 3 do
+            {i + 1, a, acc + a}
+          end
+
+        acc
+      end)
+    end
+
+    test "computes the gradient of a multi-element carry" do
+      for type <- [f: 8, bf: 16, f: 16, f: 32, f: 64] do
+        # acc = a + 3a, so the gradient is 4 and keeps the input's type.
+        result = grad_while_accumulator(Nx.tensor(1.0, type: type))
+
+        assert Nx.type(result) == type
+        assert_equal(result, 4)
+      end
+    end
+
+    defn grad_while_carried_series(a, s) do
+      grad(a, fn a ->
+        {_i, acc, _s} =
+          while {i = 0, acc = a, s = s}, i < 3 do
+            {i + 1, acc + Nx.sum(s), s}
+          end
+
+        acc
+      end)
+    end
+
+    test "computes the gradient when a carry has a different type to the input" do
+      for type <- [f: 8, bf: 16, f: 16, f: 32, f: 64] do
+        # acc = a + 3 * sum(s), so the gradient is 1 whatever s holds.
+        s = Nx.broadcast(Nx.tensor(2, type: type), {4})
+        result = grad_while_carried_series(Nx.tensor(1.0, type: {:f, 64}), s)
+
+        assert Nx.type(result) == {:f, 64}
+        assert_equal(result, 1)
+
+        result = grad_while_carried_series(Nx.tensor(1, type: type), Nx.broadcast(2, {4}))
+
+        # a's gradient is floating point; for a float type that's a no-op, for
+        # an integer type it's the same-size float (s64 becomes f64, not f32).
+        assert Nx.type(result) == type
+        assert_equal(result, 1)
+      end
+    end
   end
 
   describe "axes" do


### PR DESCRIPTION
Closes #1829.

`grad` through a `while` stopped compiling under EXLA at f64 once #1828 (mine) made the seed follow the differentiated expression's type:

```elixir
defn acc_grad(a) do
  grad(a, fn a ->
    {_i, _a, acc} =
      while {i = 0, a = a, acc = a}, i < 3 do
        {i + 1, a, acc + a}
      end

    acc
  end)
end

EXLA.jit(&acc_grad/1).(Nx.tensor(1.0, type: :f64))
#=> ** (RuntimeError) expect operands to be compatible with body block return types
```

The gradient carries were built with `Nx.broadcast/2`, which takes the shape from the carry's initial and the type from the incoming gradient. With one element in the carry those agree; with more than one they don't. This takes the type from the initial instead.

That alone isn't enough, because the body can compute a gradient in a wider type than the carry it flows into — an f64 parameter carried alongside an f32 series still failed. This differentiates the body, widens the carries to whatever it produced, and differentiates again. 

The tests are in exla rather than nx because `Nx.Defn.Evaluator` computes the right answer in every one of these cases; only the MLIR lowering rejects a mismatched carry, which is why #1828's own test didn't catch this.

`nx` 2781 and `exla` 1435, both green.
