### PR TITLE
fix(nx): keep a reshaped float constant a constant

### DIFF
--- a/nx/lib/nx/defn/expr.ex
+++ b/nx/lib/nx/defn/expr.ex
@@ -1090,7 +1090,12 @@ defmodule Nx.Defn.Expr do
   @impl true
   def reshape(out, tensor) do
     tensor = to_expr(tensor)
-    expr(out, tensor.data.context, :reshape, [tensor])
+
+    if c = maybe_constant(tensor) do
+      constant(out, c)
+    else
+      expr(out, tensor.data.context, :reshape, [tensor])
+    end
   end
 
   @impl true

--- a/nx/test/nx/defn/evaluator_test.exs
+++ b/nx/test/nx/defn/evaluator_test.exs
@@ -771,8 +771,7 @@ defmodule Nx.Defn.EvaluatorTest do
         \s\s
           Nx.Defn.Expr
           parameter a:2   s32[1][1]
-          b = reshape 2   s32[1][1]
-          c = less a, b   u8[1][1]
+          b = less a, 2   u8[1][1]
         >, consider using Nx.all/1 or Nx.any/1 to obtain a scalar predicate from tensor
         """
         |> String.trim()

--- a/nx/test/nx/defn/expr_test.exs
+++ b/nx/test/nx/defn/expr_test.exs
@@ -221,6 +221,21 @@ defmodule Nx.Defn.ExprTest do
       assert %T{type: {:c, 128}, data: %Expr{op: :multiply, args: [^c_c128, ^t_f64]}} =
                Nx.multiply(t_f64, c_c64)
     end
+
+    test "reshaping a float constant keeps it a constant" do
+      c_f32 = Expr.constant(Nx.tensor(0.7, type: :f32), 0.7, [])
+      t_f64 = Nx.tensor([2, 2], type: :f64) |> Expr.tensor()
+      pred = Nx.tensor([1, 0], type: :u8) |> Expr.tensor()
+
+      assert %T{shape: {1}, data: %Expr{op: :constant, args: [0.7]}} = Nx.reshape(c_f32, {1})
+
+      # vectorized operands reach an op through a reshape, so a literal only
+      # stays a constant if the reshape keeps it one
+      assert %T{data: %Expr{op: :select, args: [_, on_true, _]}} =
+               Nx.select(Nx.vectorize(pred, :a), c_f32, Nx.vectorize(t_f64, :a))
+
+      assert %T{data: %Expr{op: :constant, args: [0.7]}} = on_true
+    end
   end
 
   describe "inspect" do

--- a/nx/test/nx/defn_test.exs
+++ b/nx/test/nx/defn_test.exs
@@ -1423,21 +1423,19 @@ defmodule Nx.DefnTest do
                  Nx.Defn.Expr
                  parameter a:0                           s32
                  parameter c:1                           s32[2][1][2]
-                 parameter h:2                           s32
-                 parameter l:3                           s32[1][2]
+                 parameter g:2                           s32
+                 parameter k:3                           s32[1][2]
                  b = greater a, 0                        u8
-                 d = reshape 1                           s32[1][1][1]
-                 e = add c, d                            s32[2][1][2]
-                 f = broadcast e, {2, 2, 2}, [0, 1, 2]   s32[2][2][2]
-                 g = less a, 0                           u8
-                 i = subtract h, 1                       s32
-                 j = reshape i                           s32[1][1][1]
-                 k = broadcast j, {2, 2, 2}, [0, 1, 2]   s32[2][2][2]
-                 m = reshape 2                           s32[1][1]
-                 n = multiply l, m                       s32[1][2]
-                 o = reshape n                           s32[1][2][1]
-                 p = broadcast o, {2, 2, 2}, [0, 1, 2]   s32[2][2][2]
-                 q = cond b -> f, g -> k, true -> p      s32[2][2][2]
+                 d = add 1, c                            s32[2][1][2]
+                 e = broadcast d, {2, 2, 2}, [0, 1, 2]   s32[2][2][2]
+                 f = less a, 0                           u8
+                 h = subtract g, 1                       s32
+                 i = reshape h                           s32[1][1][1]
+                 j = broadcast i, {2, 2, 2}, [0, 1, 2]   s32[2][2][2]
+                 l = multiply 2, k                       s32[1][2]
+                 m = reshape l                           s32[1][2][1]
+                 n = broadcast m, {2, 2, 2}, [0, 1, 2]   s32[2][2][2]
+                 o = cond b -> e, f -> j, true -> n      s32[2][2][2]
                >
                """)
 


### PR DESCRIPTION
`broadcast/4` folds a constant it's handed; `reshape/2` didn't, so a literal reaching an op through a reshape arrived as a plain node.

```elixir
defn pick(pred, t), do: Nx.select(pred, 0.1, t)

pick(Nx.vectorize(pred, :a), Nx.vectorize(t, :a))
```

Vectorized operands take that route. Folding also drops the reshape and broadcast nodes wrapping the literal, so two tests asserting inspected expressions now assert smaller graphs.

Split out of #1835.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
