### PR TITLE
fix(exla): support container arguments in shard_jit input_shardings

### DIFF
--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -241,8 +241,8 @@ defmodule EXLA.Defn do
 
     {buffers, infeeds} =
       EXLA.Defn.Buffers.split_by_value(args, used_inputs, fn
-        arg, _i, nil -> EXLA.Defn.Buffers.from_nx!(arg, executable, true)
-        arg, i, _depth -> {i, EXLA.Defn.Buffers.from_nx!(arg, executable, false)}
+        arg, _i, nil -> EXLA.Defn.Buffers.from_nx!(arg, executable)
+        arg, i, _depth -> {i, EXLA.Defn.Buffers.from_nx!(arg, executable, transfer?: false)}
       end)
 
     infeeds = Map.new(infeeds)
@@ -302,7 +302,7 @@ defmodule EXLA.Defn do
           target_device_id = if is_sharded?, do: partition_index, else: executable.device_id
 
           EXLA.Defn.Buffers.filter_by_indexes(partition_args, used_inputs, fn arg, _i ->
-            EXLA.Defn.Buffers.from_nx!(arg, executable, true, target_device_id)
+            EXLA.Defn.Buffers.from_nx!(arg, executable, target_device_id: target_device_id)
           end)
         end)
 

--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -40,26 +40,13 @@ defmodule EXLA.Defn do
   def __shard_jit__(key, mesh, vars, fun, args_list, options) do
     input_shardings = options[:input_shardings]
 
-    # Validate that input_shardings is a list
-    if not is_list(input_shardings) do
-      raise ArgumentError,
-            "input_shardings are required for sharding in EXLA, see EXLA.shard_jit/3 for more information"
-    end
-
-    # Validate number of input_shardings matches number of parameters
-    num_params = length(vars)
-    num_shardings = length(input_shardings)
-
-    if num_shardings != num_params do
-      raise ArgumentError,
-            "expected #{num_params} input sharding configuration(s), got #{num_shardings}"
-    end
-
-    # Convert map format to list format and validate
+    # Convert map format to list format and validate. This also flattens
+    # container arguments (e.g. an Axon.ModelState) into their tensor leaves,
+    # applying the matching sharding spec to every leaf.
     {input_shardings_list, unsharded_shape_multipliers} =
-      convert_and_validate_input_shardings!(mesh, input_shardings, vars)
+      Nx.Defn.Compiler.validate_and_convert_input_shardings!(mesh, input_shardings, vars)
 
-    vars = calculate_unsharded_inputs(vars, unsharded_shape_multipliers)
+    vars = Nx.Defn.Compiler.calculate_unsharded_inputs(vars, unsharded_shape_multipliers)
 
     options =
       options
@@ -69,105 +56,6 @@ defmodule EXLA.Defn do
     compiled_fun = __compile__(key, vars, fun, options)
 
     compiled_fun.([args_list])
-  end
-
-  defp convert_and_validate_input_shardings!(mesh, input_shardings, vars) do
-    # Create a set of all available mesh axes
-    all_axes =
-      mesh.shape
-      |> tuple_size()
-      |> axes_for_rank()
-      |> MapSet.new()
-
-    # Each entry in `vars` is one argument to the jitted function, which may itself
-    # be a container (e.g. a struct implementing Nx.Container) wrapping several
-    # tensors. The same sharding spec applies to every tensor leaf found in that
-    # argument, so we validate and convert it once per leaf rather than assuming
-    # `var` is a plain %Nx.Tensor{}.
-    per_var_results =
-      Enum.zip_with(input_shardings, vars, fn input_sharding, var ->
-        unless is_map(input_sharding) do
-          raise ArgumentError,
-                "expected input sharding to be a map, got: #{inspect(input_sharding)}"
-        end
-
-        {_var, reverse_leaf_results} =
-          Nx.Defn.Composite.traverse(var, [], fn tensor, acc ->
-            leaf_result =
-              convert_and_validate_tensor_sharding!(mesh, all_axes, input_sharding, tensor)
-
-            {tensor, [leaf_result | acc]}
-          end)
-
-        Enum.reverse(reverse_leaf_results)
-      end)
-
-    # Separate the list format (for MLIR), flattened across every leaf in order
-    # (matching how `compile/8` flattens `vars` into individual arguments), from
-    # the multipliers (for shape calculation), which stay grouped per argument so
-    # `calculate_unsharded_inputs/2` can rebuild each argument's container shape.
-    list_format = per_var_results |> Enum.flat_map(& &1) |> Enum.map(&elem(&1, 0))
-
-    multipliers =
-      Enum.map(per_var_results, fn leaf_results -> Enum.map(leaf_results, &elem(&1, 1)) end)
-
-    {list_format, multipliers}
-  end
-
-  defp convert_and_validate_tensor_sharding!(mesh, all_axes, input_sharding, tensor) do
-    # Convert map format to list format
-    # Map: %{tensor_dim => [mesh_axes]}
-    # List: [[mesh_axes], [mesh_axes], ...]
-    tensor_rank = tuple_size(tensor.shape)
-
-    # Build a mapping from dimension indices to mesh axes
-    dim_to_axes_map =
-      Enum.reduce(input_sharding, %{}, fn {tensor_dim, mesh_axes}, acc ->
-        # Normalize tensor dimension (could be integer, negative integer, or atom name)
-        dim_index = Nx.axis_index(tensor, tensor_dim)
-
-        # Check for duplicate dimension specifications
-        if Map.has_key?(acc, dim_index) do
-          raise ArgumentError,
-                "tensor dimension #{inspect(tensor_dim)} (index #{dim_index}) was specified multiple times"
-        end
-
-        Map.put(acc, dim_index, mesh_axes)
-      end)
-
-    # Convert to list format (one entry per tensor dimension)
-    dim_shardings_list =
-      for dim_idx <- 0..(tensor_rank - 1)//1 do
-        Map.get(dim_to_axes_map, dim_idx, [])
-      end
-
-    # Track which axes have been used for this specific tensor
-    {dim_shardings, _used_axes} =
-      Enum.map_reduce(dim_shardings_list, MapSet.new(), fn axis_list, used_axes ->
-        # For each dimension, check that axes are valid and not reused
-        Enum.each(axis_list, fn axis ->
-          if axis not in all_axes do
-            raise ArgumentError,
-                  "axis #{axis} is not valid for mesh with #{MapSet.size(all_axes)} axes"
-          end
-
-          if axis in used_axes do
-            raise ArgumentError, "axis #{axis} was used twice in the same input sharding"
-          end
-        end)
-
-        # Mark these axes as used
-        new_used_axes = Enum.reduce(axis_list, used_axes, &MapSet.put(&2, &1))
-
-        accumulated_dim_shardings =
-          Enum.reduce(axis_list, 1, fn axis, acc ->
-            acc * elem(mesh.shape, axis)
-          end)
-
-        {accumulated_dim_shardings, new_used_axes}
-      end)
-
-    {dim_shardings_list, dim_shardings}
   end
 
   @doc false
