### PR TITLE
fix(exla): use per-partition device id when preparing shard_jit input buffers

### DIFF
--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -241,8 +241,8 @@ defmodule EXLA.Defn do
 
     {buffers, infeeds} =
       EXLA.Defn.Buffers.split_by_value(args, used_inputs, fn
-        arg, _i, nil -> EXLA.Defn.Buffers.from_nx!(arg, executable, true)
-        arg, i, _depth -> {i, EXLA.Defn.Buffers.from_nx!(arg, executable, false)}
+        arg, _i, nil -> EXLA.Defn.Buffers.from_nx!(arg, executable)
+        arg, i, _depth -> {i, EXLA.Defn.Buffers.from_nx!(arg, executable, transfer?: false)}
       end)
 
     infeeds = Map.new(infeeds)
@@ -302,7 +302,7 @@ defmodule EXLA.Defn do
           target_device_id = if is_sharded?, do: partition_index, else: executable.device_id
 
           EXLA.Defn.Buffers.filter_by_indexes(partition_args, used_inputs, fn arg, _i ->
-            EXLA.Defn.Buffers.from_nx!(arg, executable, true, target_device_id)
+            EXLA.Defn.Buffers.from_nx!(arg, executable, target_device_id: target_device_id)
           end)
         end)
 

--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -298,11 +298,7 @@ defmodule EXLA.Defn do
         args
         |> Enum.with_index()
         |> Enum.map(fn {partition_args, partition_index} ->
-          # executable.device_id is -1 for sharded (SPMD) executables, since
-          # they are not pinned to a single device (see EXLA.MLIR.Module.compile/5).
-          # -1 is only meaningful to EXLA.Executable.run/3; each partition's
-          # arguments must instead be placed on the device matching its
-          # partition index, following PjRt's default device assignment.
+          # executable.device_id is -1 for sharded executables; use the partition index instead.
           target_device_id = if is_sharded?, do: partition_index, else: executable.device_id
 
           EXLA.Defn.Buffers.filter_by_indexes(partition_args, used_inputs, fn arg, _i ->

--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -295,9 +295,18 @@ defmodule EXLA.Defn do
 
       # Check if args are pre-sliced (list of arglists for each partition)
       input_lists =
-        Enum.map(args, fn partition_args ->
+        args
+        |> Enum.with_index()
+        |> Enum.map(fn {partition_args, partition_index} ->
+          # executable.device_id is -1 for sharded (SPMD) executables, since
+          # they are not pinned to a single device (see EXLA.MLIR.Module.compile/5).
+          # -1 is only meaningful to EXLA.Executable.run/3; each partition's
+          # arguments must instead be placed on the device matching its
+          # partition index, following PjRt's default device assignment.
+          target_device_id = if is_sharded?, do: partition_index, else: executable.device_id
+
           EXLA.Defn.Buffers.filter_by_indexes(partition_args, used_inputs, fn arg, _i ->
-            EXLA.Defn.Buffers.from_nx!(arg, executable)
+            EXLA.Defn.Buffers.from_nx!(arg, executable, true, target_device_id)
           end)
         end)
 

--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -295,9 +295,7 @@ defmodule EXLA.Defn do
 
       # Check if args are pre-sliced (list of arglists for each partition)
       input_lists =
-        args
-        |> Enum.with_index()
-        |> Enum.map(fn {partition_args, partition_index} ->
+        Enum.with_index(args, fn partition_args, partition_index ->
           # executable.device_id is -1 for sharded executables; use the partition index instead.
           target_device_id = if is_sharded?, do: partition_index, else: executable.device_id
 

--- a/exla/lib/exla/defn/buffers.ex
+++ b/exla/lib/exla/defn/buffers.ex
@@ -141,12 +141,18 @@ defmodule EXLA.Defn.Buffers do
   @doc """
   Nx -> EXLA.DeviceBuffer + EXLA.BinaryBuffer.
 
-  `target_device_id` defaults to `executable.device_id`, but callers for
-  sharded execution must pass the real per-partition device id instead,
-  since `executable.device_id` is `-1` for sharded executables.
+  ## Options
+
+    * `:transfer?` - whether to automatically transfer a mismatched device
+      buffer to the target device. Defaults to `true`.
+
+    * `:target_device_id` - defaults to `executable.device_id`, but callers
+      for sharded execution must pass the real per-partition device id
+      instead, since `executable.device_id` is `-1` for sharded executables.
   """
-  def from_nx!(fun, executable, transfer? \\ true, target_device_id \\ nil) do
-    target_device_id = target_device_id || executable.device_id
+  def from_nx!(fun, executable, opts \\ []) do
+    transfer? = Keyword.get(opts, :transfer?, true)
+    target_device_id = Keyword.get(opts, :target_device_id) || executable.device_id
 
     %Nx.Tensor{data: data} =
       tensor = Nx.devectorize(fun.())

--- a/exla/lib/exla/defn/buffers.ex
+++ b/exla/lib/exla/defn/buffers.ex
@@ -140,8 +140,17 @@ defmodule EXLA.Defn.Buffers do
 
   @doc """
   Nx -> EXLA.DeviceBuffer + EXLA.BinaryBuffer.
+
+  `target_device_id` overrides the device to place/compare the buffer
+  against. It defaults to `executable.device_id`, but that is `-1` for
+  sharded (SPMD) executables, which is only a valid value for `run/3` and
+  never a real device to transfer to. Callers preparing per-partition
+  arguments for sharded execution must pass the actual device id for that
+  partition.
   """
-  def from_nx!(fun, executable, transfer? \\ true) do
+  def from_nx!(fun, executable, transfer? \\ true, target_device_id \\ nil) do
+    target_device_id = target_device_id || executable.device_id
+
     %Nx.Tensor{data: data} =
       tensor = Nx.devectorize(fun.())
 
@@ -160,17 +169,17 @@ defmodule EXLA.Defn.Buffers do
 
       %EXLA.Backend{buffer: %EXLA.DeviceBuffer{} = buffer}
       when transfer? and buffer.client_name != executable.client.name
-      when transfer? and buffer.device_id != executable.device_id ->
+      when transfer? and buffer.device_id != target_device_id ->
         buffer_client = EXLA.Client.fetch!(buffer.client_name)
 
         if buffer_client.automatic_transfers do
-          EXLA.DeviceBuffer.copy_to_device(buffer, executable.client, executable.device_id)
+          EXLA.DeviceBuffer.copy_to_device(buffer, executable.client, target_device_id)
         else
           default = EXLA.Client.fetch!(EXLA.Client.default_name())
 
           raise ArgumentError, """
           EXLA computation (defn) is allocated on client #{executable.client.name} \
-          ##{executable.device_id} (#{executable.client.platform}) \
+          ##{target_device_id} (#{executable.client.platform}) \
           but one of the input tensors are allocated on #{buffer_client.name} \
           ##{buffer.device_id} (#{buffer_client.platform}).
 

--- a/exla/lib/exla/defn/buffers.ex
+++ b/exla/lib/exla/defn/buffers.ex
@@ -141,12 +141,9 @@ defmodule EXLA.Defn.Buffers do
   @doc """
   Nx -> EXLA.DeviceBuffer + EXLA.BinaryBuffer.
 
-  `target_device_id` overrides the device to place/compare the buffer
-  against. It defaults to `executable.device_id`, but that is `-1` for
-  sharded (SPMD) executables, which is only a valid value for `run/3` and
-  never a real device to transfer to. Callers preparing per-partition
-  arguments for sharded execution must pass the actual device id for that
-  partition.
+  `target_device_id` defaults to `executable.device_id`, but callers for
+  sharded execution must pass the real per-partition device id instead,
+  since `executable.device_id` is `-1` for sharded executables.
   """
   def from_nx!(fun, executable, transfer? \\ true, target_device_id \\ nil) do
     target_device_id = target_device_id || executable.device_id

--- a/exla/test/exla/defn/sharding_test.exs
+++ b/exla/test/exla/defn/sharding_test.exs
@@ -395,12 +395,6 @@ defmodule EXLA.Defn.ShardingTest do
   describe "input buffers already on an EXLA device" do
     @moduletag :multi_device
     test "does not crash with 'No matching device found for device_id -1'" do
-      # Regression test: when inputs are already EXLA.Backend device buffers
-      # (instead of plain Nx.BinaryBackend tensors), preparing arguments for
-      # a sharded (SPMD) executable used to compare each buffer's device
-      # against `executable.device_id`, which is `-1` for sharded executables
-      # (a sentinel meaning "multiple devices", not a real device). That sent
-      # `-1` into `EXLA.NIF.copy_buffer_to_device/3`, which doesn't accept it.
       previous_backend = Nx.default_backend()
       Nx.default_backend({EXLA.Backend, client: :host})
 

--- a/exla/test/exla/defn/sharding_test.exs
+++ b/exla/test/exla/defn/sharding_test.exs
@@ -392,6 +392,47 @@ defmodule EXLA.Defn.ShardingTest do
     end
   end
 
+  describe "input buffers already on an EXLA device" do
+    @moduletag :multi_device
+    test "does not crash with 'No matching device found for device_id -1'" do
+      # Regression test: when inputs are already EXLA.Backend device buffers
+      # (instead of plain Nx.BinaryBackend tensors), preparing arguments for
+      # a sharded (SPMD) executable used to compare each buffer's device
+      # against `executable.device_id`, which is `-1` for sharded executables
+      # (a sentinel meaning "multiple devices", not a real device). That sent
+      # `-1` into `EXLA.NIF.copy_buffer_to_device/3`, which doesn't accept it.
+      previous_backend = Nx.default_backend()
+      Nx.default_backend({EXLA.Backend, client: :host})
+
+      try do
+        fun = fn a, b -> Nx.dot(a, b) end
+
+        mesh = %Mesh{name: "two_host_devices", shape: {2}}
+
+        sharded_matmul =
+          EXLA.shard_jit(
+            fun,
+            mesh,
+            client: :host,
+            input_shardings: [%{0 => [0]}, %{}]
+          )
+
+        a0 = Nx.broadcast(Nx.tensor(1.0, type: {:f, 32}), {2, 4})
+        a1 = Nx.broadcast(Nx.tensor(2.0, type: {:f, 32}), {2, 4})
+        b = Nx.eye(4, type: {:f, 32})
+
+        [result0, result1] = sharded_matmul.([[a0, b], [a1, b]])
+
+        assert_equal(result0, a0)
+        assert result0.data.buffer.device_id == 0
+        assert_equal(result1, a1)
+        assert result1.data.buffer.device_id == 1
+      after
+        Nx.default_backend(previous_backend)
+      end
+    end
+  end
+
   describe "mesh validation" do
     test "raises when input_shardings provided without mesh" do
       fun = fn x -> Nx.add(x, 1) end


### PR DESCRIPTION
EXLA.MLIR.Module.compile/5 sets executable.device_id to -1 for sharded
(SPMD) executables, since they are not pinned to one device. maybe_outfeed
passed that -1 straight into EXLA.Defn.Buffers.from_nx!/2, which compares
it against each input buffer's device id and, on a mismatch, calls
EXLA.DeviceBuffer.copy_to_device/3 with device_id -1. The NIF rejects -1,
raising "No matching device found for device_id -1" any time a shard_jit
input tensor already lived on an EXLA device (e.g. default_backend set to
EXLA.Backend) instead of Nx.BinaryBackend.

from_nx!/4 now takes the real target device id for the buffer it is
preparing. maybe_outfeed passes each partition's index as that id when
the run is sharded, matching PjRt's default per-partition device
assignment, and keeps using executable.device_id otherwise.

Added a regression test in sharding_test.exs that reproduces the crash
with EXLA.Backend-resident inputs and checks the fix returns correct
per-partition results with the right device ids.