@@ -2497,31 +2385,5 @@ defmodule EXLA.Defn do
 
   defp expr_to_typespec(expr) do
     Typespec.tensor(expr.type, expr.shape)
-  end
-
-  defp calculate_unsharded_inputs(vars, input_shardings) do
-    # We use only the first input list in the collection,
-    # and we just assume they all have the same deep shapes.
-    #
-    # `input_shardings` holds one multiplier list per leaf tensor found in the
-    # matching `var` (a var may be a container wrapping several tensors), so we
-    # consume one multiplier list per leaf as we traverse it.
-
-    Enum.zip_with(vars, input_shardings, fn var, leaf_multipliers ->
-      {var, []} =
-        Nx.Defn.Composite.traverse(var, leaf_multipliers, fn
-          %T{shape: shape} = t, [multiplier | rest] ->
-            # TODO: we need to decide how vectorization interacts with input shardings
-            updated_shape =
-              shape |> Tuple.to_list() |> Enum.zip_with(multiplier, &*/2) |> List.to_tuple()
-
-            {%{t | shape: updated_shape}, rest}
-
-          leaf, [_multiplier | rest] ->
-            {leaf, rest}
-        end)
-
-      var
-    end)
   end
 end

--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -298,11 +298,7 @@ defmodule EXLA.Defn do
         args
         |> Enum.with_index()
         |> Enum.map(fn {partition_args, partition_index} ->
-          # executable.device_id is -1 for sharded (SPMD) executables, since
-          # they are not pinned to a single device (see EXLA.MLIR.Module.compile/5).
-          # -1 is only meaningful to EXLA.Executable.run/3; each partition's
-          # arguments must instead be placed on the device matching its
-          # partition index, following PjRt's default device assignment.
+          # executable.device_id is -1 for sharded executables; use the partition index instead.
           target_device_id = if is_sharded?, do: partition_index, else: executable.device_id
 
           EXLA.Defn.Buffers.filter_by_indexes(partition_args, used_inputs, fn arg, _i ->

--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -295,9 +295,18 @@ defmodule EXLA.Defn do
 
       # Check if args are pre-sliced (list of arglists for each partition)
       input_lists =
-        Enum.map(args, fn partition_args ->
+        args
+        |> Enum.with_index()
+        |> Enum.map(fn {partition_args, partition_index} ->
+          # executable.device_id is -1 for sharded (SPMD) executables, since
+          # they are not pinned to a single device (see EXLA.MLIR.Module.compile/5).
+          # -1 is only meaningful to EXLA.Executable.run/3; each partition's
+          # arguments must instead be placed on the device matching its
+          # partition index, following PjRt's default device assignment.
+          target_device_id = if is_sharded?, do: partition_index, else: executable.device_id
+
           EXLA.Defn.Buffers.filter_by_indexes(partition_args, used_inputs, fn arg, _i ->
-            EXLA.Defn.Buffers.from_nx!(arg, executable)
+            EXLA.Defn.Buffers.from_nx!(arg, executable, true, target_device_id)
           end)
         end)
 

--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -295,9 +295,7 @@ defmodule EXLA.Defn do
 
       # Check if args are pre-sliced (list of arglists for each partition)
       input_lists =
-        args
-        |> Enum.with_index()
-        |> Enum.map(fn {partition_args, partition_index} ->
+        Enum.with_index(args, fn partition_args, partition_index ->
           # executable.device_id is -1 for sharded executables; use the partition index instead.
           target_device_id = if is_sharded?, do: partition_index, else: executable.device_id
 

--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -79,72 +79,95 @@ defmodule EXLA.Defn do
       |> axes_for_rank()
       |> MapSet.new()
 
-    # Convert and validate each input tensor's sharding spec
-    results =
+    # Each entry in `vars` is one argument to the jitted function, which may itself
+    # be a container (e.g. a struct implementing Nx.Container) wrapping several
+    # tensors. The same sharding spec applies to every tensor leaf found in that
+    # argument, so we validate and convert it once per leaf rather than assuming
+    # `var` is a plain %Nx.Tensor{}.
+    per_var_results =
       Enum.zip_with(input_shardings, vars, fn input_sharding, var ->
         unless is_map(input_sharding) do
           raise ArgumentError,
                 "expected input sharding to be a map, got: #{inspect(input_sharding)}"
         end
 
-        # Convert map format to list format
-        # Map: %{tensor_dim => [mesh_axes]}
-        # List: [[mesh_axes], [mesh_axes], ...]
-        tensor_rank = tuple_size(var.shape)
+        {_var, reverse_leaf_results} =
+          Nx.Defn.Composite.traverse(var, [], fn tensor, acc ->
+            leaf_result =
+              convert_and_validate_tensor_sharding!(mesh, all_axes, input_sharding, tensor)
 
-        # Build a mapping from dimension indices to mesh axes
-        dim_to_axes_map =
-          Enum.reduce(input_sharding, %{}, fn {tensor_dim, mesh_axes}, acc ->
-            # Normalize tensor dimension (could be integer, negative integer, or atom name)
-            dim_index = Nx.axis_index(var, tensor_dim)
-
-            # Check for duplicate dimension specifications
-            if Map.has_key?(acc, dim_index) do
-              raise ArgumentError,
-                    "tensor dimension #{inspect(tensor_dim)} (index #{dim_index}) was specified multiple times"
-            end
-
-            Map.put(acc, dim_index, mesh_axes)
+            {tensor, [leaf_result | acc]}
           end)
 
-        # Convert to list format (one entry per tensor dimension)
-        dim_shardings_list =
-          for dim_idx <- 0..(tensor_rank - 1)//1 do
-            Map.get(dim_to_axes_map, dim_idx, [])
-          end
-
-        # Track which axes have been used for this specific tensor
-        {dim_shardings, _used_axes} =
-          Enum.map_reduce(dim_shardings_list, MapSet.new(), fn axis_list, used_axes ->
-            # For each dimension, check that axes are valid and not reused
-            Enum.each(axis_list, fn axis ->
-              if axis not in all_axes do
-                raise ArgumentError,
-                      "axis #{axis} is not valid for mesh with #{MapSet.size(all_axes)} axes"
-              end
-
-              if axis in used_axes do
-                raise ArgumentError, "axis #{axis} was used twice in the same input sharding"
-              end
-            end)
-
-            # Mark these axes as used
-            new_used_axes = Enum.reduce(axis_list, used_axes, &MapSet.put(&2, &1))
-
-            accumulated_dim_shardings =
-              Enum.reduce(axis_list, 1, fn axis, acc ->
-                acc * elem(mesh.shape, axis)
-              end)
-
-            {accumulated_dim_shardings, new_used_axes}
-          end)
-
-        {dim_shardings_list, dim_shardings}
+        Enum.reverse(reverse_leaf_results)
       end)
 
-    # Separate the list format (for MLIR) and multipliers (for shape calculation)
-    {list_format, multipliers} = Enum.unzip(results)
+    # Separate the list format (for MLIR), flattened across every leaf in order
+    # (matching how `compile/8` flattens `vars` into individual arguments), from
+    # the multipliers (for shape calculation), which stay grouped per argument so
+    # `calculate_unsharded_inputs/2` can rebuild each argument's container shape.
+    list_format = per_var_results |> Enum.flat_map(& &1) |> Enum.map(&elem(&1, 0))
+
+    multipliers =
+      Enum.map(per_var_results, fn leaf_results -> Enum.map(leaf_results, &elem(&1, 1)) end)
+
     {list_format, multipliers}
+  end
+
+  defp convert_and_validate_tensor_sharding!(mesh, all_axes, input_sharding, tensor) do
+    # Convert map format to list format
+    # Map: %{tensor_dim => [mesh_axes]}
+    # List: [[mesh_axes], [mesh_axes], ...]
+    tensor_rank = tuple_size(tensor.shape)
+
+    # Build a mapping from dimension indices to mesh axes
+    dim_to_axes_map =
+      Enum.reduce(input_sharding, %{}, fn {tensor_dim, mesh_axes}, acc ->
+        # Normalize tensor dimension (could be integer, negative integer, or atom name)
+        dim_index = Nx.axis_index(tensor, tensor_dim)
+
+        # Check for duplicate dimension specifications
+        if Map.has_key?(acc, dim_index) do
+          raise ArgumentError,
+                "tensor dimension #{inspect(tensor_dim)} (index #{dim_index}) was specified multiple times"
+        end
+
+        Map.put(acc, dim_index, mesh_axes)
+      end)
+
+    # Convert to list format (one entry per tensor dimension)
+    dim_shardings_list =
+      for dim_idx <- 0..(tensor_rank - 1)//1 do
+        Map.get(dim_to_axes_map, dim_idx, [])
+      end
+
+    # Track which axes have been used for this specific tensor
+    {dim_shardings, _used_axes} =
+      Enum.map_reduce(dim_shardings_list, MapSet.new(), fn axis_list, used_axes ->
+        # For each dimension, check that axes are valid and not reused
+        Enum.each(axis_list, fn axis ->
+          if axis not in all_axes do
+            raise ArgumentError,
+                  "axis #{axis} is not valid for mesh with #{MapSet.size(all_axes)} axes"
+          end
+
+          if axis in used_axes do
+            raise ArgumentError, "axis #{axis} was used twice in the same input sharding"
+          end
+        end)
+
+        # Mark these axes as used
+        new_used_axes = Enum.reduce(axis_list, used_axes, &MapSet.put(&2, &1))
+
+        accumulated_dim_shardings =
+          Enum.reduce(axis_list, 1, fn axis, acc ->
+            acc * elem(mesh.shape, axis)
+          end)
+
+        {accumulated_dim_shardings, new_used_axes}
+      end)
+
+    {dim_shardings_list, dim_shardings}
   end
 
   @doc false
@@ -2479,19 +2502,26 @@ defmodule EXLA.Defn do
   defp calculate_unsharded_inputs(vars, input_shardings) do
     # We use only the first input list in the collection,
     # and we just assume they all have the same deep shapes.
+    #
+    # `input_shardings` holds one multiplier list per leaf tensor found in the
+    # matching `var` (a var may be a container wrapping several tensors), so we
+    # consume one multiplier list per leaf as we traverse it.
 
-    Enum.zip_with(vars, input_shardings, fn var, sharding ->
-      Nx.Defn.Composite.traverse(var, fn
-        %T{shape: shape} = t ->
-          # TODO: we need to decide how vectorization interacts with input shardings
-          updated_shape =
-            shape |> Tuple.to_list() |> Enum.zip_with(sharding, &*/2) |> List.to_tuple()
+    Enum.zip_with(vars, input_shardings, fn var, leaf_multipliers ->
+      {var, []} =
+        Nx.Defn.Composite.traverse(var, leaf_multipliers, fn
+          %T{shape: shape} = t, [multiplier | rest] ->
+            # TODO: we need to decide how vectorization interacts with input shardings
+            updated_shape =
+              shape |> Tuple.to_list() |> Enum.zip_with(multiplier, &*/2) |> List.to_tuple()
 
-          %{t | shape: updated_shape}
+            {%{t | shape: updated_shape}, rest}
 
-        var ->
-          var
-      end)
+          leaf, [_multiplier | rest] ->
+            {leaf, rest}
+        end)
+
+      var
     end)
   end
 end

--- a/exla/lib/exla/defn.ex
+++ b/exla/lib/exla/defn.ex
@@ -38,21 +38,12 @@ defmodule EXLA.Defn do
 
   @doc false
   def __shard_jit__(key, mesh, vars, fun, args_list, options) do
-    input_shardings = options[:input_shardings]
-
-    # Convert map format to list format and validate. This also flattens
-    # container arguments (e.g. an Axon.ModelState) into their tensor leaves,
-    # applying the matching sharding spec to every leaf.
-    {input_shardings_list, unsharded_shape_multipliers} =
-      Nx.Defn.Compiler.validate_and_convert_input_shardings!(mesh, input_shardings, vars)
-
-    vars = Nx.Defn.Compiler.calculate_unsharded_inputs(vars, unsharded_shape_multipliers)
-
-    options =
-      options
-      |> Keyword.put(:mesh, mesh)
-      |> Keyword.put(:input_shardings, input_shardings_list)
-
+    # By the time we get here, `Nx.Defn.Compiler.__shard_jit__/5` has already
+    # validated `options[:input_shardings]` (converting it to list format, one
+    # entry per tensor leaf) and adjusted `vars` to their unsharded (full
+    # logical) shapes, so containers (e.g. an Axon.ModelState) are handled
+    # transparently, just like they are for regular (non-sharded) `jit`.
+    options = Keyword.put(options, :mesh, mesh)
     compiled_fun = __compile__(key, vars, fun, options)
 
     compiled_fun.([args_list])

--- a/exla/lib/exla/defn/buffers.ex
+++ b/exla/lib/exla/defn/buffers.ex
@@ -141,12 +141,18 @@ defmodule EXLA.Defn.Buffers do
   @doc """
   Nx -> EXLA.DeviceBuffer + EXLA.BinaryBuffer.
 
-  `target_device_id` defaults to `executable.device_id`, but callers for
-  sharded execution must pass the real per-partition device id instead,
-  since `executable.device_id` is `-1` for sharded executables.
+  ## Options
+
+    * `:transfer?` - whether to automatically transfer a mismatched device
+      buffer to the target device. Defaults to `true`.
+
+    * `:target_device_id` - defaults to `executable.device_id`, but callers
+      for sharded execution must pass the real per-partition device id
+      instead, since `executable.device_id` is `-1` for sharded executables.
   """
-  def from_nx!(fun, executable, transfer? \\ true, target_device_id \\ nil) do
-    target_device_id = target_device_id || executable.device_id
+  def from_nx!(fun, executable, opts \\ []) do
+    transfer? = Keyword.get(opts, :transfer?, true)
+    target_device_id = Keyword.get(opts, :target_device_id) || executable.device_id
 
     %Nx.Tensor{data: data} =
       tensor = Nx.devectorize(fun.())

--- a/exla/lib/exla/defn/buffers.ex
+++ b/exla/lib/exla/defn/buffers.ex
@@ -140,8 +140,17 @@ defmodule EXLA.Defn.Buffers do
 
   @doc """
   Nx -> EXLA.DeviceBuffer + EXLA.BinaryBuffer.
+
+  `target_device_id` overrides the device to place/compare the buffer
+  against. It defaults to `executable.device_id`, but that is `-1` for
+  sharded (SPMD) executables, which is only a valid value for `run/3` and
+  never a real device to transfer to. Callers preparing per-partition
+  arguments for sharded execution must pass the actual device id for that
+  partition.
   """
-  def from_nx!(fun, executable, transfer? \\ true) do
+  def from_nx!(fun, executable, transfer? \\ true, target_device_id \\ nil) do
+    target_device_id = target_device_id || executable.device_id
+
     %Nx.Tensor{data: data} =
       tensor = Nx.devectorize(fun.())
 
@@ -160,17 +169,17 @@ defmodule EXLA.Defn.Buffers do
 
       %EXLA.Backend{buffer: %EXLA.DeviceBuffer{} = buffer}
       when transfer? and buffer.client_name != executable.client.name
-      when transfer? and buffer.device_id != executable.device_id ->
+      when transfer? and buffer.device_id != target_device_id ->
         buffer_client = EXLA.Client.fetch!(buffer.client_name)
 
         if buffer_client.automatic_transfers do
-          EXLA.DeviceBuffer.copy_to_device(buffer, executable.client, executable.device_id)
+          EXLA.DeviceBuffer.copy_to_device(buffer, executable.client, target_device_id)
         else
           default = EXLA.Client.fetch!(EXLA.Client.default_name())
 
           raise ArgumentError, """
           EXLA computation (defn) is allocated on client #{executable.client.name} \
-          ##{executable.device_id} (#{executable.client.platform}) \
+          ##{target_device_id} (#{executable.client.platform}) \
           but one of the input tensors are allocated on #{buffer_client.name} \
           ##{buffer.device_id} (#{buffer_client.platform}).
 

--- a/exla/lib/exla/defn/buffers.ex
+++ b/exla/lib/exla/defn/buffers.ex
@@ -141,12 +141,9 @@ defmodule EXLA.Defn.Buffers do
   @doc """
   Nx -> EXLA.DeviceBuffer + EXLA.BinaryBuffer.
 
-  `target_device_id` overrides the device to place/compare the buffer
-  against. It defaults to `executable.device_id`, but that is `-1` for
-  sharded (SPMD) executables, which is only a valid value for `run/3` and
-  never a real device to transfer to. Callers preparing per-partition
-  arguments for sharded execution must pass the actual device id for that
-  partition.
+  `target_device_id` defaults to `executable.device_id`, but callers for
+  sharded execution must pass the real per-partition device id instead,
+  since `executable.device_id` is `-1` for sharded executables.
   """
   def from_nx!(fun, executable, transfer? \\ true, target_device_id \\ nil) do
     target_device_id = target_device_id || executable.device_id

--- a/exla/test/exla/defn/sharding_test.exs
+++ b/exla/test/exla/defn/sharding_test.exs
@@ -738,6 +738,50 @@ defmodule EXLA.Defn.ShardingTest do
     end
   end
 
+  describe "container arguments" do
+    @moduletag :multi_device
+    test "applies one sharding spec to every leaf of a container argument" do
+      # fun receives a plain map container as its first argument (like an
+      # Axon.ModelState or any other struct/map implementing Nx.Container),
+      # instead of a bare Nx.Tensor.
+      fun = fn container, tensor -> Nx.add(Map.fetch!(container, :value), tensor) end
+
+      mesh = %Mesh{name: "two_devices", shape: {2}}
+
+      # A single "%{}" sharding spec applies to every leaf inside the
+      # container (here: just `value`, replicated on every device), while the
+      # plain tensor argument keeps its own sharding spec.
+      input_shardings = [%{}, %{0 => [0]}]
+
+      container = %{value: Nx.tensor([1])}
+
+      args = [
+        [container, Nx.tensor([1, 2])],
+        [container, Nx.tensor([3, 4])]
+      ]
+
+      [result0, result1] =
+        EXLA.shard_jit(fun, mesh, client: :host, input_shardings: input_shardings).(args)
+
+      assert_equal(result0, Nx.tensor([2, 3]))
+      assert_equal(result1, Nx.tensor([4, 5]))
+    end
+
+    test "raises a clear error, not a KeyError, for an invalid sharding on a container leaf" do
+      fun = fn container, tensor -> Nx.add(container.value, tensor) end
+
+      mesh = %Mesh{name: "mesh", shape: {2}}
+      # Axis 1 does not exist on this mesh.
+      input_shardings = [%{0 => [1]}, %{}]
+
+      args = List.duplicate([%{value: Nx.tensor([1, 2])}, Nx.tensor([3, 4])], 2)
+
+      assert_raise ArgumentError, ~r/axis 1 is not valid for mesh/, fn ->
+        EXLA.shard_jit(fun, mesh, client: :host, input_shardings: input_shardings).(args)
+      end
+    end
+  end
+
   describe "MLIR output format" do
     test "MLIR contains mesh definition with correct shape" do
       fun = fn x -> Nx.add(x, 1) end

--- a/exla/test/exla/defn/sharding_test.exs
+++ b/exla/test/exla/defn/sharding_test.exs
@@ -395,12 +395,6 @@ defmodule EXLA.Defn.ShardingTest do
   describe "input buffers already on an EXLA device" do
     @moduletag :multi_device
     test "does not crash with 'No matching device found for device_id -1'" do
-      # Regression test: when inputs are already EXLA.Backend device buffers
-      # (instead of plain Nx.BinaryBackend tensors), preparing arguments for
-      # a sharded (SPMD) executable used to compare each buffer's device
-      # against `executable.device_id`, which is `-1` for sharded executables
-      # (a sentinel meaning "multiple devices", not a real device). That sent
-      # `-1` into `EXLA.NIF.copy_buffer_to_device/3`, which doesn't accept it.
       previous_backend = Nx.default_backend()
       Nx.default_backend({EXLA.Backend, client: :host})
 

--- a/exla/test/exla/defn/sharding_test.exs
+++ b/exla/test/exla/defn/sharding_test.exs
@@ -392,6 +392,47 @@ defmodule EXLA.Defn.ShardingTest do
     end
   end
 
+  describe "input buffers already on an EXLA device" do
+    @moduletag :multi_device
+    test "does not crash with 'No matching device found for device_id -1'" do
+      # Regression test: when inputs are already EXLA.Backend device buffers
+      # (instead of plain Nx.BinaryBackend tensors), preparing arguments for
+      # a sharded (SPMD) executable used to compare each buffer's device
+      # against `executable.device_id`, which is `-1` for sharded executables
+      # (a sentinel meaning "multiple devices", not a real device). That sent
+      # `-1` into `EXLA.NIF.copy_buffer_to_device/3`, which doesn't accept it.
+      previous_backend = Nx.default_backend()
+      Nx.default_backend({EXLA.Backend, client: :host})
+
+      try do
+        fun = fn a, b -> Nx.dot(a, b) end
+
+        mesh = %Mesh{name: "two_host_devices", shape: {2}}
+
+        sharded_matmul =
+          EXLA.shard_jit(
+            fun,
+            mesh,
+            client: :host,
+            input_shardings: [%{0 => [0]}, %{}]
+          )
+
+        a0 = Nx.broadcast(Nx.tensor(1.0, type: {:f, 32}), {2, 4})
+        a1 = Nx.broadcast(Nx.tensor(2.0, type: {:f, 32}), {2, 4})
+        b = Nx.eye(4, type: {:f, 32})
+
+        [result0, result1] = sharded_matmul.([[a0, b], [a1, b]])
+
+        assert_equal(result0, a0)
+        assert result0.data.buffer.device_id == 0
+        assert_equal(result1, a1)
+        assert result1.data.buffer.device_id == 1
+      after
+        Nx.default_backend(previous_backend)
+      end
+    end
+  end
+
   describe "mesh validation" do
     test "raises when input_shardings provided without mesh" do
       fun = fn x -> Nx.add(x, 1) end

--- a/nx/lib/nx/defn/compiler.ex
+++ b/nx/lib/nx/defn/compiler.ex
@@ -887,6 +887,145 @@ defmodule Nx.Defn.Compiler do
   end
 
   @doc false
+  def validate_and_convert_input_shardings!(mesh, input_shardings, vars) do
+    unless is_list(input_shardings) do
+      raise ArgumentError,
+            "input_shardings are required for sharding, see Nx.Defn.shard_jit/3 for more information"
+    end
+
+    num_params = length(vars)
+    num_shardings = length(input_shardings)
+
+    if num_shardings != num_params do
+      raise ArgumentError,
+            "expected #{num_params} input sharding configuration(s), got #{num_shardings}"
+    end
+
+    all_axes =
+      mesh.shape
+      |> tuple_size()
+      |> then(&Enum.to_list(0..(&1 - 1)//1))
+      |> MapSet.new()
+
+    # Each entry in `vars` is one argument to the jitted function, which may itself
+    # be a container (e.g. a struct implementing Nx.Container) wrapping several
+    # tensors. The same sharding spec applies to every tensor leaf found in that
+    # argument, so we validate and convert it once per leaf rather than assuming
+    # `var` is a plain %Nx.Tensor{}.
+    per_var_results =
+      Enum.zip_with(input_shardings, vars, fn input_sharding, var ->
+        unless is_map(input_sharding) do
+          raise ArgumentError,
+                "expected input sharding to be a map, got: #{inspect(input_sharding)}"
+        end
+
+        {_var, reverse_leaf_results} =
+          Nx.Defn.Composite.traverse(var, [], fn tensor, acc ->
+            leaf_result =
+              validate_and_convert_tensor_sharding!(mesh, all_axes, input_sharding, tensor)
+
+            {tensor, [leaf_result | acc]}
+          end)
+
+        Enum.reverse(reverse_leaf_results)
+      end)
+
+    # Separate the list format (one entry per leaf, flattened in the same order
+    # backends flatten `vars` into individual arguments) from the multipliers
+    # (for shape calculation), which stay grouped per argument so
+    # `calculate_unsharded_inputs/2` can rebuild each argument's container shape.
+    list_format = per_var_results |> Enum.flat_map(& &1) |> Enum.map(&elem(&1, 0))
+
+    multipliers =
+      Enum.map(per_var_results, fn leaf_results -> Enum.map(leaf_results, &elem(&1, 1)) end)
+
+    {list_format, multipliers}
+  end
+
+  defp validate_and_convert_tensor_sharding!(mesh, all_axes, input_sharding, tensor) do
+    # Convert map format to list format
+    # Map: %{tensor_dim => [mesh_axes]}
+    # List: [[mesh_axes], [mesh_axes], ...]
+    tensor_rank = tuple_size(tensor.shape)
+
+    # Build a mapping from dimension indices to mesh axes
+    dim_to_axes_map =
+      Enum.reduce(input_sharding, %{}, fn {tensor_dim, mesh_axes}, acc ->
+        # Normalize tensor dimension (could be integer, negative integer, or atom name)
+        dim_index = Nx.axis_index(tensor, tensor_dim)
+
+        # Check for duplicate dimension specifications
+        if Map.has_key?(acc, dim_index) do
+          raise ArgumentError,
+                "tensor dimension #{inspect(tensor_dim)} (index #{dim_index}) was specified multiple times"
+        end
+
+        Map.put(acc, dim_index, mesh_axes)
+      end)
+
+    # Convert to list format (one entry per tensor dimension)
+    dim_shardings_list =
+      for dim_idx <- 0..(tensor_rank - 1)//1 do
+        Map.get(dim_to_axes_map, dim_idx, [])
+      end
+
+    # Track which axes have been used for this specific tensor
+    {dim_shardings, _used_axes} =
+      Enum.map_reduce(dim_shardings_list, MapSet.new(), fn axis_list, used_axes ->
+        # For each dimension, check that axes are valid and not reused
+        Enum.each(axis_list, fn axis ->
+          if axis not in all_axes do
+            raise ArgumentError,
+                  "axis #{axis} is not valid for mesh with #{MapSet.size(all_axes)} axes"
+          end
+
+          if axis in used_axes do
+            raise ArgumentError, "axis #{axis} was used twice in the same input sharding"
+          end
+        end)
+
+        # Mark these axes as used
+        new_used_axes = Enum.reduce(axis_list, used_axes, &MapSet.put(&2, &1))
+
+        accumulated_dim_shardings =
+          Enum.reduce(axis_list, 1, fn axis, acc ->
+            acc * elem(mesh.shape, axis)
+          end)
+
+        {accumulated_dim_shardings, new_used_axes}
+      end)
+
+    {dim_shardings_list, dim_shardings}
+  end
+
+  @doc false
+  def calculate_unsharded_inputs(vars, input_shardings) do
+    # We use only the first input list in the collection,
+    # and we just assume they all have the same deep shapes.
+    #
+    # `input_shardings` holds one multiplier list per leaf tensor found in the
+    # matching `var` (a var may be a container wrapping several tensors), so we
+    # consume one multiplier list per leaf as we traverse it.
+
+    Enum.zip_with(vars, input_shardings, fn var, leaf_multipliers ->
+      {var, []} =
+        Nx.Defn.Composite.traverse(var, leaf_multipliers, fn
+          %Nx.Tensor{shape: shape} = t, [multiplier | rest] ->
+            # TODO: we need to decide how vectorization interacts with input shardings
+            updated_shape =
+              shape |> Tuple.to_list() |> Enum.zip_with(multiplier, &*/2) |> List.to_tuple()
+
+            {%{t | shape: updated_shape}, rest}
+
+          leaf, [_multiplier | rest] ->
+            {leaf, rest}
+        end)
+
+      var
+    end)
+  end
+
+  @doc false
   def to_lazy_params(fun, args) do
     {params, cache, {templates, funs, _}} =
       Enum.reduce(args, {[], [], {[], [], 0}}, fn

--- a/nx/lib/nx/defn/compiler.ex
+++ b/nx/lib/nx/defn/compiler.ex
@@ -293,6 +293,19 @@ defmodule Nx.Defn.Compiler do
   end
 
   def __shard_jit__(fun, mesh, params, args_list, opts) do
+    {input_shardings, opts} = Keyword.pop(opts, :input_shardings)
+
+    # Container arguments (e.g. an Axon.ModelState) are flattened into their
+    # tensor leaves here, once, so every compiler backend receives an already
+    # validated and expanded (one entry per leaf) `:input_shardings` list,
+    # the same way `to_lazy_params_sharded/2` already flattens `args_list`
+    # into per-leaf functions for regular compilation.
+    {input_shardings, multipliers} =
+      validate_and_convert_input_shardings!(mesh, input_shardings, params)
+
+    params = calculate_unsharded_inputs(params, multipliers)
+    opts = Keyword.put(opts, :input_shardings, input_shardings)
+
     {module, runtime_fun, opts} = prepare_options(fun, opts)
     module.__shard_jit__(fun, mesh, params, runtime_fun, args_list, opts)
   rescue
@@ -886,8 +899,7 @@ defmodule Nx.Defn.Compiler do
     {fun, params, templates, [first_flatten | rest_flattens]}
   end
 
-  @doc false
-  def validate_and_convert_input_shardings!(mesh, input_shardings, vars) do
+  defp validate_and_convert_input_shardings!(mesh, input_shardings, vars) do
     unless is_list(input_shardings) do
       raise ArgumentError,
             "input_shardings are required for sharding, see Nx.Defn.shard_jit/3 for more information"
@@ -998,8 +1010,7 @@ defmodule Nx.Defn.Compiler do
     {dim_shardings_list, dim_shardings}
   end
 
-  @doc false
-  def calculate_unsharded_inputs(vars, input_shardings) do
+  defp calculate_unsharded_inputs(vars, input_shardings) do
     # We use only the first input list in the collection,
     # and we just assume they all have the same deep shapes.
     #

--- a/nx/test/nx/defn/shard_jit_test.exs
+++ b/nx/test/nx/defn/shard_jit_test.exs
@@ -1,0 +1,104 @@
+defmodule Nx.Defn.ShardJitTest do
+  use ExUnit.Case, async: true
+
+  # A minimal Nx.Defn.Compiler that just records the arguments it receives
+  # from Nx.Defn.Compiler.__shard_jit__/5, so we can assert on how
+  # `vars` and `options[:input_shardings]` were flattened/validated before
+  # ever reaching a backend. Real backends (e.g. EXLA) receive the exact
+  # same shapes this test asserts on.
+  defmodule TestCompiler do
+    @behaviour Nx.Defn.Compiler
+
+    @impl true
+    def __to_backend__(_opts), do: {Nx.BinaryBackend, []}
+
+    @impl true
+    def __partitions_options__(opts), do: [opts]
+
+    @impl true
+    def __compile__(_key, _vars, _fun, _opts) do
+      raise "not implemented"
+    end
+
+    @impl true
+    def __jit__(_key, _vars, fun, args_list, _opts) do
+      Enum.map(args_list, &apply(fun, &1))
+    end
+
+    @impl true
+    def __shard_jit__(_key, mesh, vars, _fun, args_list, opts) do
+      send(self(), {:shard_jit, mesh, vars, Keyword.fetch!(opts, :input_shardings)})
+      Enum.map(args_list, fn _ -> :ok end)
+    end
+  end
+
+  describe "container arguments" do
+    test "expands a single sharding spec across every leaf of a container argument" do
+      mesh = %Nx.Mesh{name: "mesh", shape: {2}}
+      fun = fn container, tensor -> Nx.add(container.a, tensor) end
+
+      # `container` has two leaves (a, b); `tensor` has one. A single "%{}"
+      # (fully replicated) spec on the container argument must apply to
+      # both of its leaves.
+      container = %{a: Nx.tensor([1, 2]), b: Nx.tensor([10, 20])}
+      tensor = Nx.tensor([100])
+
+      args_list = [[container, tensor], [container, tensor]]
+
+      Nx.Defn.shard_jit(fun, mesh,
+        compiler: TestCompiler,
+        input_shardings: [%{}, %{0 => [0]}]
+      ).(args_list)
+
+      assert_received {:shard_jit, ^mesh, [container_var, tensor_var], input_shardings}
+
+      # One list-format entry per leaf: container.a, container.b, tensor.
+      assert input_shardings == [[[]], [[]], [[0]]]
+
+      # container.a/b stay fully replicated (unsharded shape == given shape),
+      # while tensor's unsharded shape is scaled up by the mesh axis it uses.
+      assert container_var.a.shape == {2}
+      assert container_var.b.shape == {2}
+      assert tensor_var.shape == {2}
+    end
+
+    test "raises a clear ArgumentError, not a KeyError, for an invalid sharding on a container leaf" do
+      mesh = %Nx.Mesh{name: "mesh", shape: {2}}
+      fun = fn container, tensor -> Nx.add(container.value, tensor) end
+
+      args_list = [[%{value: Nx.tensor([1])}, Nx.tensor([1, 2])]]
+
+      assert_raise ArgumentError, ~r/axis 1 is not valid for mesh with 1 axes/, fn ->
+        Nx.Defn.shard_jit(fun, mesh,
+          compiler: TestCompiler,
+          # Mesh only has axis 0, so axis 1 is invalid.
+          input_shardings: [%{0 => [1]}, %{}]
+        ).(args_list)
+      end
+    end
+  end
+
+  describe "input_shardings validation" do
+    test "raises when input_shardings is not a list" do
+      mesh = %Nx.Mesh{name: "mesh", shape: {2}}
+      fun = fn x -> Nx.add(x, 1) end
+
+      assert_raise ArgumentError, ~r/input_shardings are required for sharding/, fn ->
+        Nx.Defn.shard_jit(fun, mesh, compiler: TestCompiler, input_shardings: nil).([
+          [Nx.tensor([1, 2])]
+        ])
+      end
+    end
+
+    test "raises when the number of input_shardings does not match the number of arguments" do
+      mesh = %Nx.Mesh{name: "mesh", shape: {2}}
+      fun = fn x, y -> Nx.add(x, y) end
+
+      assert_raise ArgumentError, ~r/expected 2 input sharding configuration.*got 1/, fn ->
+        Nx.Defn.shard_jit(fun, mesh, compiler: TestCompiler, input_shardings: [%{}]).([
+          [Nx.tensor([1]), Nx.tensor([2])]
+        ])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Stacked on #1833.

## Problem

EXLA.shard_jit/3 read var.shape directly in convert_and_validate_input_shardings!/3 to validate each input_shardings entry against its matching argument. When an argument is a container instead of a plain Nx.Tensor (for example an Axon.ModelState, or any struct/map implementing Nx.Container), this crashed with an unrelated KeyError instead of validating the sharding spec.

EXLA.jit/2 and Nx.Defn.jit/2 already accept containers transparently; shard_jit did not.

## Fix

Container flattening now happens once, in Nx.Defn.Compiler.__shard_jit__/5, the shared dispatcher every backend's __shard_jit__ callback goes through, the same way to_lazy_params_sharded/2 already flattens args_list for regular compilation. Each input_shardings entry is validated and expanded to one entry per tensor leaf, and the argument's shape is adjusted to its unsharded (full logical) size, before a backend ever sees it.

A single %{} (fully replicated) sharding on a container argument applies to every leaf inside it, matching the behavior described in the bug report.

Compiler backends no longer need to know anything about containers. EXLA.Defn.__shard_jit__/6 shrinks down to merging the mesh into options and compiling; any other compiler implementing __shard_jit__ gets the same container support automatically.

## Testing

Added tests in sharding_test.exs covering a map container argument with a replicated sharding spec, and a clear ArgumentError (not a KeyError) when a container leaf's sharding spec is invalid.

Full mix test suite passes for both nx and exla.